### PR TITLE
BIGTOP-2841: Fix bigtop/slaves-ubuntu-16.04-aarch64 build failure

### DIFF
--- a/docker/bigtop-slaves/ubuntu-16.04-aarch64/Dockerfile
+++ b/docker/bigtop-slaves/ubuntu-16.04-aarch64/Dockerfile
@@ -12,12 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM aarch64/ubuntu:16.04
+FROM bigtop/puppet:ubuntu-16.04-aarch64
 MAINTAINER Roman Shaposhnik <rvs@apache.org>
 
 COPY bigtop_toolchain /etc/puppet/modules/bigtop_toolchain
 
-RUN /etc/puppet/modules/bigtop_toolchain/bin/puppetize.sh
-RUN puppet apply -e "include bigtop_toolchain::installer"
+RUN  apt-get clean && apt-get update && puppet apply -e "include bigtop_toolchain::installer"
 COPY . /tmp/bigtop
 RUN cd /tmp/bigtop && ./gradlew && cd && rm -rf /tmp/bigtop


### PR DESCRIPTION
Change-Id: Ibee5879191f27a0f04fb1aa71b0f1da01305cf8f
Signed-off-by: Jun He <jun.he@arm.com>