### PR TITLE
BIGTOP-2821: expose extra config options for spark

### DIFF
--- a/bigtop-deploy/puppet/modules/spark/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/spark/manifests/init.pp
@@ -146,6 +146,9 @@ class spark {
       $use_yarn_shuffle_service = false,
       $event_log_dir =  "hdfs:///var/log/spark/apps",
       $history_log_dir = "hdfs:///var/log/spark/apps",
+      $extra_lib_dirs = "/usr/lib/hadoop/lib/native",
+      $driver_mem = "1g",
+      $executor_mem = "1g",
   ) {
 
 ### This is an ungodly hack to deal with the consequence of adding

--- a/bigtop-deploy/puppet/modules/spark/templates/spark-defaults.conf
+++ b/bigtop-deploy/puppet/modules/spark/templates/spark-defaults.conf
@@ -30,4 +30,9 @@ spark.yarn.historyServer.address <%= @master_host %>:<%= @history_ui_port %>
 <% end -%>
 spark.history.ui.port <%= @history_ui_port %>
 spark.shuffle.service.enabled <%= @use_yarn_shuffle_service %>
-spark.driver.extraJavaOptions -Djava.library.path=/usr/lib/hadoop/lib/native
+<% if @extra_lib_dirs -%>
+spark.driver.extraLibraryPath <%= @extra_lib_dirs %>
+spark.executor.extraLibraryPath <%= @extra_lib_dirs %>
+<% end -%>
+spark.driver.memory <%= @driver_mem %>
+spark.executor.memory <%= @executor_mem %>


### PR DESCRIPTION
Let users configure extra library paths and driver/executor memory by exposing these options in puppet and using them in `spark-defaults.conf`.