### PR TITLE
BIGTOP-2851: Add debian 8 aarch64 bigtop puppet

### DIFF
--- a/docker/bigtop-puppet/debian-8-aarch64/Dockerfile
+++ b/docker/bigtop-puppet/debian-8-aarch64/Dockerfile
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM aarch64/debian:jessie
+MAINTAINER naresh.bhat@linaro.org
+
+COPY puppetize.sh /tmp/puppetize.sh
+
+RUN bash /tmp/puppetize.sh

--- a/docker/bigtop-puppet/debian-8-aarch64/build.sh
+++ b/docker/bigtop-puppet/debian-8-aarch64/build.sh
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+cp ../../../bigtop_toolchain/bin/puppetize.sh .
+docker build --pull=true -t bigtop/puppet:debian-8-aarch64 .


### PR DESCRIPTION
Add Debian 8 bigtop-puppet for AArch64 architecture.

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>