### PR TITLE
BIGTOP-2506 Zookeeper: non default interface for client

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop_zookeeper/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop_zookeeper/manifests/init.pp
@@ -63,6 +63,7 @@ class hadoop_zookeeper (
                 $datadir = "/var/lib/zookeeper",
                 $ensemble = ["localhost:2888:3888"],
                 $kerberos_realm = $hadoop_zookeeper::kerberos_realm,
+                $client_bind_addr = "",
   ) inherits hadoop_zookeeper {
     include common
 

--- a/bigtop-deploy/puppet/modules/hadoop_zookeeper/templates/zoo.cfg
+++ b/bigtop-deploy/puppet/modules/hadoop_zookeeper/templates/zoo.cfg
@@ -24,6 +24,10 @@ initLimit=10
 syncLimit=5
 # the directory where the snapshot is stored.
 dataDir=<%= @datadir %>
+<% if !@client_bind_addr.nil? && !@client_bind_addr.empty? %>
+# bind to this network ip/interface
+clientPortAddress=<%= @client_bind_addr %>
+<% end %>
 # the port at which the clients will connect
 clientPort=<%= @port %>
 <% @ensemble.each_with_index do |server,idx| %>


### PR DESCRIPTION
Added puppet config for clientPortBindAddress.

Allows us to bind to a specific interface/ip in secure environments,
where we might want to restrict incoming connections.

If you're following the full chain of PRs for this change, the next link is the .patch file in the apache-base-layer: https://github.com/juju-solutions/layer-apache-bigtop-base/pull/33, which contains these changes, in addition to some fixes for apt installing things on Xenial.
