### PR TITLE
BIGTOP-2868: Add Basic Travic CI Execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+
+install:
+- mvn clean install -DskipTests -DskipITs
+
+script:
+- mvn test -B

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Travis CI](https://img.shields.io/travis/apache/bigtop.svg?branch=master)](https://travis-ci.org/apache/bigtop)
+
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements. See the NOTICE file distributed with
 this work for additional information regarding copyright ownership.
@@ -18,7 +20,7 @@ limitations under the License.
 ==========================================
 
 ...is a project for the development of packaging and tests of the [Apache Hadoop](http://hadoop.apache.org/) ecosystem.
- 
+
 The primary goal of Apache Bigtop is to build a community around the packaging and interoperability testing of Apache Hadoop-related projects. This includes testing at various levels (packaging, platform, runtime, upgrade, etc...) developed by a community with a focus on the system as a whole, rather than individual projects.
 
 Immediately Get Started with Deployment and Smoke Testing of BigTop
@@ -32,7 +34,7 @@ Quick overview of source code directories
 * __bigtop-deploy__ : deployment scripts and puppet stuff for Apache Bigtop.
 * __bigtop-packages__ : RPM/DEB specifications for Apache Bigtop subcomponents.
 * __bigtop-test-framework__ : The source code for the iTest utilities (framework used by smoke tests).
-* __bigtop-tests__ : 
+* __bigtop-tests__ :
 * __test-artifacts__ : source for tests.
 * __test-execution__ : maven pom drivers for running the integration tests found in test-artifacts.
 * __bigtop-toolchain__ : puppet scripts for setting up an instance which can build Apache Bigtop, sets up utils like jdk/maven/protobufs/...
@@ -41,20 +43,20 @@ Quick overview of source code directories
 
 Also, there is a new project underway, Apache Bigtop blueprints, which aims to create templates/examples that demonstrate/compare various Apache Hadoop ecosystem components with one another.
 
-Contributing 
+Contributing
 ============
 
 There are lots of ways to contribute.  People with different expertise can help with various subprojects:
-    
+
 * __puppet__ : Much of the Apache Bigtop deploy and packaging tools use puppet to bootstrap and set up a cluster. But recipes for other tools are also welcome (ie. Chef, Ansible, etc.)
-* __groovy__ : Primary language used to write the Apache Bigtop smokes and itest framework. 
-* __maven__ : Used to build Apache Bigtop smokes and also to define the high level Apache Bigtop project. 
+* __groovy__ : Primary language used to write the Apache Bigtop smokes and itest framework.
+* __maven__ : Used to build Apache Bigtop smokes and also to define the high level Apache Bigtop project.
 * __RPM/DEB__ : Used to package Apache Hadoop ecosystem related projects into GNU/Linux installable packages for most popular GNU/Linux distributions. So one could add a new project or improve existing packages.
 * __hadoop__ : Apache Hadoop users can also contribute by using the Apache Bigtop smokes, improving them, and evaluating their breadth.
 * __contributing your workloads__ : Contributing your workloads enable us to tests projects against real use cases and enable you to have people verifying the use cases you care about are always working.
 * __documentation__ : We are always in need of a better documentation!
 * __giving feedback__ : Tell us how you use Apache Bigtop, what was great and what was not so great. Also, what are you expecting from it and what would you like to see in the future?
- 
+
 Also, opening [JIRA's](https://issues.apache.org/jira/browse/BIGTOP) and getting started by posting on the mailing list is helpful.
 
 CTR model
@@ -81,7 +83,7 @@ rules will be used for the CTR process:
     before it gets committed without a +1 from other committers
   * there's no changes in the JIRA process, except as specified above
 
-What do people use Apache Bigtop for? 
+What do people use Apache Bigtop for?
 ==============================
 
 You can go to the [Apache Bigtop website](http://bigtop.apache.org/) for notes on how to do "common" tasks like:
@@ -101,13 +103,13 @@ For Users: Running the smoke tests
 
 The simplest way to test bigtop is described in bigtop-tests/smoke-tests/README file
 
-For integration (API level) testing with maven, read on. 
+For integration (API level) testing with maven, read on.
 
 For Users: Running the integration tests
 -----------------------------------------
 
 WARNING: since testing packages requires installing them on a live system it is highly recommended to use VMs for that. Testing Apache Bigtop is done using iTest framework. The tests are organized in maven submodules, with one submodule per Apache Bigtop component.  The bigtop-tests/test-execution/smokes/pom.xml defines all submodules to be tested, and each submodule is in its own directory under smokes/, for example:
- 
+
 *smokes/hadoop/pom.xml*
 *smokes/hive/pom.xml*
 *... and so on.*
@@ -140,23 +142,23 @@ WARNING: since testing packages requires installing them on a live system it is 
         mvn clean install -DskipTests -DskipITs -DperformRelease -f ./test-artifacts/pom.xml
 
   * Step 2: Now, rebuild in "offline" mode.  This will make sure that your local changes to bigtop are embeded in the changes.
-    
+
         mvn clean install -DskipTests -DskipITs -DperformRelease -o -nsu -f ./bigtop-test-framework/pom.xml
         mvn clean install -DskipTests -DskipITs -DperformRelease -o -nsu -f ./bigtop-tests/test-artifacts/pom.xml
- 
+
   * Step 3: Now, you can run the smoke tests on your cluster.
-    * Example 1: Running all the smoke tests with TRACE level logging (shows std out from each mr job). 
-      
-            mvn clean verify -Dorg.apache.bigtop.itest.log4j.level=TRACE -f ./bigtop/bigtop-tests/test-execution/smokes/pom.xml 
+    * Example 1: Running all the smoke tests with TRACE level logging (shows std out from each mr job).
+
+            mvn clean verify -Dorg.apache.bigtop.itest.log4j.level=TRACE -f ./bigtop/bigtop-tests/test-execution/smokes/pom.xml
 
     * Just running hadoop examples, nothing else.
 
             mvn clean verify -D'org.apache.maven-failsafe-plugin.testInclude=**/*TestHadoopExamples*' -f bigtop-tests/test-execution/smokes/hadoop/pom.xml
- 
-    Note: A minor bug/issue: you need the "testInclude" regular expression above, even if you don't want to customize the tests, 
+
+    Note: A minor bug/issue: you need the "testInclude" regular expression above, even if you don't want to customize the tests,
     since existing test names don't follow the maven integration test naming convention of IT*, but instead, follow the surefire (unit test) convention of Test*.
 
-For Users: Creating Your Own Apache Hadoop Environment 
+For Users: Creating Your Own Apache Hadoop Environment
 -----------------------------------------------
 
 Another common use case for Apache Bigtop is creating / setting up your own Apache Hadoop distribution.  
@@ -166,9 +168,9 @@ You can also try out provisioner to quickly get the idea how it works.
 
 For Developers: Building the entire distribution from scratch
 -------------------------------------------------------------
- 
+
 Packages have been built for CentOS, Fedora, OpenSUSE, Ubuntu, and Debian. They can probably be built for other platforms as well. Some of the binary artifacts might be compatible with other closely related distributions.
- 
+
 __On all systems, Building Apache Bigtop requires certain set of tools__
 
   To bootstrap the development environment from scratch execute
@@ -250,4 +252,3 @@ Contact us
 ----------
 
 You can get in touch with us on [the Apache Bigtop mailing lists](http://bigtop.apache.org/mail-lists.html).
-


### PR DESCRIPTION
As per [BIGTOP-2868](https://issues.apache.org/jira/browse/BIGTOP-2868), start by adding a basic build script to build packages, allowing some preliminary validation of pull request viability

This configuration currently uses the maven commands - the newer Gradle commands failed to cooperate (I will add comments below with specifics)

The main goal for this iteration is to have a Travis build which packages RPM/DEB and makes sure that process still succeeds for changed code in pull requests