### PR TITLE
BIGTOP-2237. Nullify the standard output when generating gradle cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -386,6 +386,8 @@ task "gen-gradle-home"(type:Exec,
   ]
   workingDir '.'
   commandLine command
+  //store the output instead of printing to the console:
+  standardOutput = new ByteArrayOutputStream()
 }
 
 task "bigtop-slaves"(dependsOn: 'gen-gradle-home', type:Exec,


### PR DESCRIPTION
New PR for updated patch.