### PR TITLE
BIGTOP-2740: hbase 1.1.3 does not work on ppc64le

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Example for HBase:
 
 ```
       name    = 'hbase'
-      version { base = '1.1.3'; pkg = base; release = 1 }
+      version { base = '1.1.9'; pkg = base; release = 1 }
       git     { repo = "https://github.com/apache/hbase.git"
                 ref  = "${version.base}"
                 dir  = "${name}-${version.base}" }

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -151,7 +151,7 @@ bigtop {
     'hbase' {
       name    = 'hbase'
       relNotes = 'Apache HBase'
-      version { base = '1.1.3'; pkg = base; release = 1 }
+      version { base = '1.1.9'; pkg = base; release = 1 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/${version.base}/"

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,7 @@
 
   <properties>
     <hadoop.version>2.7.3</hadoop.version>
-    <!--An awful hack for BIGTOP-1429-->
-    <hbase.version>1.1.3</hbase.version>
+    <hbase.version>1.1.9</hbase.version>
     <pig.version>0.15.0</pig.version>
     <pig-smoke.version>0.15.0</pig-smoke.version>
     <sqoop.version>1.4.6</sqoop.version>


### PR DESCRIPTION
HBase 1.1.x was broken on non-Intel arches until v1.1.4 ([HBASE-15322](https://issues.apache.org/jira/browse/HBASE-15322)).

Pick up this fix by bumping to v1.1.9, the latest stable release from the 1.1 branch.  This is a super simple bump as I did not see any config or other changes needed from the upstream 1.1 branch.