### PR TITLE
BIGTOP-2833: Fix puppetize issue for AArch64

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -72,7 +72,9 @@ case ${ID}-${VERSION_ID} in
 	yum -y install curl sudo unzip wget puppet tar
 	;;
     centos-7*)
-        rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+	if [ $HOSTTYPE = "x86_64" ] ; then
+		rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+	fi
 	yum -y install hostname curl sudo unzip wget puppet
 	;;
     *)


### PR DESCRIPTION
The patch fix the execution issue of puppetize.sh
on AArch64 architecture

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>