### PR TITLE
BIGTOP-2776: corrects patch for Bump Apache Apex version to 3.6.0

### DIFF
--- a/bigtop-packages/src/common/apex/patch1-for-hadoop27x.diff
+++ b/bigtop-packages/src/common/apex/patch1-for-hadoop27x.diff
@@ -1,7 +1,7 @@
-diff -Naur orig/engine/src/main/java/com/datatorrent/stram/client/StramAppLauncher.java new/engine/src/main/java/com/datatorrent/stram/client/StramAppLauncher.java
---- orig/engine/src/main/java/com/datatorrent/stram/client/StramAppLauncher.java	2016-11-22 02:49:11.000000000 +0530
-+++ new/engine/src/main/java/com/datatorrent/stram/client/StramAppLauncher.java	2017-03-23 23:08:32.692947303 +0530
-@@ -583,7 +583,7 @@
+diff -uraN apache-apex-core-3.6.0-orig/engine/src/main/java/com/datatorrent/stram/client/StramAppLauncher.java apache-apex-core-3.6.0/engine/src/main/java/com/datatorrent/stram/client/StramAppLauncher.java
+--- apache-apex-core-3.6.0-orig/engine/src/main/java/com/datatorrent/stram/client/StramAppLauncher.java	2017-04-28 20:55:41.000000000 +0200
++++ apache-apex-core-3.6.0/engine/src/main/java/com/datatorrent/stram/client/StramAppLauncher.java	2017-05-27 23:44:35.028907503 +0200
+@@ -584,7 +584,7 @@
      if (UserGroupInformation.isSecurityEnabled()) {
        long hdfsTokenMaxLifeTime = conf.getLong(StramClientUtils.DT_HDFS_TOKEN_MAX_LIFE_TIME, conf.getLong(StramClientUtils.HDFS_TOKEN_MAX_LIFE_TIME, StramClientUtils.DELEGATION_TOKEN_MAX_LIFETIME_DEFAULT));
        dag.setAttribute(LogicalPlan.HDFS_TOKEN_LIFE_TIME, hdfsTokenMaxLifeTime);
@@ -10,15 +10,15 @@ diff -Naur orig/engine/src/main/java/com/datatorrent/stram/client/StramAppLaunch
        dag.setAttribute(LogicalPlan.RM_TOKEN_LIFE_TIME, rmTokenMaxLifeTime);
        setTokenRefreshCredentials(dag, conf);
      }
-diff -Naur orig/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java new/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
---- orig/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java	2016-11-22 02:48:16.000000000 +0530
-+++ new/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java	2017-03-23 23:07:18.948865455 +0530
-@@ -156,7 +156,7 @@
+diff -uraN apache-apex-core-3.6.0-orig/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java apache-apex-core-3.6.0/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
+--- apache-apex-core-3.6.0-orig/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java	2017-04-28 20:55:41.000000000 +0200
++++ apache-apex-core-3.6.0/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java	2017-05-27 23:44:20.360926755 +0200
+@@ -162,7 +162,7 @@
     */
    public static Attribute<Boolean> FAST_PUBLISHER_SUBSCRIBER = new Attribute<>(false);
    public static Attribute<Long> HDFS_TOKEN_LIFE_TIME = new Attribute<>(604800000L);
 -  public static Attribute<Long> RM_TOKEN_LIFE_TIME = new Attribute<>(YarnConfiguration.DELEGATION_TOKEN_MAX_LIFETIME_DEFAULT);
 +  public static Attribute<Long> RM_TOKEN_LIFE_TIME = new Attribute<>(YarnConfiguration.RM_DELEGATION_TOKEN_MAX_LIFETIME_DEFAULT);
-   public static Attribute<String> PRINCIPAL = new Attribute<String>(null, new StringCodec.String2String());
-   public static Attribute<String> KEY_TAB_FILE = new Attribute<>((String)null, new StringCodec.String2String());
+   public static Attribute<String> PRINCIPAL = new Attribute<>(null, StringCodec.String2String.getInstance());
+   public static Attribute<String> KEY_TAB_FILE = new Attribute<>((String)null, StringCodec.String2String.getInstance());
    public static Attribute<Double> TOKEN_REFRESH_ANTICIPATORY_FACTOR = new Attribute<>(0.7);


### PR DESCRIPTION
This updates the apex patch up to the new version