### PR TITLE
BIGTOP-2555: hadoop charms should use bind-host overrides

### DIFF
--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/reactive/namenode.py
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/reactive/namenode.py
@@ -20,7 +20,6 @@ from charms.layer.apache_bigtop_base import (
 )
 from charmhelpers.core import hookenv, host
 from jujubigdata import utils
-from path import Path
 
 
 ###############################################################################
@@ -62,9 +61,13 @@ def install_namenode():
             'namenode',
             'mapred-app',
         ],
+        # NB: We want the NN to listen on all interfaces, so bind to 0.0.0.0.
         overrides={
             'hadoop::common_hdfs::hadoop_namenode_port': hdfs_port,
+            'hadoop::common_hdfs::hadoop_namenode_bind_host': '0.0.0.0',
             'hadoop::common_hdfs::hadoop_namenode_http_port': webhdfs_port,
+            'hadoop::common_hdfs::hadoop_namenode_http_bind_host': '0.0.0.0',
+            'hadoop::common_hdfs::hadoop_namenode_https_bind_host': '0.0.0.0',
         }
     )
     bigtop.trigger_puppet()
@@ -74,14 +77,6 @@ def install_namenode():
     # to signify NN's readiness. Set our NN info in the KV to fulfill this
     # requirement.
     utils.initialize_kv_host()
-
-    # make our namenode listen on all interfaces
-    hdfs_site = Path('/etc/hadoop/conf/hdfs-site.xml')
-    with utils.xmlpropmap_edit_in_place(hdfs_site) as props:
-        props['dfs.namenode.rpc-bind-host'] = '0.0.0.0'
-        props['dfs.namenode.servicerpc-bind-host'] = '0.0.0.0'
-        props['dfs.namenode.http-bind-host'] = '0.0.0.0'
-        props['dfs.namenode.https-bind-host'] = '0.0.0.0'
 
     # We need to create the 'mapred' user/group since we are not installing
     # hadoop-mapreduce. This is needed so the namenode can access yarn

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/reactive/resourcemanager.py
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/reactive/resourcemanager.py
@@ -72,6 +72,8 @@ def install_resourcemanager(namenode):
         rm_http = get_layer_opts().port('rm_webapp_http')
         jh_ipc = get_layer_opts().port('jobhistory')
         jh_http = get_layer_opts().port('jh_webapp_http')
+        hdfs_port = namenode.port()
+        webhdfs_port = namenode.webhdfs_port()
 
         bigtop = Bigtop()
         bigtop.render_site_yaml(
@@ -82,11 +84,20 @@ def install_resourcemanager(namenode):
             roles=[
                 'resourcemanager',
             ],
+            # NB: When we colocate the NN and RM, the RM will run puppet apply
+            # last. To ensure we don't lose any hdfs-site.xml data set by the
+            # NN, override common_hdfs properties again here.
             overrides={
                 'hadoop::common_yarn::hadoop_rm_port': rm_ipc,
                 'hadoop::common_yarn::hadoop_rm_webapp_port': rm_http,
+                'hadoop::common_yarn::hadoop_rm_bind_host': '0.0.0.0',
                 'hadoop::common_mapred_app::mapreduce_jobhistory_port': jh_ipc,
                 'hadoop::common_mapred_app::mapreduce_jobhistory_webapp_port': jh_http,
+                'hadoop::common_hdfs::hadoop_namenode_port': hdfs_port,
+                'hadoop::common_hdfs::hadoop_namenode_bind_host': '0.0.0.0',
+                'hadoop::common_hdfs::hadoop_namenode_http_port': webhdfs_port,
+                'hadoop::common_hdfs::hadoop_namenode_http_bind_host': '0.0.0.0',
+                'hadoop::common_hdfs::hadoop_namenode_https_bind_host': '0.0.0.0',
             }
         )
         bigtop.trigger_puppet()

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/reactive/resourcemanager.py
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/reactive/resourcemanager.py
@@ -91,6 +91,7 @@ def install_resourcemanager(namenode):
                 'hadoop::common_yarn::hadoop_rm_port': rm_ipc,
                 'hadoop::common_yarn::hadoop_rm_webapp_port': rm_http,
                 'hadoop::common_yarn::hadoop_rm_bind_host': '0.0.0.0',
+                'hadoop::common_mapred_app::mapreduce_jobhistory_host': '0.0.0.0',
                 'hadoop::common_mapred_app::mapreduce_jobhistory_port': jh_ipc,
                 'hadoop::common_mapred_app::mapreduce_jobhistory_webapp_port': jh_http,
                 'hadoop::common_hdfs::hadoop_namenode_port': hdfs_port,


### PR DESCRIPTION
- remove unused import
- Bind NN and RM to 0.0.0.0 (all interfaces) using the hiera options from
BIGTOP-2554. This fixes a problem where lxd would bind the apps to
`facter fqdn` which may not be resolvable to other containers in the lxd env.
- Note: since we recommend colocating NN and RM, make sure the RM repeats
the NN overrides so the RM puppet apply doesn't lose hdfs-site.xml config
from the NN puppet apply.