### PR TITLE
BIGTOP-2469: Add cloud-weather-report test plan

### DIFF
--- a/bigtop-tests/cloud-weather-report/README.md
+++ b/bigtop-tests/cloud-weather-report/README.md
@@ -1,0 +1,43 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+# Testing Bigtop on various Clouds
+
+[Cloud Weather Report (cwr)][CWR] enables charm authors and maintainers to run
+health checks and benchmarks on multiple clouds using [Juju][].
+
+When the cwr starts executing, it deploys a bundle or charm on the clouds chosen
+by the author. It runs all the tests associated with each charm in each cloud it
+deployed to. It also runs benchmarks on those clouds allowing charm authors to
+see how their charms are performing on different clouds.
+
+Results of the test runs are stored in local static html pages with a link
+provided at the end of the run.
+
+You will first need to set up [Juju][] and [CWR][], and bootstrap one or more
+Juju controllers, such as on [AWS][] or [GCE][].  Then, you can run the
+report with the `cwr` tool:
+
+    cwr aws gce bigtop-tests/cloud-weather-report/hadoop-processing.yaml
+
+A set of various Cloud Weather Reports are generated daily and can be viewed
+[online](http://status.juju.solutions/recent).
+
+
+[CWR]: https://github.com/juju-solutions/cloud-weather-report/
+[Juju]: https://jujucharms.com/docs/stable/getting-started
+[AWS]: https://jujucharms.com/docs/stable/config-aws
+[GCE]: https://jujucharms.com/docs/stable/config-gce

--- a/bigtop-tests/cloud-weather-report/hadoop-processing.yaml
+++ b/bigtop-tests/cloud-weather-report/hadoop-processing.yaml
@@ -1,0 +1,7 @@
+# Bundle info: https://jujucharms.com/hadoop-processing
+bundle: bundle:hadoop-processing
+benchmark:
+    resourcemanager:
+        terasort
+bundle_name: hadoop-processing
+bundle_file: bundle.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ rat {
        "bigtop-packages/src/charm/**/wheelhouse.txt",
        "bigtop-packages/src/charm/**/*.yaml",
        "bigtop-deploy/juju/**/*.yaml",
+       "bigtop-tests/cloud-weather-report/**/*.yaml",
        /* Misc individual files */
        "src/site/resources/bigtop.rdf",
        "src/site/resources/images/bigtop-logo.ai",

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,7 @@
               <exclude>bigtop-packages/src/charm/**/wheelhouse.txt</exclude>
               <exclude>bigtop-packages/src/charm/**/*.yaml</exclude>
               <exclude>bigtop-deploy/juju/**/*.yaml</exclude>
+              <exclude>bigtop-tests/cloud-weather-report/**/*.yaml</exclude>
               <!-- Miscelaneous individual files -->
               <exclude>src/site/resources/bigtop.rdf</exclude>
               <exclude>src/site/resources/images/bigtop-logo.ai</exclude>


### PR DESCRIPTION
We've split the original request to enable Bigtop/Juju support into a couple smaller subtasks. This one is for delivering the cloud-weather-report test plan for running the Juju bundle against multiple clouds and verifying the results.
