### PR TITLE
BIGTOP-2824: Add centos 7 aarch64 sandbox support

### DIFF
--- a/docker/sandbox/sandbox-env.sh
+++ b/docker/sandbox/sandbox-env.sh
@@ -21,6 +21,7 @@ BIGTOP_VERSION=1.2.0
 RPMS=( \
     centos-6 \
     centos-7 \
+    centos-7-aarch64 \
     fedora-25 \
     opensuse-42.1 \
 )


### PR DESCRIPTION
This patch will add the CentOS 7 AArch64 support for sandbox.

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>