### PR TITLE
BIGTOP-2504 Kafka should be able to bind to something other than 0.0.0.0/the default interface

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -191,6 +191,7 @@ hadoop::common::tez_jars: "/usr/lib/tez"
 #kafka
 kafka::server::port: "9092"
 kafka::server::zookeeper_connection_string: "%{hiera('bigtop::hadoop_head_node')}:2181"
+kafka::server::bind_addr: ""
 
 zeppelin::server::spark_master_url: "yarn-client"
 zeppelin::server::hiveserver2_url: "jdbc:hive2://%{hiera('hadoop-hive::common::hiveserver2_host')}:%{hiera('hadoop-hive::common::hiveserver2_port')}"

--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -191,7 +191,6 @@ hadoop::common::tez_jars: "/usr/lib/tez"
 #kafka
 kafka::server::port: "9092"
 kafka::server::zookeeper_connection_string: "%{hiera('bigtop::hadoop_head_node')}:2181"
-kafka::server::bind_addr: ""
 
 zeppelin::server::spark_master_url: "yarn-client"
 zeppelin::server::hiveserver2_url: "jdbc:hive2://%{hiera('hadoop-hive::common::hiveserver2_host')}:%{hiera('hadoop-hive::common::hiveserver2_port')}"

--- a/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
@@ -22,10 +22,10 @@ class kafka {
   }
 
   class server(
+      $bind_addr = undef,
       $broker_id = "0",
       $port = "9092",
       $zookeeper_connection_string = "localhost:2181",
-      $bind_addr = ""
     ) {
 
     package { 'kafka':

--- a/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
@@ -24,7 +24,8 @@ class kafka {
   class server(
       $broker_id = "0",
       $port = "9092",
-      $zookeeper_connection_string = "localhost:2181"
+      $zookeeper_connection_string = "localhost:2181",
+      $bind_addr = ""
     ) {
 
     package { 'kafka':

--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
@@ -25,7 +25,7 @@ broker.id=<%= @broker_id %>
 port=<%= @port %>
 
 # Hostname the broker will bind to. If not set, the server will bind to all interfaces
-<% if @bind_addr %>
+<% if !@bind_addr.nil? && !@bind_addr.empty? %>
 host.name=<%= @bind_addr %>
 <% else %>
 #host.name=localhost

--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
@@ -25,7 +25,11 @@ broker.id=<%= @broker_id %>
 port=<%= @port %>
 
 # Hostname the broker will bind to. If not set, the server will bind to all interfaces
+<% if @bind_addr %>
+host.name=<%= @bind_addr %>
+<% else %>
 #host.name=localhost
+<% end %>
 
 # Hostname the broker will advertise to producers and consumers. If not set, it uses the
 # value for "host.name" if configured.  Otherwise, it will use the value returned from

--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
@@ -25,11 +25,11 @@ broker.id=<%= @broker_id %>
 port=<%= @port %>
 
 # Hostname the broker will bind to. If not set, the server will bind to all interfaces
-<% if !@bind_addr.nil? && !@bind_addr.empty? %>
-host.name=<%= @bind_addr %>
-<% else %>
+<% if @bind_addr.nil? -%>
 #host.name=localhost
-<% end %>
+<% else -%>
+host.name=<%= @bind_addr %>
+<% end -%>
 
 # Hostname the broker will advertise to producers and consumers. If not set, it uses the
 # value for "host.name" if configured.  Otherwise, it will use the value returned from


### PR DESCRIPTION
For security reasons, some people deploying kafka would like to bind it to listen on a specific network interface. Details in this ticket, filed against the kafka juju charm:

https://bugs.launchpad.net/charms/+source/apache-kafka/+bug/1602666

This ticket tracks work to add the necessary hooks in the puppet scripts.