### PR TITLE
BIGTOP-2586: hadoop-processing tests.yaml should include PPA for Amulet

### DIFF
--- a/bigtop-deploy/juju/hadoop-processing/tests/tests.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/tests/tests.yaml
@@ -1,5 +1,7 @@
 reset: false
 deployment_timeout: 3600
+sources:
+  - 'ppa:juju/stable'
 packages:
   - amulet
   - python3-yaml

--- a/bigtop-deploy/juju/spark-processing/tests/tests.yaml
+++ b/bigtop-deploy/juju/spark-processing/tests/tests.yaml
@@ -1,2 +1,4 @@
+sources:
+  - 'ppa:juju/stable'
 packages:
   - amulet


### PR DESCRIPTION
Add source PPA for Juju bundles' tests.yaml (both hadoop-processing and
spark-processing).