### PR TITLE
BIGTOP-2571: cwr driven updates to the zeppelin juju charm

### DIFF
--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/README.md
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/README.md
@@ -27,25 +27,25 @@ As a Multi-purpose Notebook, Apache Zeppelin is the place for interactive:
  * Data Analytics
  * Data Visualization & Collaboration
 
-This charm deploys the Zeppelin component of the Apache Bigtop platform.
+This charm deploys the Zeppelin component of the [Apache Bigtop][] platform.
+
+[Apache Bigtop]: http://bigtop.apache.org/
 
 
 # Deploying
 
 A working Juju installation is assumed to be present. If Juju is not yet set
-up, please follow the
-[getting-started](https://jujucharms.com/docs/2.0/getting-started)
-instructions prior to deploying this charm.
+up, please follow the [getting-started][] instructions prior to deploying this
+charm.
 
-This charm is intended to be deployed via one of the
-[apache bigtop bundles](https://jujucharms.com/u/bigdata-charmers/#bundles).
+This charm is intended to be deployed via one of the [apache bigtop bundles][].
 For example:
 
     juju deploy hadoop-processing
 
 > **Note**: The above assumes Juju 2.0 or greater. If using an earlier version
-of Juju, use [juju-quickstart](https://launchpad.net/juju-quickstart) with the
-following syntax: `juju quickstart hadoop-processing`.
+of Juju, use [juju-quickstart][] with the following syntax: `juju quickstart
+hadoop-processing`.
 
 This will deploy an Apache Bigtop Hadoop cluster. More information about this
 deployment can be found in the [bundle readme](https://jujucharms.com/hadoop-processing/).
@@ -65,6 +65,16 @@ The web interface will be available at the following URL:
 
     http://ZEPPELIN_PUBLIC_IP:9080
 
+## Network-Restricted Environments
+Charms can be deployed in environments with limited network access. To deploy
+in this environment, configure a Juju model with appropriate proxy and/or
+mirror options. See [Configuring Models][] for more information.
+
+[getting-started]: https://jujucharms.com/docs/stable/getting-started
+[apache bigtop bundles]: https://jujucharms.com/u/bigdata-charmers/#bundles
+[juju-quickstart]: https://launchpad.net/juju-quickstart
+[Configuring Models]: https://jujucharms.com/docs/stable/models-config
+
 
 # Verifying
 
@@ -77,7 +87,7 @@ are ready:
 This is particularly useful when combined with `watch` to track the on-going
 progress of the deployment:
 
-    watch -n 0.5 juju status
+    watch -n 2 juju status
 
 The message column will provide information about a given unit's state.
 This charm is ready for use once the status message indicates that it is
@@ -94,7 +104,7 @@ of Juju, the syntax is `juju action do zeppelin/0 smoke-test`.
 
 Watch the progress of the smoke test actions with:
 
-    watch -n 0.5 juju show-action-status
+    watch -n 2 juju show-action-status
 
 > **Note**: The above assumes Juju 2.0 or greater. If using an earlier version
 of Juju, the syntax is `juju action status`.
@@ -107,15 +117,6 @@ more information about a specific smoke test with:
 
 > **Note**: The above assumes Juju 2.0 or greater. If using an earlier version
 of Juju, the syntax is `juju action fetch <action-id>`.
-
-
-# Network-Restricted Environments
-
-Charms can be deployed in environments with limited network access. To deploy
-in this environment, configure a Juju model with appropriate
-proxy and/or mirror options. See
-[Configuring Models](https://jujucharms.com/docs/2.0/models-config) for more
-information.
 
 
 # Contact Information

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/reactive/zeppelin.py
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/reactive/zeppelin.py
@@ -18,6 +18,7 @@ import hashlib
 from charms.reactive import when, when_not
 from charms.reactive import is_state, set_state, remove_state
 from charmhelpers.core import hookenv
+from charms.layer.apache_bigtop_base import get_package_version
 from charms.layer.bigtop_zeppelin import Zeppelin
 from charms.reactive.helpers import data_changed
 
@@ -72,6 +73,9 @@ def initial_setup():
     zeppelin.open_ports()
     set_state('zeppelin.installed')
     update_status()
+    # set app version string for juju status output
+    zeppelin_version = get_package_version('zeppelin') or 'unknown'
+    hookenv.application_version_set(zeppelin_version)
 
 
 @when('zeppelin.installed')

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/tests/01-basic-deployment.py
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/tests/01-basic-deployment.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import amulet
+import re
+import unittest
+
+
+class TestDeploy(unittest.TestCase):
+    """
+    Simple deployment test for Apache Bigtop Zeppelin.
+    """
+    @classmethod
+    def setUpClass(cls):
+        cls.d = amulet.Deployment(series='xenial')
+        cls.d.add('zeppelin', 'cs:xenial/zeppelin')
+        cls.d.setup(timeout=1800)
+        cls.d.sentry.wait_for_messages({'zeppelin': re.compile('ready')}, timeout=1800)
+        cls.zeppelin = cls.d.sentry['zeppelin'][0]
+
+    def test_deployed(self):
+        """
+        Validate Zeppelin deployed successfully.
+        """
+        self.assertTrue(self.d.deployed)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/tests/02-zeppelin-smoke.py
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/tests/02-zeppelin-smoke.py
@@ -22,7 +22,7 @@ import unittest
 
 class TestDeploy(unittest.TestCase):
     """
-    Deployment and smoke test for the Apache Bigtop Zeppelin service.
+    Smoke test for Apache Bigtop Zeppelin.
     """
     @classmethod
     def setUpClass(cls):
@@ -33,7 +33,7 @@ class TestDeploy(unittest.TestCase):
         cls.d.relate('zeppelin:spark', 'spark:client')
 
         cls.d.setup(timeout=1800)
-        cls.d.sentry.wait_for_messages({'zeppelin': re.compile('ready')}, timeout=1800)
+        cls.d.sentry.wait_for_messages({'zeppelin': re.compile('ready with')}, timeout=1800)
         cls.zeppelin = cls.d.sentry['zeppelin'][0]
 
     def test_zeppelin(self):


### PR DESCRIPTION
Simplify our smoke test (it's must simpler and faster to smoke zeppelin/spark than it is to smoke zeppelin/hadoop).

Since zeppelin is based on hadoop-client, we were inheriting the client's 01-basic-deployment.py test, which installs `hadoop-client`.  Zeppelin tests don't need hadoop client, so override this test with one that does a simple deployment of just the zeppelin charm.

While we're in here, make the readme consistent with other bigtop charms and set our application version for `juju status` output.