### PR TITLE
add src param so rpm build works

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -319,7 +319,8 @@ bigtop {
       name    = "bigtop-utils"
       relNotes = "Service package for Apache Bigtop runtime"
       version { base = bigtop.version; pkg = base-"-SNAPSHOT"; release = 1 }
-      tarball { destination = "bigtop-utils-${version.base}.tar.gz" }
+      tarball { destination = "bigtop-utils-${version.base}.tar.gz";
+                source =  ""}
     }
     'bigtop-jsvc' {
       name    = "bigtop-jsvc"


### PR DESCRIPTION
gradle bigtop-utils-rpm task fails with:

Copy  to /opt/bigtop/build/bigtop-utils/tar/bigtop-utils-1.1.0-SNAPSHOT.tar.gz
:bigtop-utils-tar FAILED

FAILURE: Build failed with an exception.

* Where:
Script '/opt/bigtop/packages.gradle' line: 250