### PR TITLE
BIGTOP-2854: Add docker provisioner yaml file Debian 8 AArch64

### DIFF
--- a/provisioner/docker/config_debian-8-aarch64.yaml
+++ b/provisioner/docker/config_debian-8-aarch64.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker:
+        memory_limit: "4g"
+        image: "bigtop/puppet:debian-8-aarch64"
+
+repo: "http://bigtop-repos.s3.amazonaws.com/releases/1.2.0/debian/8-aarch64/aarch64"
+distro: debian
+components: [hdfs, yarn, mapreduce]
+enable_local_repo: false
+smoke_test_components: [hdfs, yarn, mapreduce]


### PR DESCRIPTION
Add docker provisioner yaml file Debian 8 AArch64.

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>