### PR TITLE
BIGTOP-2603: NN/RM charm should include a spark user/group

### DIFF
--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/layer.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/layer.yaml
@@ -8,14 +8,17 @@ options:
   apache-bigtop-base:
     groups:
       - 'mapred'
+      - 'spark'
       - 'yarn'
     users:
       mapred:
-        groups: ['hadoop', 'mapred']
+        groups: ['mapred', 'hadoop']
+      spark:
+        groups: ['spark', 'hadoop']
       ubuntu:
-        groups: ['hadoop', 'mapred']
+        groups: ['hadoop', 'mapred', 'spark']
       yarn:
-        groups: ['hadoop', 'yarn']
+        groups: ['yarn', 'hadoop']
     ports:
       namenode:
         port: 8020

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/reactive/namenode.py
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/reactive/namenode.py
@@ -78,10 +78,10 @@ def install_namenode():
     # requirement.
     utils.initialize_kv_host()
 
-    # We need to create the 'mapred' user/group since we are not installing
-    # hadoop-mapreduce. This is needed so the namenode can access yarn
-    # job history files in hdfs. Also add our ubuntu user to the hadoop
-    # and mapred groups.
+    # We need to create the 'mapred' and 'spark' user/group since we may not
+    # be installing hadoop-mapreduce or spark on this machine. This is needed
+    # so the namenode can access yarn and spark job history files in hdfs. Also
+    # add our ubuntu user to the hadoop, mapred, and spark groups.
     get_layer_opts().add_users()
 
     set_state('apache-bigtop-namenode.installed')

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/layer.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/layer.yaml
@@ -7,9 +7,14 @@ includes:
   - 'interface:benchmark'
 options:
   apache-bigtop-base:
+    groups:
+      - 'mapred'
+      - 'spark'
     users:
+      spark:
+        groups: ['spark', 'hadoop']
       ubuntu:
-        groups: ['hadoop', 'mapred']
+        groups: ['hadoop', 'mapred', 'spark']
     ports:
         resourcemanager:
             port: 8032

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/reactive/resourcemanager.py
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/reactive/resourcemanager.py
@@ -109,7 +109,10 @@ def install_resourcemanager(namenode):
         # requirement.
         utils.initialize_kv_host()
 
-        # Add our ubuntu user to the hadoop and mapred groups.
+        # We need to create the 'spark' user/group since we may not be
+        # installing spark on this machine. This is needed so the history
+        # server can access spark job history files in hdfs. Also add our
+        # ubuntu user to the hadoop, mapred, and spark groups on this machine.
         get_layer_opts().add_users()
 
         set_state('apache-bigtop-resourcemanager.installed')


### PR DESCRIPTION
When NN/RM are not colocated with spark, they do not know about the spark user/group.  When in `yarn-client` mode, the spark charm will create hdfs dirs with `spark` ACLs.  This leads to warnings like this on the namenode:

`WARN org.apache.hadoop.security.UserGroupInformation: No groups available for user spark`

Always create the spark user/group on NN and RM.  This also works if spark/NN/RM are all colocated.

Note that `hadoop` should be a secondary group (not primary) for extra users created by these charms, so this PR ensures that as well.