### PR TITLE
BIGTOP-2737: Spark charm doesn't handle HA or examples well

### DIFF
--- a/bigtop-packages/src/charm/spark/layer-spark/actions.yaml
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions.yaml
@@ -1,5 +1,12 @@
+pagerank:
+    description: Calculate PageRank for a sample data set
+    params:
+        iterations:
+            description: Number of iterations for the SparkPageRank job
+            type: string
+            default: "1"
 smoke-test:
-    description: Verify that Spark is working by calculating pi.
+    description: Verify that Spark is working by calculating pi
 sparkpi:
     description: Calculate Pi
     params:
@@ -19,8 +26,6 @@ logisticregression:
     description: Run the Spark Bench LogisticRegression benchmark.
 matrixfactorization:
     description: Run the Spark Bench MatrixFactorization benchmark.
-pagerank:
-    description: Run the Spark Bench PageRank benchmark.
 pca:
     description: Run the Spark Bench PCA benchmark.
 pregeloperation:

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
@@ -1,1 +1,0 @@
-sparkbench

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
@@ -61,19 +61,20 @@ def main():
     # act as the spark workers and will not have access to this local data.
     # In yarn mode, copy our input data to hdfs so nodemanagers can access it.
     mode = hookenv.config()['spark_execution_mode']
-    if mode.startswith('yarn') and is_state('hadoop.hdfs.ready'):
-        try:
-            utils.run_as('ubuntu',
-                         'hdfs', 'dfs', '-put', '-f', sample, '/user/ubuntu',
-                         capture_output=True)
-        except subprocess.CalledProcessError as e:
-            msg = 'Unable to copy pagerank sample data to hdfs'
-            fail('{}: {}'.format(msg, e), 'error')
+    if mode.startswith('yarn'):
+        if is_state('hadoop.hdfs.ready'):
+            try:
+                utils.run_as('ubuntu',
+                             'hdfs', 'dfs', '-put', '-f', sample, '/user/ubuntu',
+                             capture_output=True)
+            except subprocess.CalledProcessError as e:
+                msg = 'Unable to copy pagerank sample data to hdfs'
+                fail('{}: {}'.format(msg, e), 'error')
+            else:
+                sample = "/user/ubuntu/web-Google.txt"
         else:
-            sample = "/user/ubuntu/web-Google.txt"
-    else:
-        msg = 'Spark is configured for yarn mode, but HDFS is not ready yet'
-        fail(msg, 'error')
+            msg = 'Spark is configured for yarn mode, but HDFS is not ready yet'
+            fail(msg, 'error')
 
     # find jar location
     spark_home = "/usr/lib/spark"

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
@@ -15,18 +15,20 @@
 # limitations under the License.
 
 import os
+import subprocess
 import sys
 
 from path import Path
 from time import time
-import subprocess
 
 from charmhelpers.contrib.benchmark import Benchmark
 from charmhelpers.core import hookenv
 from charms.reactive import is_state
+from jujubigdata import utils
 
 
 def fail(msg, output):
+    print(msg)
     hookenv.action_set({'output': output})
     hookenv.action_fail(msg)
     sys.exit(1)
@@ -36,27 +38,44 @@ def main():
     bench = Benchmark()
 
     if not is_state('spark.started'):
-        fail('Spark not yet ready', 'error')
+        msg = 'Spark is not started yet'
+        fail(msg, 'error')
 
+    # gather params and create dir to store results
     num_iter = hookenv.action_get('iterations')
-
-    # create dir to store results
     run = int(time())
     result_dir = Path('/opt/sparkpagerank-results')
     result_log = result_dir / '{}.log'.format(run)
     if not result_dir.exists():
         result_dir.mkdir()
     result_dir.chown('ubuntu', 'ubuntu')
-
-    bench.start()
-    start = int(time())
-
     hookenv.log("values: {} {}".format(num_iter, result_log))
 
-    print('calculating pagerank')
-
-    # set sample jar and data location
     sample = "/home/ubuntu/SparkBench/PageRank/web-Google.txt"
+    if not os.path.isfile(sample):
+        msg = 'Could not find pagerank sample data'
+        fail('{}: {}'.format(msg, sample), 'error')
+
+    # Benchmark input data is packed into our sparkbench.tgz, which makes
+    # it available on all spark units. In yarn mode, however, the nodemanagers
+    # act as the spark workers and will not have access to this local data.
+    # In yarn mode, copy our input data to hdfs so nodemanagers can access it.
+    mode = hookenv.config()['spark_execution_mode']
+    if mode.startswith('yarn') and is_state('hadoop.hdfs.ready'):
+        try:
+            utils.run_as('ubuntu',
+                         'hdfs', 'dfs', '-put', '-f', sample, '/user/ubuntu',
+                         capture_output=True)
+        except subprocess.CalledProcessError as e:
+            msg = 'Unable to copy pagerank sample data to hdfs'
+            fail('{}: {}'.format(msg, e), 'error')
+        else:
+            sample = "/user/ubuntu/web-Google.txt"
+    else:
+        msg = 'Spark is configured for yarn mode, but HDFS is not ready yet'
+        fail(msg, 'error')
+
+    # find jar location
     spark_home = "/usr/lib/spark"
     example_jar_name = "spark-examples.jar"
     example_jar_path = None
@@ -65,7 +84,12 @@ def main():
             example_jar_path = os.path.join(root, example_jar_name)
 
     if not example_jar_path:
-        fail('could not find {}'.format(example_jar_name), 'error')
+        msg = 'Could not find {}'.format(example_jar_name)
+        fail(msg, 'error')
+
+    print('Calculating PageRank')
+    bench.start()
+    start = int(time())
 
     with open(result_log, 'w') as log_file:
         arg_list = [
@@ -81,9 +105,8 @@ def main():
             subprocess.check_call(arg_list, stdout=log_file,
                                   stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print('SparkPageRank command failed: ')
-            print('{}'.format(' '.join(arg_list)))
-            fail('spark-submit failed: {}'.format(e), 'error')
+            msg = 'SparkPageRank command failed: {}'.format(' '.join(arg_list))
+            fail('{}: {}'.format(msg, e), 'error')
 
     stop = int(time())
     bench.finish()
@@ -100,7 +123,8 @@ def main():
                 break
 
     if not success:
-        fail('spark-submit failed to calculate pagerank', 'error')
+        msg = 'Spark-submit failed to calculate pagerank'
+        fail(msg, 'error')
 
     hookenv.action_set({'output': {'status': 'completed'}})
 

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+from path import Path
+from time import time
+import subprocess
+
+from charmhelpers.contrib.benchmark import Benchmark
+from charmhelpers.core import hookenv
+from charms.reactive import is_state
+
+
+def fail(msg, output):
+    hookenv.action_set({'output': output})
+    hookenv.action_fail(msg)
+    sys.exit(1)
+
+
+def main():
+    bench = Benchmark()
+
+    if not is_state('spark.started'):
+        fail('Spark not yet ready', 'error')
+
+    num_iter = hookenv.action_get('iterations')
+
+    # create dir to store results
+    run = int(time())
+    result_dir = Path('/opt/sparkpagerank-results')
+    result_log = result_dir / '{}.log'.format(run)
+    if not result_dir.exists():
+        result_dir.mkdir()
+    result_dir.chown('ubuntu', 'ubuntu')
+
+    bench.start()
+    start = int(time())
+
+    hookenv.log("values: {} {}".format(num_iter, result_log))
+
+    print('calculating pagerank')
+
+    # set sample jar and data location
+    sample = "/home/ubuntu/SparkBench/PageRank/web-Google.txt"
+    spark_home = "/usr/lib/spark"
+    example_jar_name = "spark-examples.jar"
+    example_jar_path = None
+    for root, dirs, files in os.walk(spark_home):
+        if example_jar_name in files:
+            example_jar_path = os.path.join(root, example_jar_name)
+
+    if not example_jar_path:
+        fail('could not find {}'.format(example_jar_name), 'error')
+
+    with open(result_log, 'w') as log_file:
+        arg_list = [
+            'spark-submit',
+            '--class',
+            'org.apache.spark.examples.SparkPageRank',
+            example_jar_path,
+            sample,
+            num_iter,
+        ]
+
+        try:
+            subprocess.check_call(arg_list, stdout=log_file,
+                                  stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            print('SparkPageRank command failed: ')
+            print('{}'.format(' '.join(arg_list)))
+            fail('spark-submit failed: {}'.format(e), 'error')
+
+    stop = int(time())
+    bench.finish()
+
+    duration = stop - start
+    bench.set_composite_score(duration, 'secs')
+    subprocess.check_call(['benchmark-raw', result_log])
+
+    with open(result_log) as log:
+        success = False
+        for line in log.readlines():
+            if 'rank' in line:
+                success = True
+                break
+
+    if not success:
+        fail('spark-submit failed to calculate pagerank', 'error')
+
+    hookenv.action_set({'output': {'status': 'completed'}})
+
+
+if __name__ == '__main__':
+    main()

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/sparkpi
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/sparkpi
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
-sys.path.append('lib')
 
 from path import Path
 from time import time
@@ -55,12 +55,23 @@ def main():
 
     print('calculating pi')
 
+    # get the examples jar
+    spark_home = "/usr/lib/spark"
+    example_jar_name = "spark-examples.jar"
+    example_jar_path = None
+    for root, dirs, files in os.walk(spark_home):
+        if example_jar_name in files:
+            example_jar_path = os.path.join(root, example_jar_name)
+
+    if not example_jar_path:
+        fail('could not find {}'.format(example_jar_name), 'error')
+
     with open(result_log, 'w') as log_file:
         arg_list = [
             'spark-submit',
             '--class',
             'org.apache.spark.examples.SparkPi',
-            '/usr/lib/spark/lib/spark-examples.jar'
+            example_jar_path
         ]
         if num_partitions:
             # This is always blank. TODO: figure out what it was

--- a/bigtop-packages/src/charm/spark/layer-spark/config.yaml
+++ b/bigtop-packages/src/charm/spark/layer-spark/config.yaml
@@ -10,7 +10,7 @@ options:
             preserved.
     spark_bench_ppc64le:
         type: string
-        default: 'https://s3.amazonaws.com/jujubigdata/ibm/noarch/SparkBench-2.0-20161101.tgz#sha256=2a34150dc3ad4a1469ca09c202f4db4ee995e2932b8a633d8c006d46c1f61e9f'
+        default: 'https://s3.amazonaws.com/jujubigdata/ibm/noarch/SparkBench-2.0-20170403.tgz#sha256=709caec6667dd82e42de25eb8bcd5763ca894e99e5c83c97bdfcf62cb1aa00c8'
         description: |
             URL (including hash) of a ppc64le tarball of SparkBench. By
             default, this points to a pre-built SparkBench binary based on
@@ -18,7 +18,7 @@ options:
             'spark_bench_enabled' is 'true'.
     spark_bench_x86_64:
         type: string
-        default: 'https://s3.amazonaws.com/jujubigdata/ibm/noarch/SparkBench-2.0-20161101.tgz#sha256=2a34150dc3ad4a1469ca09c202f4db4ee995e2932b8a633d8c006d46c1f61e9f'
+        default: 'https://s3.amazonaws.com/jujubigdata/ibm/noarch/SparkBench-2.0-20170403.tgz#sha256=709caec6667dd82e42de25eb8bcd5763ca894e99e5c83c97bdfcf62cb1aa00c8'
         description: |
             URL (including hash) of an x86_64 tarball of SparkBench. By
             default, this points to a pre-built SparkBench binary based on

--- a/bigtop-packages/src/charm/spark/layer-spark/config.yaml
+++ b/bigtop-packages/src/charm/spark/layer-spark/config.yaml
@@ -1,10 +1,4 @@
 options:
-    resources_mirror:
-        type: string
-        default: ''
-        description: |
-            URL used to fetch resources (e.g., Hadoop binaries) instead of the
-            location specified in resources.yaml.
     spark_bench_enabled:
         type: boolean
         default: true

--- a/bigtop-packages/src/charm/spark/layer-spark/config.yaml
+++ b/bigtop-packages/src/charm/spark/layer-spark/config.yaml
@@ -1,4 +1,18 @@
 options:
+    driver_memory:
+        type: string
+        default: '1g'
+        description: |
+            Specify gigabytes (e.g. 1g) or megabytes (e.g. 1024m). If running
+            in 'local' or 'standalone' mode, you may also specify a percentage
+            of total system memory (e.g. 50%).
+    executor_memory:
+        type: string
+        default: '1g'
+        description: |
+            Specify gigabytes (e.g. 1g) or megabytes (e.g. 1024m). If running
+            in 'local' or 'standalone' mode, you may also specify a percentage
+            of total system memory (e.g. 50%).
     spark_bench_enabled:
         type: boolean
         default: true

--- a/bigtop-packages/src/charm/spark/layer-spark/lib/charms/layer/bigtop_spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/lib/charms/layer/bigtop_spark.py
@@ -326,12 +326,12 @@ class Spark(object):
         host.service_start('spark-history-server')
         if hookenv.config()['spark_execution_mode'] == 'standalone':
             if host.service_start('spark-master'):
-                # If the master started, wait 60s for recovery before starting
+                # If the master started, wait 2m for recovery before starting
                 # the worker.
                 hookenv.status_set('maintenance',
                                    'waiting for spark master recovery')
-                hookenv.log("Waiting 1m to ensure spark master is ALIVE")
-                time.sleep(60)
+                hookenv.log("Waiting 2m to ensure spark master is ALIVE")
+                time.sleep(120)
                 host.service_start('spark-worker')
             else:
                 hookenv.log("Master did not start; not starting worker")

--- a/bigtop-packages/src/charm/spark/layer-spark/lib/charms/layer/bigtop_spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/lib/charms/layer/bigtop_spark.py
@@ -332,9 +332,9 @@ class Spark(object):
                                    'waiting for spark master recovery')
                 hookenv.log("Waiting 2m to ensure spark master is ALIVE")
                 time.sleep(120)
-                host.service_start('spark-worker')
             else:
-                hookenv.log("Master did not start; not starting worker")
+                hookenv.log("Master did not start")
+            host.service_start('spark-worker')
 
     def stop(self):
         host.service_stop('spark-history-server')

--- a/bigtop-packages/src/charm/spark/layer-spark/lib/charms/layer/bigtop_spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/lib/charms/layer/bigtop_spark.py
@@ -220,7 +220,7 @@ class Spark(object):
             zk_connect = ",".join(zks)
             override['spark::common::zookeeper_connection_string'] = zk_connect
         else:
-            override['spark::common::zookeeper_connection_string'] = ""
+            override['spark::common::zookeeper_connection_string'] = None
 
         bigtop = Bigtop()
         bigtop.render_site_yaml(hosts, roles, override)

--- a/bigtop-packages/src/charm/spark/layer-spark/lib/charms/layer/bigtop_spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/lib/charms/layer/bigtop_spark.py
@@ -268,8 +268,8 @@ class Spark(object):
 
         spark_env = '/etc/spark/conf/spark-env.sh'
         utils.re_edit_in_place(spark_env, {
-            r'.*SPARK_DRIVER_MEMORY.*': 'SPARK_DRIVER_MEMORY={}'.format(driver_mem),
-            r'.*SPARK_EXECUTOR_MEMORY.*': 'SPARK_EXECUTOR_MEMORY={}'.format(executor_mem),
+            r'.*SPARK_DRIVER_MEMORY.*': 'export SPARK_DRIVER_MEMORY={}'.format(driver_mem),
+            r'.*SPARK_EXECUTOR_MEMORY.*': 'export SPARK_EXECUTOR_MEMORY={}'.format(executor_mem),
         }, append_non_matches=True)
 
         # Install SB (subsequent calls will reconfigure existing install)

--- a/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
@@ -158,12 +158,14 @@ def reinstall_spark():
     }
 
     # If neither config nor our matrix is changing, there is nothing to do.
-    if (not is_state('config.changed') and
+    if (not is_state('config.changed') or
             not data_changed('deployment_matrix', deployment_matrix)):
         return
 
     # (Re)install based on our execution mode
     hookenv.status_set('maintenance', 'configuring spark in {} mode'.format(mode))
+    hookenv.log("Configuring spark with deployment matrix: {}".format(deployment_matrix))
+
     if mode.startswith('yarn') and is_state('hadoop.yarn.ready'):
         install_spark_yarn()
     elif mode.startswith('local') or mode == 'standalone':

--- a/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
@@ -158,8 +158,8 @@ def reinstall_spark():
     }
 
     # If neither config nor our matrix is changing, there is nothing to do.
-    if (not is_state('config.changed') or
-            not data_changed('deployment_matrix', deployment_matrix)):
+    if not (is_state('config.changed') or
+            data_changed('deployment_matrix', deployment_matrix)):
         return
 
     # (Re)install based on our execution mode

--- a/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
@@ -69,10 +69,11 @@ def install_spark(hadoop=None, zks=None):
         hosts['namenode'] = nns[0]
 
     spark = Spark()
-    if (zks and data_changed('zks', zks)):
-        # If zks have changed, give the ensemble time to settle, or else we
-        # might try to start spark master with data from the wrong zk leader.
-        # Doing so will cause spark-master to shutdown:
+    if (data_changed('zks', zks) and not is_state('sparkpeers.departed')):
+        # If zks have changed and we are not handling a departed spark peer,
+        # give the ensemble time to settle. Otherwise we might try to start
+        # spark master with data from the wrong zk leader. Doing so will cause
+        # spark-master to shutdown:
         #  https://issues.apache.org/jira/browse/SPARK-15544
         hookenv.status_set('maintenance',
                            'waiting for zookeeper ensemble to settle')

--- a/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
@@ -87,9 +87,9 @@ def install_spark(hadoop=None, zks=None):
 
 def set_deployment_mode_state(state):
     if is_state('spark.yarn.installed'):
-        remove_state('spark.yarn.installed')
-    if is_state('spark.standalone.installed'):
         remove_state('spark.standalone.installed')
+    if is_state('spark.standalone.installed'):
+        remove_state('spark.yarn.installed')
     set_state('spark.started')
     set_state(state)
     # set app version string for juju status output
@@ -167,7 +167,7 @@ def reconfigure_spark():
 def send_fqdn():
     spark_master_host = get_fqdn()
     leadership.leader_set({'master-fqdn': spark_master_host})
-    hookenv.log("Setting leader to {}".format(spark_master_host))
+    hookenv.log("Setting juju leader to {}".format(spark_master_host))
 
 
 @when('leadership.changed.master-fqdn')

--- a/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
+++ b/bigtop-packages/src/charm/spark/layer-spark/reactive/spark.py
@@ -74,8 +74,10 @@ def install_spark(hadoop, zks, peers):
     spark = Spark()
     hookenv.status_set('maintenance', 'configuring spark in mode: {}'.format(mode))
     spark.configure(hosts, zks, peers)
-    # BUG: if a zk, spark master will go into recovery; workers will need to
-    # be restarted after the master becomes alive again.
+
+    # restart services to pick up possible config changes
+    spark.stop()
+    spark.start()
 
 
 def set_deployment_mode_state(state):


### PR DESCRIPTION
See [jira](https://issues.apache.org/jira/browse/BIGTOP-2737) for details, but in general, the spark charm didn't transition well among execution modes (services are started when they don't need to be, stale zk connection info persists, etc).  Fix this by waiting for required services to become ready and only starting spark services as needed by our execution mode.

Also, with the release of bigtop-1.2, we get spark-2.1.  Hooray!  However, the `spark-examples.jar` has moved, so we need to be smarter about finding that programmatically in our actions (`sparkpi`, `pagerank`, etc).

On the subject of benchmarks, the SparkBench suite that we've been making available to our spark charm doesn't work with spark-2.1, so we'll need to deprecate it or possibly find a version that works.  For now, just make sure we can run a consistent set of benchmarks across spark-1.5 and spark-2.1 -- that means `sparkpi` and `pagerank`.

And finally, the spark charm reactive logic was difficult to follow.  Use this opportunity to refactor it to ease future maintenance.