### PR TITLE
BIGTOP-2119: Bump Mahout version to 0.11.1

### DIFF
--- a/bigtop-packages/src/rpm/mahout/SPECS/mahout.spec
+++ b/bigtop-packages/src/rpm/mahout/SPECS/mahout.spec
@@ -101,7 +101,7 @@ fi
 #######################
 %files 
 %defattr(-,root,root,755)
-%doc LICENSE.txt README.txt NOTICE.txt
+%doc LICENSE.txt README.md NOTICE.txt
 %config(noreplace) %{config_mahout}.dist
 %{lib_mahout}
 %{bin_mahout}/mahout

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -214,7 +214,7 @@ bigtop {
     'mahout' {
       name    = 'mahout'
       relNotes = 'Apache Mahout'
-      version { base = '0.11.0'; pkg = base; release = 1 }
+      version { base = '0.11.1'; pkg = base; release = 1 }
       tarball { destination = "apache-$name-distribution-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
Updated mahout version in bigtop.bom, built mahout-pkg, installed .deb, and ran a recommender job as well as checked the spark-shell works.