### PR TITLE
BIGTOP-2866:Fix rmr and people directory error

### DIFF
--- a/bigtop-tests/smoke-tests/spark/TestSpark.groovy
+++ b/bigtop-tests/smoke-tests/spark/TestSpark.groovy
@@ -62,7 +62,7 @@ class TestSpark {
   public static void tearDown() {
     sh.exec("hdfs dfs -ls")
     logError(sh)
-    sh.exec("hdfs dfs -rmr people* examples")
+    sh.exec("hdfs dfs -rm -r examples")
     logError(sh)
   }
 


### PR DESCRIPTION
The below error is issued while running the spark smoke
tests on AArch64 architecture.  The patch will fix the issues.
...
....
org.apache.bigtop.itest.spark.TestSpark STANDARD_OUT
Failed command: hdfs dfs -rmr people* examples
error code: 1
stdout: [Deleted examples]
stderr: [rmr: DEPRECATED: Please use 'rm -r' instead.,
rmr: `people*': No such file or directory,
...
.....

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>