### PR TITLE
BIGTOP-2550: Update juju hadoop bundle for Juju 2.0 and Xenial

### DIFF
--- a/bigtop-deploy/juju/hadoop-processing/README.md
+++ b/bigtop-deploy/juju/hadoop-processing/README.md
@@ -163,7 +163,7 @@ application and expose it:
 
 The web interface will be available at the following URL:
 
-        http://NAMENODE_PUBLIC_IP:50070
+    http://NAMENODE_PUBLIC_IP:50070
 
 Similarly, to access the Resource Manager web consoles, find the
 `PUBLIC-ADDRESS` of the resourcemanager application and expose it:

--- a/bigtop-deploy/juju/hadoop-processing/README.md
+++ b/bigtop-deploy/juju/hadoop-processing/README.md
@@ -85,12 +85,17 @@ The charms in this bundle can also be built from their source layers in the
 [Bigtop charm repository][].  See the [Bigtop charm README][] for instructions
 on building and deploying these charms locally.
 
+## Network-Restricted Environments
+Charms can be deployed in environments with limited network access. To deploy
+in this environment, configure a Juju model with appropriate proxy and/or
+mirror options. See [Configuring Models][] for more information.
 
 [getting-started]: https://jujucharms.com/docs/stable/getting-started
 [bundle.yaml]: https://github.com/apache/bigtop/blob/master/bigtop-deploy/juju/hadoop-processing/bundle.yaml
 [juju-quickstart]: https://launchpad.net/juju-quickstart
 [Bigtop charm repository]: https://github.com/apache/bigtop/tree/master/bigtop-packages/src/charm
 [Bigtop charm README]: https://github.com/apache/bigtop/blob/master/bigtop-packages/src/charm/README.md
+[Configuring Models]: https://jujucharms.com/docs/stable/models-config
 
 
 # Verifying
@@ -262,15 +267,6 @@ capabilities, simply add more slave units. To add one unit:
 Multiple units may be added at once.  For example, add four more slave units:
 
     juju add-unit -n4 slave
-
-
-# Network-Restricted Environments
-
-Charms can be deployed in environments with limited network access. To deploy
-in this environment, configure a Juju model with appropriate proxy and/or
-mirror options. See [Configuring Models][] for more information.
-
-[Configuring Models]: https://jujucharms.com/docs/2.0/models-config
 
 
 # Contact Information

--- a/bigtop-deploy/juju/hadoop-processing/README.md
+++ b/bigtop-deploy/juju/hadoop-processing/README.md
@@ -14,95 +14,120 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-## Overview
+# Overview
 
 The Apache Hadoop software library is a framework that allows for the
 distributed processing of large data sets across clusters of computers
 using a simple programming model.
 
-It is designed to scale up from single servers to thousands of machines,
+Hadoop is designed to scale from a few servers to thousands of machines,
 each offering local computation and storage. Rather than rely on hardware
-to deliver high-avaiability, the library itself is designed to detect
-and handle failures at the application layer, so delivering a
-highly-availabile service on top of a cluster of computers, each of
-which may be prone to failures.
+to deliver high-availability, Hadoop can detect and handle failures at the
+application layer. This provides a highly-available service on top of a cluster
+of machines, each of which may be prone to failure.
 
 This bundle provides a complete deployment of the core components of the
 [Apache Bigtop](http://bigtop.apache.org/)
-platform to perform distributed data analytics at scale.  These components
-include:
+platform to perform distributed data processing at scale. Ganglia and rsyslog
+applications are also provided to monitor cluster health and syslog activity.
+
+## Bundle Composition
+
+The applications that comprise this bundle are spread across 6 units as
+follows:
 
   * NameNode (HDFS)
   * ResourceManager (YARN)
-  * Slaves (DataNode and NodeManager)
-  * Client (Bigtop hadoop client)
-    * Plugin (subordinate cluster facilitator)
+    * Colocated on the NameNode unit
+  * Slave (DataNode and NodeManager)
+    * 3 separate units
+  * Client (Hadoop endpoint)
+  * Plugin (Facilitates communication with the Hadoop cluster)
+    * Colocated on the Client unit
+  * Ganglia (Web interface for monitoring cluster metrics)
+  * Rsyslog (Aggregate cluster syslog events in a single location)
+    * Colocated on the Ganglia unit
 
-Deploying this bundle gives you a fully configured and connected Apache Bigtop
-cluster on any supported cloud, which can be easily scaled to meet workload
+Deploying this bundle results in a fully configured Apache Bigtop
+cluster on any supported cloud, which can be scaled to meet workload
 demands.
 
 
-## Deploying this bundle
+# Deploying
 
-In this deployment, the aforementioned components are deployed on separate
-units. To deploy this bundle, simply use:
+A working Juju installation is assumed to be present. If Juju is not yet set
+up, please follow the
+[getting-started](https://jujucharms.com/docs/2.0/getting-started)
+instructions prior to deploying this bundle.
+
+Once ready, deploy this bundle with the `juju deploy` command:
 
     juju deploy hadoop-processing
 
-This will deploy this bundle and all the charms from the [charm store][].
+> **Note**: The above assumes Juju 2.0 or greater. If using an earlier version
+of Juju, use [juju-quickstart](https://launchpad.net/juju-quickstart) with the
+following syntax: `juju quickstart hadoop-processing`.
 
-> Note: With Juju versions < 2.0, you will need to use [juju-deployer][] to
-deploy the bundle.
+The charms in this bundle can also be built from their source layers in the
+[Bigtop charm repository][].  See the [Bigtop charm README][] for instructions
+on building and deploying these charms locally.
 
-You can also build all of the charms from their source layers in the
-[Bigtop repository][].  See the [charm package README][] for instructions
-to build and deploy the charms.
-
-The default bundle deploys three slave nodes and one node of each of
-the other services. To scale the cluster, use:
-
-    juju add-unit slave -n 2
-
-This will add two additional slave nodes, for a total of five.
-
-[charm store]: https://jujucharms.com/
-[Bigtop repository]: https://github.com/apache/bigtop
-[charm package README]: ../../../bigtop-packages/src/charm/README.md
-[juju-deployer]: https://pypi.python.org/pypi/juju-deployer/
+[Bigtop charm repository]: https://github.com/apache/bigtop/tree/master/bigtop-packages/src/charm
+[Bigtop charm README]: https://github.com/apache/bigtop/blob/master/bigtop-packages/src/charm/README.md
 
 
-## Status and Smoke Test
+# Verifying
 
-The services provide extended status reporting to indicate when they are ready:
+## Status
+The applications that make up this bundle provide status messages to
+indicate when they are ready:
 
-    juju status --format=tabular
+    juju status
 
 This is particularly useful when combined with `watch` to track the on-going
 progress of the deployment:
 
-    watch -n 0.5 juju status --format=tabular
+    watch -n 0.5 juju status
 
-The charms for each master component (namenode, resourcemanager)
-also each provide a `smoke-test` action that can be used to verify that each
-component is functioning as expected.  You can run them all and then watch the
-action status list:
+The message for each unit will provide information about that unit's state.
+Once they all indicate that they are ready, perform application smoke tests
+to verify that the bundle is working as expected.
 
-    juju action do namenode/0 smoke-test
-    juju action do resourcemanager/0 smoke-test
-    watch -n 0.5 juju action status
+## Smoke Test
+The charms for each core component (namenode, resourcemanager, and slave)
+provide a `smoke-test` action that can be used to verify the application is
+functioning as expected. Note that the 'slave' component runs extensive
+tests provided by Apache Bigtop and may take up to 30 minutes to complete.
+Run the smoke-test actions as follows:
+
+    juju run-action namenode/0 smoke-test
+    juju run-action resourcemanager/0 smoke-test
+    juju run-action slave/0 smoke-test
+
+> **Note**: The above assumes Juju 2.0 or greater. If using an earlier version
+of Juju, the syntax is `juju action do <application>/0 smoke-test`.
+
+Watch the progress of the smoke test actions with:
+
+    watch -n 0.5 juju show-action-status
+
+> **Note**: The above assumes Juju 2.0 or greater. If using an earlier version
+of Juju, the syntax is `juju action status`.
 
 Eventually, all of the actions should settle to `status: completed`.  If
-any go instead to `status: failed` then it means that component is not working
-as expected.  You can get more information about that component's smoke test:
+any report `status: failed`, that application is not working as expected. Get
+more information about a specific smoke test with:
 
-    juju action fetch <action-id>
+    juju show-action-output <action-id>
+
+> **Note**: The above assumes Juju 2.0 or greater. If using an earlier version
+of Juju, the syntax is `juju action fetch <action-id>`.
 
 
-## Monitoring
+# Monitoring
 
 This bundle includes Ganglia for system-level monitoring of the namenode,
-resourcemanager, and slave units. Metrics are sent to a central
+resourcemanager, slave, and client units. Metrics are sent to a centralized
 ganglia unit for easy viewing in a browser. To view the ganglia web interface,
 first expose the service:
 
@@ -117,74 +142,98 @@ The ganglia web interface will be available at:
     http://GANGLIA_PUBLIC_IP/ganglia
 
 
-## Benchmarking
+# Logging
 
-This charm provides several benchmarks to gauge the performance of your
-environment.
+This bundle includes rsyslog to collect syslog data from the namenode,
+resourcemanager, slave, and client units. These logs are sent to a
+centralized rsyslog unit for easy syslog analysis of the units that make up
+the Hadoop cluster. One method of viewing this log data is to simply cat syslog
+from the rsyslog unit:
 
-The easiest way to run the benchmarks on this service is to relate it to the
-[Benchmark GUI][].  You will likely also want to relate it to the
-[Benchmark Collector][] to have machine-level information collected during the
-benchmark, for a more complete picture of how the machine performed.
+    juju run --unit rsyslog/0 'sudo cat /var/log/syslog'
 
-[Benchmark GUI]: https://jujucharms.com/benchmark-gui/
-[Benchmark Collector]: https://jujucharms.com/benchmark-collector/
-
-However, each benchmark is also an action that can be called manually:
-
-        $ juju action do resourcemanager/0 nnbench
-        Action queued with id: 55887b40-116c-4020-8b35-1e28a54cc622
-        $ juju action fetch --wait 0 55887b40-116c-4020-8b35-1e28a54cc622
-
-        results:
-          meta:
-            composite:
-              direction: asc
-              units: secs
-              value: "128"
-            start: 2016-02-04T14:55:39Z
-            stop: 2016-02-04T14:57:47Z
-          results:
-            raw: '{"BAD_ID": "0", "FILE: Number of read operations": "0", "Reduce input groups":
-              "8", "Reduce input records": "95", "Map output bytes": "1823", "Map input records":
-              "12", "Combine input records": "0", "HDFS: Number of bytes read": "18635", "FILE:
-              Number of bytes written": "32999982", "HDFS: Number of write operations": "330",
-              "Combine output records": "0", "Total committed heap usage (bytes)": "3144749056",
-              "Bytes Written": "164", "WRONG_LENGTH": "0", "Failed Shuffles": "0", "FILE:
-              Number of bytes read": "27879457", "WRONG_MAP": "0", "Spilled Records": "190",
-              "Merged Map outputs": "72", "HDFS: Number of large read operations": "0", "Reduce
-              shuffle bytes": "2445", "FILE: Number of large read operations": "0", "Map output
-              materialized bytes": "2445", "IO_ERROR": "0", "CONNECTION": "0", "HDFS: Number
-              of read operations": "567", "Map output records": "95", "Reduce output records":
-              "8", "WRONG_REDUCE": "0", "HDFS: Number of bytes written": "27412", "GC time
-              elapsed (ms)": "603", "Input split bytes": "1610", "Shuffled Maps ": "72", "FILE:
-              Number of write operations": "0", "Bytes Read": "1490"}'
-        status: completed
-        timing:
-          completed: 2016-02-04 14:57:48 +0000 UTC
-          enqueued: 2016-02-04 14:55:14 +0000 UTC
-          started: 2016-02-04 14:55:27 +0000 UTC
+Logs may also be forwarded to an external rsyslog processing service. See
+the *Forwarding logs to a system outside of the Juju environment* section of
+the [rsyslog README](https://jujucharms.com/rsyslog/) for more information.
 
 
-## Deploying in Network-Restricted Environments
+# Benchmarking
+
+The `resourcemanager` charm in this bundle provide several benchmarks to gauge
+the performance of the Hadoop cluster. Each benchmark is an action that can be
+run with `juju run-action`:
+
+    $ juju actions resourcemanager
+    ACTION      DESCRIPTION
+    mrbench     Mapreduce benchmark for small jobs
+    nnbench     Load test the NameNode hardware and configuration
+    smoke-test  Run an Apache Bigtop smoke test.
+    teragen     Generate data with teragen
+    terasort    Runs teragen to generate sample data, and then runs terasort to sort that data
+    testdfsio   DFS IO Testing
+
+    $ juju run-action resourcemanager/0 nnbench
+    Action queued with id: 55887b40-116c-4020-8b35-1e28a54cc622
+
+    $ juju show-action-output 55887b40-116c-4020-8b35-1e28a54cc622
+    results:
+      meta:
+        composite:
+          direction: asc
+          units: secs
+          value: "128"
+        start: 2016-02-04T14:55:39Z
+        stop: 2016-02-04T14:57:47Z
+      results:
+        raw: '{"BAD_ID": "0", "FILE: Number of read operations": "0", "Reduce input groups":
+          "8", "Reduce input records": "95", "Map output bytes": "1823", "Map input records":
+          "12", "Combine input records": "0", "HDFS: Number of bytes read": "18635", "FILE:
+          Number of bytes written": "32999982", "HDFS: Number of write operations": "330",
+          "Combine output records": "0", "Total committed heap usage (bytes)": "3144749056",
+          "Bytes Written": "164", "WRONG_LENGTH": "0", "Failed Shuffles": "0", "FILE:
+          Number of bytes read": "27879457", "WRONG_MAP": "0", "Spilled Records": "190",
+          "Merged Map outputs": "72", "HDFS: Number of large read operations": "0", "Reduce
+          shuffle bytes": "2445", "FILE: Number of large read operations": "0", "Map output
+          materialized bytes": "2445", "IO_ERROR": "0", "CONNECTION": "0", "HDFS: Number
+          of read operations": "567", "Map output records": "95", "Reduce output records":
+          "8", "WRONG_REDUCE": "0", "HDFS: Number of bytes written": "27412", "GC time
+          elapsed (ms)": "603", "Input split bytes": "1610", "Shuffled Maps ": "72", "FILE:
+          Number of write operations": "0", "Bytes Read": "1490"}'
+    status: completed
+    timing:
+      completed: 2016-02-04 14:57:48 +0000 UTC
+      enqueued: 2016-02-04 14:55:14 +0000 UTC
+      started: 2016-02-04 14:55:27 +0000 UTC
+
+
+# Scaling
+
+By default, three slave units and one unit of each of the other components are
+deployed with this bundle. To scale the cluster compute and storage
+capabilities, simply add more slave units. To add one unit:
+
+    juju add-unit slave
+
+Multiple units may be added at once.  For example, add four more slave units:
+
+    juju add-unit -n4 slave
+
+
+# Network-Restricted Environments
 
 Charms can be deployed in environments with limited network access. To deploy
-in this environment, you will need a local mirror to serve required packages.
+in this environment, configure a Juju model with appropriate
+proxy and/or mirror options. See
+[Configuring Models](https://jujucharms.com/docs/2.0/models-config) for more
+information.
 
 
-### Mirroring Packages
-
-You can setup a local mirror for apt packages using squid-deb-proxy.
-For instructions on configuring juju to use this, see the
-[Juju Proxy Documentation](https://juju.ubuntu.com/docs/howto-proxies.html).
-
-
-## Contact Information
+# Contact Information
 
 - <bigdata@lists.ubuntu.com>
 
 
-## Resources
+# Resources
 
 - [Apache Bigtop](http://bigtop.apache.org/) home page
 - [Apache Bigtop issue tracking](http://bigtop.apache.org/issue-tracking.html)

--- a/bigtop-deploy/juju/hadoop-processing/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle-dev.yaml
@@ -1,68 +1,103 @@
 services:
-  openjdk:
-    charm: cs:trusty/openjdk
-    annotations:
-      gui-x: "500"
-      gui-y: "400"
-    options:
-      java-type: "jdk"
-      java-major: "8"
   namenode:
-    charm: cs:~bigdata-dev/trusty/hadoop-namenode
+    charm: "cs:~bigdata-dev/xenial/hadoop-namenode"
     num_units: 1
     annotations:
       gui-x: "500"
       gui-y: "800"
-    constraints: mem=7G
+    to:
+      - "1"
   resourcemanager:
-    charm: cs:~bigdata-dev/trusty/hadoop-resourcemanager
+    charm: "cs:~bigdata-dev/xenial/hadoop-resourcemanager"
     num_units: 1
     annotations:
       gui-x: "500"
       gui-y: "0"
-    constraints: mem=7G
+    to:
+      - "1"
   slave:
-    charm: cs:~bigdata-dev/trusty/hadoop-slave
+    charm: "cs:~bigdata-dev/xenial/hadoop-slave"
     num_units: 3
     annotations:
       gui-x: "0"
       gui-y: "400"
-    constraints: mem=7G
+    to:
+      - "2"
+      - "3"
+      - "4"
   plugin:
-    charm: cs:~bigdata-dev/trusty/hadoop-plugin
+    charm: "cs:~bigdata-dev/xenial/hadoop-plugin"
     annotations:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: cs:trusty/hadoop-client
+    charm: "cs:xenial/hadoop-client-2"
     num_units: 1
     annotations:
       gui-x: "1250"
       gui-y: "400"
+    to:
+      - "5"
+  ganglia:
+    charm: "cs:trusty/ganglia-2"
+    num_units: 1
+    annotations:
+      gui-x: "0"
+      gui-y: "800"
+    to:
+      - "6"
   ganglia-node:
-    charm: cs:trusty/ganglia-node
+    charm: "cs:~bigdata-dev/xenial/ganglia-node-2"
     annotations:
       gui-x: "250"
       gui-y: "400"
-  ganglia:
-    charm: cs:trusty/ganglia
+  rsyslog:
+    charm: "cs:trusty/rsyslog-10"
     num_units: 1
+    annotations:
+      gui-x: "1000"
+      gui-y: "800"
+    to:
+      - "6"
+  rsyslog-forwarder-ha:
+    charm: "cs:~bigdata-dev/xenial/rsyslog-forwarder-ha-2"
     annotations:
       gui-x: "750"
       gui-y: "400"
-series: trusty
+series: xenial
 relations:
-  - [openjdk, namenode]
-  - [openjdk, resourcemanager]
-  - [openjdk, slave]
-  - [openjdk, client]
   - [resourcemanager, namenode]
   - [namenode, slave]
   - [resourcemanager, slave]
   - [plugin, namenode]
   - [plugin, resourcemanager]
   - [client, plugin]
-  - ["ganglia:node", ganglia-node]
-  - [ganglia-node, namenode]
-  - [ganglia-node, resourcemanager]
-  - [ganglia-node, slave]
+  - ["ganglia-node:juju-info", "client:juju-info"]
+  - ["ganglia-node:juju-info", "namenode:juju-info"]
+  - ["ganglia-node:juju-info", "resourcemanager:juju-info"]
+  - ["ganglia-node:juju-info", "slave:juju-info"]
+  - ["ganglia:node", "ganglia-node:node"]
+  - ["rsyslog-forwarder-ha:juju-info", "client:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "namenode:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "resourcemanager:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "slave:juju-info"]
+  - ["rsyslog:aggregator", "rsyslog-forwarder-ha:syslog"]
+machines:
+  "1":
+    constraints: "mem=7G"
+    series: "xenial"
+  "2":
+    constraints: "mem=7G"
+    series: "xenial"
+  "3":
+    constraints: "mem=7G"
+    series: "xenial"
+  "4":
+    constraints: "mem=7G"
+    series: "xenial"
+  "5":
+    constraints: "mem=3G"
+    series: "xenial"
+  "6":
+    constraints: "mem=3G"
+    series: "trusty"

--- a/bigtop-deploy/juju/hadoop-processing/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle-local.yaml
@@ -1,68 +1,103 @@
 services:
-  openjdk:
-    charm: cs:trusty/openjdk
-    annotations:
-      gui-x: "500"
-      gui-y: "400"
-    options:
-      java-type: "jdk"
-      java-major: "8"
   namenode:
-    charm: local:trusty/hadoop-namenode
+    charm: "/home/ubuntu/charms/xenial/hadoop-namenode"
     num_units: 1
     annotations:
       gui-x: "500"
       gui-y: "800"
-    constraints: mem=7G
+    to:
+      - "1"
   resourcemanager:
-    charm: local:trusty/hadoop-resourcemanager
+    charm: "/home/ubuntu/charms/xenial/hadoop-resourcemanager"
     num_units: 1
     annotations:
       gui-x: "500"
       gui-y: "0"
-    constraints: mem=7G
+    to:
+      - "1"
   slave:
-    charm: local:trusty/hadoop-slave
+    charm: "/home/ubuntu/charms/xenial/hadoop-slave"
     num_units: 3
     annotations:
       gui-x: "0"
       gui-y: "400"
-    constraints: mem=7G
+    to:
+      - "2"
+      - "3"
+      - "4"
   plugin:
-    charm: local:trusty/hadoop-plugin
+    charm: "/home/ubuntu/charms/xenial/hadoop-plugin"
     annotations:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: cs:trusty/hadoop-client
+    charm: "cs:xenial/hadoop-client-2"
     num_units: 1
     annotations:
       gui-x: "1250"
       gui-y: "400"
+    to:
+      - "5"
+  ganglia:
+    charm: "cs:trusty/ganglia-2"
+    num_units: 1
+    annotations:
+      gui-x: "0"
+      gui-y: "800"
+    to:
+      - "6"
   ganglia-node:
-    charm: cs:trusty/ganglia-node
+    charm: "cs:~bigdata-dev/xenial/ganglia-node-2"
     annotations:
       gui-x: "250"
       gui-y: "400"
-  ganglia:
-    charm: cs:trusty/ganglia
+  rsyslog:
+    charm: "cs:trusty/rsyslog-10"
     num_units: 1
+    annotations:
+      gui-x: "1000"
+      gui-y: "800"
+    to:
+      - "6"
+  rsyslog-forwarder-ha:
+    charm: "cs:~bigdata-dev/xenial/rsyslog-forwarder-ha-2"
     annotations:
       gui-x: "750"
       gui-y: "400"
-series: trusty
+series: xenial
 relations:
-  - [openjdk, namenode]
-  - [openjdk, resourcemanager]
-  - [openjdk, slave]
-  - [openjdk, client]
   - [resourcemanager, namenode]
   - [namenode, slave]
   - [resourcemanager, slave]
   - [plugin, namenode]
   - [plugin, resourcemanager]
   - [client, plugin]
-  - ["ganglia:node", ganglia-node]
-  - [ganglia-node, namenode]
-  - [ganglia-node, resourcemanager]
-  - [ganglia-node, slave]
+  - ["ganglia-node:juju-info", "client:juju-info"]
+  - ["ganglia-node:juju-info", "namenode:juju-info"]
+  - ["ganglia-node:juju-info", "resourcemanager:juju-info"]
+  - ["ganglia-node:juju-info", "slave:juju-info"]
+  - ["ganglia:node", "ganglia-node:node"]
+  - ["rsyslog-forwarder-ha:juju-info", "client:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "namenode:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "resourcemanager:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "slave:juju-info"]
+  - ["rsyslog:aggregator", "rsyslog-forwarder-ha:syslog"]
+machines:
+  "1":
+    constraints: "mem=7G"
+    series: "xenial"
+  "2":
+    constraints: "mem=7G"
+    series: "xenial"
+  "3":
+    constraints: "mem=7G"
+    series: "xenial"
+  "4":
+    constraints: "mem=7G"
+    series: "xenial"
+  "5":
+    constraints: "mem=3G"
+    series: "xenial"
+  "6":
+    constraints: "mem=3G"
+    series: "trusty"

--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -1,68 +1,103 @@
 services:
-  openjdk:
-    charm: cs:trusty/openjdk-1
-    annotations:
-      gui-x: "500"
-      gui-y: "400"
-    options:
-      java-type: "jdk"
-      java-major: "8"
   namenode:
-    charm: cs:trusty/hadoop-namenode-3
+    charm: "cs:xenial/hadoop-namenode-2"
     num_units: 1
     annotations:
       gui-x: "500"
       gui-y: "800"
-    constraints: mem=7G
+    to:
+      - "1"
   resourcemanager:
-    charm: cs:trusty/hadoop-resourcemanager-3
+    charm: "cs:xenial/hadoop-resourcemanager-2"
     num_units: 1
     annotations:
       gui-x: "500"
       gui-y: "0"
-    constraints: mem=7G
+    to:
+      - "1"
   slave:
-    charm: cs:trusty/hadoop-slave-4
+    charm: "cs:xenial/hadoop-slave-2"
     num_units: 3
     annotations:
       gui-x: "0"
       gui-y: "400"
-    constraints: mem=7G
+    to:
+      - "2"
+      - "3"
+      - "4"
   plugin:
-    charm: cs:trusty/hadoop-plugin-3
+    charm: "cs:xenial/hadoop-plugin-2"
     annotations:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: cs:trusty/hadoop-client-4
+    charm: "cs:xenial/hadoop-client-2"
     num_units: 1
     annotations:
       gui-x: "1250"
       gui-y: "400"
+    to:
+      - "5"
+  ganglia:
+    charm: "cs:trusty/ganglia-2"
+    num_units: 1
+    annotations:
+      gui-x: "0"
+      gui-y: "800"
+    to:
+      - "6"
   ganglia-node:
-    charm: cs:trusty/ganglia-node-2
+    charm: "cs:~bigdata-dev/xenial/ganglia-node-2"
     annotations:
       gui-x: "250"
       gui-y: "400"
-  ganglia:
-    charm: cs:trusty/ganglia-2
+  rsyslog:
+    charm: "cs:trusty/rsyslog-10"
     num_units: 1
+    annotations:
+      gui-x: "1000"
+      gui-y: "800"
+    to:
+      - "6"
+  rsyslog-forwarder-ha:
+    charm: "cs:~bigdata-dev/xenial/rsyslog-forwarder-ha-2"
     annotations:
       gui-x: "750"
       gui-y: "400"
-series: trusty
+series: xenial
 relations:
-  - [openjdk, namenode]
-  - [openjdk, resourcemanager]
-  - [openjdk, slave]
-  - [openjdk, client]
   - [resourcemanager, namenode]
   - [namenode, slave]
   - [resourcemanager, slave]
   - [plugin, namenode]
   - [plugin, resourcemanager]
   - [client, plugin]
-  - ["ganglia:node", ganglia-node]
-  - [ganglia-node, namenode]
-  - [ganglia-node, resourcemanager]
-  - [ganglia-node, slave]
+  - ["ganglia-node:juju-info", "client:juju-info"]
+  - ["ganglia-node:juju-info", "namenode:juju-info"]
+  - ["ganglia-node:juju-info", "resourcemanager:juju-info"]
+  - ["ganglia-node:juju-info", "slave:juju-info"]
+  - ["ganglia:node", "ganglia-node:node"]
+  - ["rsyslog-forwarder-ha:juju-info", "client:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "namenode:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "resourcemanager:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "slave:juju-info"]
+  - ["rsyslog:aggregator", "rsyslog-forwarder-ha:syslog"]
+machines:
+  "1":
+    constraints: "mem=7G"
+    series: "xenial"
+  "2":
+    constraints: "mem=7G"
+    series: "xenial"
+  "3":
+    constraints: "mem=7G"
+    series: "xenial"
+  "4":
+    constraints: "mem=7G"
+    series: "xenial"
+  "5":
+    constraints: "mem=3G"
+    series: "xenial"
+  "6":
+    constraints: "mem=3G"
+    series: "trusty"

--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-2"
+    charm: "cs:xenial/hadoop-namenode-3"
     num_units: 1
     annotations:
       gui-x: "500"
@@ -8,7 +8,7 @@ services:
     to:
       - "1"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-2"
+    charm: "cs:xenial/hadoop-resourcemanager-3"
     num_units: 1
     annotations:
       gui-x: "500"
@@ -16,7 +16,7 @@ services:
     to:
       - "1"
   slave:
-    charm: "cs:xenial/hadoop-slave-2"
+    charm: "cs:xenial/hadoop-slave-3"
     num_units: 3
     annotations:
       gui-x: "0"
@@ -26,7 +26,7 @@ services:
       - "3"
       - "4"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-2"
+    charm: "cs:xenial/hadoop-plugin-3"
     annotations:
       gui-x: "1000"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-3"
+    charm: "cs:xenial/hadoop-namenode-4"
     num_units: 1
     annotations:
       gui-x: "500"
@@ -8,7 +8,7 @@ services:
     to:
       - "1"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-3"
+    charm: "cs:xenial/hadoop-resourcemanager-4"
     num_units: 1
     annotations:
       gui-x: "500"
@@ -16,7 +16,7 @@ services:
     to:
       - "1"
   slave:
-    charm: "cs:xenial/hadoop-slave-3"
+    charm: "cs:xenial/hadoop-slave-4"
     num_units: 3
     annotations:
       gui-x: "0"
@@ -26,7 +26,7 @@ services:
       - "3"
       - "4"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-3"
+    charm: "cs:xenial/hadoop-plugin-4"
     annotations:
       gui-x: "1000"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-processing/tests/tests.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/tests/tests.yaml
@@ -1,4 +1,5 @@
 reset: false
+deployment_timeout: 3600
 packages:
   - amulet
   - python3-yaml


### PR DESCRIPTION
- Update README with xenial and juju2 instructions.  Callout juju1 equivalent commands where applicable.
- Colocate apps that can live together (eg: RM and NN) to cut down on required machine resources.  Note this colocation in the readme.
- Bump charm revisions to include newly built charms from BIGTOP-2548.