### PR TITLE
BIGTOP-2764: deployment failure when roles include spark::common and spark::yarn*

### DIFF
--- a/bigtop-deploy/puppet/modules/spark/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/spark/manifests/init.pp
@@ -148,14 +148,13 @@ class spark {
       $history_log_dir = "hdfs:///var/log/spark/apps",
   ) {
 
-    package { 'spark-core':
-      ensure => latest,
-    }
 ### This is an ungodly hack to deal with the consequence of adding
 ### unconditional hive-support into Spark
 ### The addition is tracked by BIGTOP-2154
 ### The real fix will come in BIGTOP-2268
-    package { 'spark-datanucleus':
+    include spark::datanucleus
+
+    package { 'spark-core':
       ensure => latest,
     }
 


### PR DESCRIPTION
We need to ensure the `spark-datanucleus` package is only defined once.  There's a hack in place so it is always defined in `spark::common` (see BIGTOP-2268):

https://github.com/apache/bigtop/blob/master/bigtop-deploy/puppet/modules/spark/manifests/init.pp#L154

This PR comments out the other definition, which should be reinstated if/when 2268 is fixed.