### PR TITLE
BIGTOP-2480: Fix occasional timeout on hadoop-processing Juju bundle

### DIFF
--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   openjdk:
-    charm: cs:trusty/openjdk-1
+    charm: cs:trusty/openjdk-4
     annotations:
       gui-x: "500"
       gui-y: "400"
@@ -8,28 +8,28 @@ services:
       java-type: "jdk"
       java-major: "8"
   namenode:
-    charm: cs:trusty/hadoop-namenode-3
+    charm: cs:trusty/hadoop-namenode-4
     num_units: 1
     annotations:
       gui-x: "500"
       gui-y: "800"
     constraints: mem=7G
   resourcemanager:
-    charm: cs:trusty/hadoop-resourcemanager-3
+    charm: cs:trusty/hadoop-resourcemanager-4
     num_units: 1
     annotations:
       gui-x: "500"
       gui-y: "0"
     constraints: mem=7G
   slave:
-    charm: cs:trusty/hadoop-slave-4
+    charm: cs:trusty/hadoop-slave-5
     num_units: 3
     annotations:
       gui-x: "0"
       gui-y: "400"
     constraints: mem=7G
   plugin:
-    charm: cs:trusty/hadoop-plugin-3
+    charm: cs:trusty/hadoop-plugin-4
     annotations:
       gui-x: "1000"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-processing/tests/00-deploy
+++ b/bigtop-deploy/juju/hadoop-processing/tests/00-deploy
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import yaml
+import amulet
+
+
+bundle_file = os.path.join(os.path.dirname(__file__), '..', 'bundle.yaml')
+d = amulet.Deployment(series='trusty')
+with open(bundle_file) as f:
+    bun = f.read()
+bundle = yaml.safe_load(bun)
+d.load(bundle)
+d.setup(timeout=3600)
+d.sentry.wait_for_messages({'client': 'Ready'}, timeout=3600)

--- a/bigtop-deploy/juju/hadoop-processing/tests/tests.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/tests/tests.yaml
@@ -1,4 +1,6 @@
 reset: false
+bundle_deploy: 00-deploy
+makefile: []
 packages:
   - amulet
   - python3-yaml


### PR DESCRIPTION
During test runs, we are sometimes seeing the bundle test timeout during the initial deploy on slow clouds. GCE in particular is slow to deploy (but is faster once deployed, go figure).

There is a feature of the bundletester tool which can be used to increase the deployment timeout.
