### PR TITLE
BIGTOP-2864:Multiple SLF4J bindings in tez

### DIFF
--- a/bigtop-packages/src/deb/tez/rules
+++ b/bigtop-packages/src/deb/tez/rules
@@ -42,6 +42,7 @@ override_dh_auto_install:
 		--build-dir=. \
 		--doc-dir=usr/share/doc/${tez_pkg_name}-doc \
 		--prefix=debian/tmp
+	rm -f debian/tmp/usr/lib/${tez_pkg_name}/lib/slf4j-log4j12-*.jar
 	ln -sf /usr/lib/hadoop/hadoop-annotations.jar debian/tmp/${lib_tez}/hadoop-annotations.jar
 	ln -sf /usr/lib/hadoop/hadoop-auth.jar debian/tmp/${lib_tez}/hadoop-auth.jar
 	ln -sf /usr/lib/hadoop-mapreduce/hadoop-mapreduce-client-common.jar debian/tmp/${lib_tez}/hadoop-mapreduce-client-common.jar

--- a/bigtop-packages/src/rpm/tez/SPECS/tez.spec
+++ b/bigtop-packages/src/rpm/tez/SPECS/tez.spec
@@ -93,6 +93,7 @@ sh %{SOURCE2} \
         --libexec-dir=%{libexec_tez} \
 	--prefix=$RPM_BUILD_ROOT
 
+%__rm -f $RPM_BUILD_ROOT/%{lib_tez}/slf4j-log4j12-*.jar
 %__ln_s -f /usr/lib/hadoop/hadoop-annotations.jar $RPM_BUILD_ROOT/%{lib_tez}/hadoop-annotations.jar
 %__ln_s -f /usr/lib/hadoop/hadoop-auth.jar $RPM_BUILD_ROOT/%{lib_tez}/hadoop-auth.jar
 %__ln_s -f /usr/lib/hadoop-mapreduce/hadoop-mapreduce-client-common.jar $RPM_BUILD_ROOT/%{lib_tez}/hadoop-mapreduce-client-common.jar


### PR DESCRIPTION
When using Tez, there will be "Class path contains multiple SLF4J bindings" warnings. This caused by existence of 'slf4j-log4j12-*.jar' in tez lib.
The same issue resolved before.
Reference : https://issues.apache.org/jira/browse/BIGTOP-583