### PR TITLE
Getting vagrant work on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force line endings to be LR even if it's in Windows,
+# so that shell script can be run as expected after 
+# folders syncing from windows host machine to linux
+# guests.
+*.sh eol=lf


### PR DESCRIPTION
Force line endings to be LR for *.sh scripts after git checkout in windows, so that running "vagrant up" under bigtop-deploy/vm/vagrant-puppet-vm can work as expected.