### PR TITLE
BIGTOP-2836: charm metric collector race condition

### DIFF
--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/metrics.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/metrics.yaml
@@ -2,12 +2,12 @@ metrics:
   namenodes:
     type: gauge
     description: number of namenodes in the cluster
-    command: "charms.reactive is_state apache-bigtop-namenode.ready && hdfs getconf -namenodes 2>/dev/null | wc -l"
+    command: "charms.reactive is_state apache-bigtop-namenode.ready && su hdfs -c 'hdfs getconf -namenodes 2>/dev/null | wc -l' || echo 0"
   offlinedatanodes:
     type: gauge
     description: number of dead datanodes in the cluster (must be run as hdfs)
-    command: "charms.reactive is_state apache-bigtop-namenode.ready && su hdfs -c 'hdfs dfsadmin -report -dead 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'"
+    command: "charms.reactive is_state apache-bigtop-namenode.ready && su hdfs -c 'hdfs dfsadmin -report -dead 2>/dev/null | grep -i datanodes | grep -o [0-9]' || echo 0"
   onlinedatanodes:
     type: gauge
     description: number of live datanodes in the cluster (must be run as hdfs)
-    command: "charms.reactive is_state apache-bigtop-namenode.ready && su hdfs -c 'hdfs dfsadmin -report -live 2>/dev/null | grep -i datanodes | grep -o [0-9] || echo 0'"
+    command: "charms.reactive is_state apache-bigtop-namenode.ready && su hdfs -c 'hdfs dfsadmin -report -live 2>/dev/null | grep -i datanodes | grep -o [0-9]' || echo 0"

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/metrics.yaml
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/metrics.yaml
@@ -2,4 +2,4 @@ metrics:
   nodemanagers:
     type: gauge
     description: number of running node managers in the cluster
-    command: "charms.reactive is_state apache-bigtop-resourcemanager.ready && yarn node -list -all 2>/dev/null | grep RUNNING | wc -l"
+    command: "charms.reactive is_state apache-bigtop-resourcemanager.ready && yarn node -list -all 2>/dev/null | grep RUNNING | wc -l || echo 0"

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/metrics.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/metrics.yaml
@@ -2,4 +2,4 @@ metrics:
   peers:
     type: gauge
     description: number of zookeeper servers in the cluster
-    command: grep ^server /etc/zookeeper/conf/zoo.cfg  | wc -l
+    command: grep ^server /etc/zookeeper/conf/zoo.cfg | wc -l || echo 0


### PR DESCRIPTION
Ensure `echo 0` is the last thing to run so that the metric hook does not cause a failed deployment. Works in all tested scenarios:

False && False || echo 0
- 0

True && False || echo 0
- 0

False && True || echo 0
- 0

True && True || echo 0
- True