### PR TITLE
[BIGTOP-2690] gradlew toolchain fails trying to download Ant 1.9.8

### DIFF
--- a/bigtop_toolchain/manifests/ant.pp
+++ b/bigtop_toolchain/manifests/ant.pp
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 class bigtop_toolchain::ant {
-  $ant =  'apache-ant-1.9.8'
+  $ant =  'apache-ant-1.9.9'
 
   $apache_prefix = nearest_apache_mirror()
 


### PR DESCRIPTION
Since Ant 1.9.9 is out, 1.9.8 is removed from some (all?) apache mirror, and gradlew toolchain fails