### PR TITLE
BIGTOP-2739: refresh juju bundles with latest charm revs

### DIFF
--- a/bigtop-deploy/juju/hadoop-hbase/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle-dev.yaml
@@ -115,17 +115,25 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"

--- a/bigtop-deploy/juju/hadoop-hbase/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle-dev.yaml
@@ -65,7 +65,7 @@ services:
       - "6"
       - "7"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -73,7 +73,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-hbase/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle-local.yaml
@@ -115,17 +115,25 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"

--- a/bigtop-deploy/juju/hadoop-hbase/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle-local.yaml
@@ -65,7 +65,7 @@ services:
       - "6"
       - "7"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -73,7 +73,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
@@ -115,17 +115,25 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"

--- a/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
@@ -65,7 +65,7 @@ services:
       - "6"
       - "7"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -73,7 +73,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-12"
+    charm: "cs:xenial/hadoop-namenode-13"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -9,7 +9,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-13"
+    charm: "cs:xenial/hadoop-resourcemanager-14"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -18,7 +18,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-12"
+    charm: "cs:xenial/hadoop-slave-13"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -29,7 +29,7 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-12"
+    charm: "cs:xenial/hadoop-plugin-13"
     annotations:
       gui-x: "1000"
       gui-y: "400"
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   hbase:
-    charm: "cs:xenial/hbase-10"
+    charm: "cs:xenial/hbase-11"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -54,7 +54,7 @@ services:
       - "2"
       - "3"
   zookeeper:
-    charm: "cs:xenial/zookeeper-16"
+    charm: "cs:xenial/zookeeper-17"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:

--- a/bigtop-deploy/juju/hadoop-hbase/tests/01-bundle.py
+++ b/bigtop-deploy/juju/hadoop-hbase/tests/01-bundle.py
@@ -27,8 +27,6 @@ class TestBundle(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # classmethod inheritance doesn't work quite right with
-        # setUpClass / tearDownClass, so subclasses have to manually call this
         cls.d = amulet.Deployment(series='xenial')
         with open(cls.bundle_file) as f:
             bun = f.read()

--- a/bigtop-deploy/juju/hadoop-hbase/tests/tests.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/tests/tests.yaml
@@ -1,5 +1,5 @@
 reset: false
-bundle_deploy: false
+deployment_timeout: 3600
 sources:
   - 'ppa:juju/stable'
 packages:

--- a/bigtop-deploy/juju/hadoop-kafka/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle-dev.yaml
@@ -81,7 +81,7 @@ services:
     to:
       - "8"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -89,7 +89,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-kafka/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle-dev.yaml
@@ -133,19 +133,28 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "8":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/hadoop-kafka/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle-local.yaml
@@ -81,7 +81,7 @@ services:
     to:
       - "8"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -89,7 +89,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-kafka/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle-local.yaml
@@ -133,19 +133,28 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "8":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-12"
+    charm: "cs:xenial/hadoop-namenode-13"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -9,7 +9,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-13"
+    charm: "cs:xenial/hadoop-resourcemanager-14"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -18,7 +18,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-12"
+    charm: "cs:xenial/hadoop-slave-13"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -29,7 +29,7 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-12"
+    charm: "cs:xenial/hadoop-plugin-13"
     annotations:
       gui-x: "1000"
       gui-y: "400"
@@ -52,7 +52,7 @@ services:
     to:
       - "4"
   zookeeper:
-    charm: "cs:xenial/zookeeper-16"
+    charm: "cs:xenial/zookeeper-17"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:
@@ -63,7 +63,7 @@ services:
       - "6"
       - "7"
   kafka:
-    charm: "cs:xenial/kafka-11"
+    charm: "cs:xenial/kafka-12"
     constraints: "mem=3G"
     num_units: 1
     annotations:

--- a/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
@@ -81,7 +81,7 @@ services:
     to:
       - "8"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -89,7 +89,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
@@ -133,19 +133,28 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "8":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/hadoop-kafka/tests/01-bundle.py
+++ b/bigtop-deploy/juju/hadoop-kafka/tests/01-bundle.py
@@ -27,8 +27,6 @@ class TestBundle(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # classmethod inheritance doesn't work quite right with
-        # setUpClass / tearDownClass, so subclasses have to manually call this
         cls.d = amulet.Deployment(series='xenial')
         with open(cls.bundle_file) as f:
             bun = f.read()

--- a/bigtop-deploy/juju/hadoop-kafka/tests/tests.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/tests/tests.yaml
@@ -1,5 +1,5 @@
 reset: false
-bundle_deploy: false
+deployment_timeout: 3600
 sources:
   - 'ppa:juju/stable'
 packages:

--- a/bigtop-deploy/juju/hadoop-processing/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle-dev.yaml
@@ -87,11 +87,16 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/hadoop-processing/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle-dev.yaml
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -51,7 +51,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-processing/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle-local.yaml
@@ -87,11 +87,16 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/hadoop-processing/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle-local.yaml
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -51,7 +51,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -87,11 +87,16 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-12"
+    charm: "cs:xenial/hadoop-namenode-13"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -9,7 +9,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-13"
+    charm: "cs:xenial/hadoop-resourcemanager-14"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -18,7 +18,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-12"
+    charm: "cs:xenial/hadoop-slave-13"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -29,7 +29,7 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-12"
+    charm: "cs:xenial/hadoop-plugin-13"
     annotations:
       gui-x: "1000"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -51,7 +51,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-processing/tests/01-bundle.py
+++ b/bigtop-deploy/juju/hadoop-processing/tests/01-bundle.py
@@ -27,8 +27,6 @@ class TestBundle(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # classmethod inheritance doesn't work quite right with
-        # setUpClass / tearDownClass, so subclasses have to manually call this
         cls.d = amulet.Deployment(series='xenial')
         with open(cls.bundle_file) as f:
             bun = f.read()

--- a/bigtop-deploy/juju/hadoop-processing/tests/tests.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/tests/tests.yaml
@@ -1,5 +1,5 @@
 reset: false
-bundle_deploy: false
+deployment_timeout: 3600
 sources:
   - 'ppa:juju/stable'
 packages:

--- a/bigtop-deploy/juju/hadoop-spark/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle-dev.yaml
@@ -65,7 +65,7 @@ services:
       - "7"
       - "8"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -73,7 +73,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-spark/bundle-dev.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle-dev.yaml
@@ -115,19 +115,28 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "8":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"

--- a/bigtop-deploy/juju/hadoop-spark/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle-local.yaml
@@ -65,7 +65,7 @@ services:
       - "7"
       - "8"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -73,7 +73,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-spark/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle-local.yaml
@@ -115,19 +115,28 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "8":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   spark:
-    charm: "cs:xenial/spark-25"
+    charm: "cs:xenial/spark-27"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     options:

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   spark:
-    charm: "cs:xenial/spark-28"
+    charm: "cs:xenial/spark-29"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     options:

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -65,7 +65,7 @@ services:
       - "7"
       - "8"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -73,7 +73,7 @@ services:
     to:
       - "4"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   spark:
-    charm: "cs:xenial/spark-29"
+    charm: "cs:xenial/spark-30"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     options:

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -115,19 +115,28 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G"
   "5":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "6":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "7":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "8":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-12"
+    charm: "cs:xenial/hadoop-namenode-13"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -9,7 +9,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-13"
+    charm: "cs:xenial/hadoop-resourcemanager-14"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -18,7 +18,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-12"
+    charm: "cs:xenial/hadoop-slave-13"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -29,7 +29,7 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-12"
+    charm: "cs:xenial/hadoop-plugin-13"
     annotations:
       gui-x: "1000"
       gui-y: "400"
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   spark:
-    charm: "cs:xenial/spark-30"
+    charm: "cs:xenial/spark-31"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     options:
@@ -54,7 +54,7 @@ services:
     to:
       - "5"
   zookeeper:
-    charm: "cs:xenial/zookeeper-16"
+    charm: "cs:xenial/zookeeper-17"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   spark:
-    charm: "cs:xenial/spark-24"
+    charm: "cs:xenial/spark-25"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     options:

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -43,7 +43,7 @@ services:
     to:
       - "4"
   spark:
-    charm: "cs:xenial/spark-27"
+    charm: "cs:xenial/spark-28"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     options:

--- a/bigtop-deploy/juju/hadoop-spark/tests/01-bundle.py
+++ b/bigtop-deploy/juju/hadoop-spark/tests/01-bundle.py
@@ -86,7 +86,9 @@ class TestBundle(unittest.TestCase):
         assert 'DataNode' not in yarn, "DataNode should not be running on resourcemanager"
         assert 'DataNode' not in hdfs, "DataNode should not be running on namenode"
 
-        assert 'Master' in spark, "Spark Master not started"
+        assert 'HistoryServer' in spark, "Spark HistoryServer not started"
+        assert 'Master' not in spark, "Spark Master should not be running in yarn mode"
+        assert 'Worker' not in spark, "Spark Worker should not be running in yarn mode"
 
     def test_hdfs(self):
         """

--- a/bigtop-deploy/juju/hadoop-spark/tests/01-bundle.py
+++ b/bigtop-deploy/juju/hadoop-spark/tests/01-bundle.py
@@ -27,8 +27,6 @@ class TestBundle(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # classmethod inheritance doesn't work quite right with
-        # setUpClass / tearDownClass, so subclasses have to manually call this
         cls.d = amulet.Deployment(series='xenial')
         with open(cls.bundle_file) as f:
             bun = f.read()

--- a/bigtop-deploy/juju/hadoop-spark/tests/tests.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/tests/tests.yaml
@@ -1,5 +1,5 @@
 reset: false
-bundle_deploy: false
+deployment_timeout: 3600
 sources:
   - 'ppa:juju/stable'
 packages:

--- a/bigtop-deploy/juju/spark-processing/bundle-dev.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle-dev.yaml
@@ -58,13 +58,19 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "5":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/spark-processing/bundle-dev.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle-dev.yaml
@@ -21,7 +21,7 @@ services:
       - "3"
       - "4"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -29,7 +29,7 @@ services:
     to:
       - "5"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/spark-processing/bundle-local.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle-local.yaml
@@ -58,13 +58,19 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "5":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/spark-processing/bundle-local.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle-local.yaml
@@ -21,7 +21,7 @@ services:
       - "3"
       - "4"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -29,7 +29,7 @@ services:
     to:
       - "5"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -1,8 +1,11 @@
 services:
   spark:
-    charm: "cs:xenial/spark-28"
+    charm: "cs:xenial/spark-29"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
+    options:
+      driver_memory: "3g"
+      executor_memory: "3g"
     annotations:
       gui-x: "500"
       gui-y: "0"

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   spark:
-    charm: "cs:xenial/spark-30"
+    charm: "cs:xenial/spark-31"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
     options:
@@ -13,7 +13,7 @@ services:
       - "0"
       - "1"
   zookeeper:
-    charm: "cs:xenial/zookeeper-16"
+    charm: "cs:xenial/zookeeper-17"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   spark:
-    charm: "cs:xenial/spark-26"
+    charm: "cs:xenial/spark-27"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
     annotations:

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -58,13 +58,19 @@ relations:
 machines:
   "0":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "1":
     series: "xenial"
+    constraints: "mem=7G root-disk=32G"
   "2":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "3":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "4":
     series: "xenial"
+    constraints: "mem=3G root-disk=32G"
   "5":
     series: "xenial"
+    constraints: "mem=3G"

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   spark:
-    charm: "cs:xenial/spark-27"
+    charm: "cs:xenial/spark-28"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
     annotations:

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -21,7 +21,7 @@ services:
       - "3"
       - "4"
   ganglia:
-    charm: "cs:~bigdata-dev/xenial/ganglia-5"
+    charm: "cs:xenial/ganglia-12"
     num_units: 1
     annotations:
       gui-x: "0"
@@ -29,7 +29,7 @@ services:
     to:
       - "5"
   ganglia-node:
-    charm: "cs:~bigdata-dev/xenial/ganglia-node-7"
+    charm: "cs:xenial/ganglia-node-7"
     annotations:
       gui-x: "250"
       gui-y: "400"

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   spark:
-    charm: "cs:xenial/spark-29"
+    charm: "cs:xenial/spark-30"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
     options:

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   spark:
-    charm: "cs:xenial/spark-24"
+    charm: "cs:xenial/spark-25"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
     annotations:

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   spark:
-    charm: "cs:xenial/spark-25"
+    charm: "cs:xenial/spark-26"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
     annotations:

--- a/bigtop-deploy/juju/spark-processing/tests/tests.yaml
+++ b/bigtop-deploy/juju/spark-processing/tests/tests.yaml
@@ -1,5 +1,5 @@
 reset: false
-bundle_deploy: false
+deployment_timeout: 3600
 sources:
   - 'ppa:juju/stable'
 packages:


### PR DESCRIPTION
See [jira](https://issues.apache.org/jira/browse/BIGTOP-2739) for details.  Notables:

- add machine constraints back to workaround [juju bug](https://bugs.launchpad.net/juju/+bug/1676986)
- use new ganglia charm revs
- use latest ~bigdata-charmers charm revs
- take advantage of spark memory options for spark-processing bundle