### PR TITLE
BIGTOP-2355: Update Mahout version to 0.13.0

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -223,7 +223,7 @@ bigtop {
     'mahout' {
       name    = 'mahout'
       relNotes = 'Apache Mahout'
-      version { base = '0.12.2'; pkg = base; release = 1 }
+      version { base = '0.13.0'; pkg = base; release = 1 }
       tarball { destination = "apache-$name-distribution-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
Tested with deb, rpm, pkg, and tar; expected files are all created but was unable to test deb install due to a hadoop-client versioning issue detailed on the dev list.