### PR TITLE
BIGTOP-2838:Support ARM64 for packages.gradle

### DIFF
--- a/packages.gradle
+++ b/packages.gradle
@@ -111,7 +111,7 @@ Label: Bigtop
 Suite: stable
 Codename: bigtop
 Version: ${config.bigtop.version}
-Architectures: amd64 ppc64el source
+Architectures: amd64 ppc64el arm64 source
 Components: contrib
 Description: Bigtop
 """;


### PR DESCRIPTION
The distribution file does not list arm64, so execution failed for task ':apt'.
`Error: 'libhdfs0_2.7.3-1_arm64.deb' has the wrong architecture to add it to bigtop!
There have been errors!
:apt FAILED
:apt (Thread[Daemon worker,5,main]) completed. Took 2.795 secs.

FAILURE: Build failed with an exception.

* Where:
Script '/ws/packages.gradle' line: 723

* What went wrong:
Execution failed for task ':apt'.
> Process 'command 'reprepro'' finished with non-zero exit value 255

* Try:
Run with --stacktrace option to get the stack trace. Run with --debug option to get more log output.`
