### PR TITLE
Update kafka to 0.10.1.1

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -385,7 +385,7 @@ bigtop {
     'kafka' {
       name    = 'kafka'
       relNotes = 'Apache Kafka'
-      version { base = '0.10.1.0'; pkg = base; release = 1 }
+      version { base = '0.10.1.1'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
update to kafka 0.10.1.1
[https://archive.apache.org/dist/kafka/0.10.1.1/RELEASE_NOTES.html.](https://archive.apache.org/dist/kafka/0.10.1.1/RELEASE_NOTES.html.)
