### PR TITLE
BIGTOP-2467 Zookeeper Puppet script does not setup Zookeeper node ids correctly

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -147,7 +147,7 @@ qfs::common::chunkserver_client_port: "22000"
 
 hadoop_zookeeper::server::myid: "0"
 hadoop_zookeeper::server::ensemble:
-  - "%{hiera('bigtop::hadoop_head_node')}:2888:3888"
+  - ["0", "%{hiera('bigtop::hadoop_head_node')}:2888:3888"]
 hadoop_zookeeper::server::kerberos_realm: "%{hiera('kerberos::site::realm')}"
 
 # those are only here because they were present as extlookup keys previously

--- a/bigtop-deploy/puppet/modules/hadoop_zookeeper/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop_zookeeper/manifests/init.pp
@@ -61,7 +61,7 @@ class hadoop_zookeeper (
   class server($myid,
                 $port = "2181",
                 $datadir = "/var/lib/zookeeper",
-                $ensemble = ["localhost:2888:3888"],
+                $ensemble = [$myid, "localhost:2888:3888"],
                 $kerberos_realm = $hadoop_zookeeper::kerberos_realm,
   ) inherits hadoop_zookeeper {
     include common

--- a/bigtop-deploy/puppet/modules/hadoop_zookeeper/templates/zoo.cfg
+++ b/bigtop-deploy/puppet/modules/hadoop_zookeeper/templates/zoo.cfg
@@ -26,8 +26,8 @@ syncLimit=5
 dataDir=<%= @datadir %>
 # the port at which the clients will connect
 clientPort=<%= @port %>
-<% @ensemble.each_with_index do |server,idx| %>
-server.<%= idx %>=<%= server %>
+<% @ensemble.each do |idx, ip| %>
+server.<%= idx %>=<%= ip %>
 <% end %>
 # purge snapshots every day
 autopurge.purgeInterval=24

--- a/bigtop-deploy/puppet/modules/hadoop_zookeeper/templates/zoo.cfg
+++ b/bigtop-deploy/puppet/modules/hadoop_zookeeper/templates/zoo.cfg
@@ -26,8 +26,14 @@ syncLimit=5
 dataDir=<%= @datadir %>
 # the port at which the clients will connect
 clientPort=<%= @port %>
-<% @ensemble.each do |idx, ip| %>
+<% if !@ensemble[0].nil? && @ensemble[0].length == 2 %>
+  <% @ensemble.each do |idx, ip| %>
 server.<%= idx %>=<%= ip %>
+  <% end %>
+<% else %>
+  <% @ensemble.each_with_index do |server,idx| %>
+server.<%= idx %>=<%= server %>
+  <% end %>
 <% end %>
 # purge snapshots every day
 autopurge.purgeInterval=24

--- a/bigtop-deploy/puppet/modules/hadoop_zookeeper/tests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop_zookeeper/tests/init.pp
@@ -16,5 +16,5 @@
 hadoop_zookeeper::client { "zoo visitor": }
 hadoop_zookeeper::server { "test-oozie-server":
   myid => "0",
-  ensemble => ["foo:2888:3888", "bar:2888:3888", "baz:2888:3888"],
+  ensemble => [[0, "foo:2888:3888"], [1, "bar:2888:3888"], [2, "baz:2888:3888"]],
 }


### PR DESCRIPTION
Zookeeper wants its peer ids to be consistent across nodes, but the
current puppet script auto-generates ids for nodes, based on their index
in a list. This breaks Zookeeper quorum.

We fix the issue by requiring that puppet take a list comprising
explicit ids and ip addresses, rather than just a list of ip addresses.