### PR TITLE
BIGTOP-2801: charm race condition when gathering metrics

### DIFF
--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/layer.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/layer.yaml
@@ -22,7 +22,6 @@ options:
     ports:
       namenode:
         port: 8020
-        exposed_on: 'namenode'
       nn_webapp_http:
         port: 50070
         exposed_on: 'namenode'

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/metrics.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/metrics.yaml
@@ -2,12 +2,12 @@ metrics:
   namenodes:
     type: gauge
     description: number of namenodes in the cluster
-    command: charms.reactive is_state 'apache-bigtop-namenode.ready' && hdfs getconf -namenodes 2>/dev/null | wc -l
+    command: "charms.reactive is_state apache-bigtop-namenode.ready && hdfs getconf -namenodes 2>/dev/null | wc -l"
   offlinedatanodes:
     type: gauge
     description: number of dead datanodes in the cluster (must be run as hdfs)
-    command: charms.reactive is_state 'apache-bigtop-namenode.ready' && su hdfs -c 'hdfs dfsadmin -report -dead 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'
+    command: "charms.reactive is_state apache-bigtop-namenode.ready && su hdfs -c 'hdfs dfsadmin -report -dead 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'"
   onlinedatanodes:
     type: gauge
     description: number of live datanodes in the cluster (must be run as hdfs)
-    command: charms.reactive is_state 'apache-bigtop-namenode.ready' && su hdfs -c 'hdfs dfsadmin -report -live 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'
+    command: "charms.reactive is_state apache-bigtop-namenode.ready && su hdfs -c 'hdfs dfsadmin -report -live 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'"

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/metrics.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/metrics.yaml
@@ -2,12 +2,12 @@ metrics:
   namenodes:
     type: gauge
     description: number of namenodes in the cluster
-    command: hdfs getconf -namenodes 2>/dev/null | wc -l
+    command: charms.reactive is_state 'apache-bigtop-namenode.ready' && hdfs getconf -namenodes 2>/dev/null | wc -l
   offlinedatanodes:
     type: gauge
     description: number of dead datanodes in the cluster (must be run as hdfs)
-    command: su hdfs -c 'hdfs dfsadmin -report -dead 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'
+    command: charms.reactive is_state 'apache-bigtop-namenode.ready' && su hdfs -c 'hdfs dfsadmin -report -dead 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'
   onlinedatanodes:
     type: gauge
     description: number of live datanodes in the cluster (must be run as hdfs)
-    command: su hdfs -c 'hdfs dfsadmin -report -live 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'
+    command: charms.reactive is_state 'apache-bigtop-namenode.ready' && su hdfs -c 'hdfs dfsadmin -report -live 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/metrics.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/metrics.yaml
@@ -2,4 +2,4 @@ metrics:
   nodemanagers:
     type: gauge
     description: number of running node managers in the cluster
-    command: charms.reactive is_state 'apache-bigtop-resourcemanager.ready' && yarn node -list -all 2>/dev/null | grep RUNNING | wc -l
+    command: "charms.reactive is_state apache-bigtop-resourcemanager.ready && yarn node -list -all 2>/dev/null | grep RUNNING | wc -l"

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/metrics.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/metrics.yaml
@@ -2,4 +2,4 @@ metrics:
   nodemanagers:
     type: gauge
     description: number of running node managers in the cluster
-    command: yarn node -list -all 2>/dev/null | grep RUNNING | wc -l
+    command: charms.reactive is_state 'apache-bigtop-resourcemanager.ready' && yarn node -list -all 2>/dev/null | grep RUNNING | wc -l


### PR DESCRIPTION
- only run the metric collector if the charm is ready.
- drive by fix for the namenode; 8020 is used intra-cluster and doesn't need to be exposed.