### PR TITLE
BIGTOP-2835: puppet fails when bigtop::jdk_preinstalled is true

### DIFF
--- a/bigtop-deploy/puppet/manifests/jdk.pp
+++ b/bigtop-deploy/puppet/manifests/jdk.pp
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+$jdk_preinstalled = hiera("bigtop::jdk_preinstalled", false)
+
 class jdk {
   case $::operatingsystem {
     /Debian/: {
@@ -39,6 +41,7 @@ class jdk {
       package { 'jdk':
         name => 'openjdk-8-jdk',
         ensure => present,
+        noop => $jdk_preinstalled,
       }
 
      }
@@ -48,12 +51,14 @@ class jdk {
       package { 'jdk':
         name => 'openjdk-8-jdk',
         ensure  => present,
+        noop => $jdk_preinstalled,
       }
     }
     /(CentOS|Amazon|Fedora)/: {
       package { 'jdk':
         name => 'java-1.8.0-openjdk-devel',
-        ensure => present
+        ensure => present,
+        noop => $jdk_preinstalled,
       }
       if ($::operatingsystem == "Fedora") {
         file { '/usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/cacerts':
@@ -65,7 +70,8 @@ class jdk {
     /OpenSuSE/: {
       package { 'jdk':
         name => 'java-1_8_0-openjdk-devel',
-        ensure => present
+        ensure => present,
+        noop => $jdk_preinstalled,
       }
     }
   }

--- a/bigtop-deploy/puppet/manifests/site.pp
+++ b/bigtop-deploy/puppet/manifests/site.pp
@@ -13,11 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$jdk_preinstalled = hiera("bigtop::jdk_preinstalled", false)
-if ( ! $jdk_preinstalled ) {
-   require jdk
-   Class['jdk'] -> Service<||>
-}
+require jdk
+Class['jdk'] -> Service<||>
 
 $provision_repo = hiera("bigtop::provision_repo", true)
 if ($provision_repo) {


### PR DESCRIPTION
Many modules require `Package["jdk"]`. Ensure it is available regardless of the `bigtop::jdk_preinstalled` option. Modify the jdk class so the package resources perform a no-op if `bigtop::jdk_preinstalled` is true.