### PR TITLE
Fix HBase and Spark versions

### DIFF
--- a/bigtop-tests/test-artifacts/spark/pom.xml
+++ b/bigtop-tests/test-artifacts/spark/pom.xml
@@ -49,7 +49,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.9.3</artifactId>
+      <artifactId>spark-core_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <hadoop.version>2.3.0</hadoop.version>
-    <hbase.version>0.98.2</hbase.version>
+    <hbase.version>0.98.2-hadoop2</hbase.version>
     <pig.version>0.12.1</pig.version>
     <pig-smoke.version>0.12.1</pig-smoke.version>
     <sqoop.version>1.99.2</sqoop.version>
@@ -239,7 +239,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-core_2.9.3</artifactId>
+        <artifactId>spark-core_2.10</artifactId>
         <version>${spark.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Add missing '-hadoop2' suffix to hbase artifact
Fix Spark version - bump from 2.9.3 to 2.10
