### PR TITLE
BIGTOP-2853: Add sandbox support for Debian 8 aarch64

### DIFF
--- a/docker/sandbox/sandbox-env.sh
+++ b/docker/sandbox/sandbox-env.sh
@@ -26,5 +26,6 @@ RPMS=( \
 )
 DEBS=( \
     debian-8 \
+    debian-8-aarch64 \
     ubuntu-16.04 \
 )


### PR DESCRIPTION
Add sandbox support for Debian 8 AArch64.

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>