### PR TITLE
Update Solr to 4.10.4

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -264,7 +264,7 @@ bigtop {
     'solr' {
       name    = 'solr'
       relNotes = 'Apache Solr'
-      version { base = '4.9.0'; pkg = base; release = 1 }
+      version { base = '4.10.4'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tgz"
                 source      = destination }
       url     { download_path = "lucene/$name/${version.base}"


### PR DESCRIPTION
I tried bumping the version of Solr to the last 4.10 release and running the 'gradlew' build script to build RPM packages.  That build process worked fine, and the resulting solr-4.10.4 packages at least install on our CentOS machines and start up as expected.

I don't know if my employer will decide to try this with 5.5.x or 6.x.  I expect that version bump would be more complicated because of Solr's switch from using Tomcat to Jetty, but haven't tried it yet.  For those versions, we might just install Solr directly from a .tgz without using Bigtop's re-packaging.
