### PR TITLE
BIGTOP-2887: ZOO_DATADIR_AUTOCREATE_DISABLE is always set

### DIFF
--- a/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
+++ b/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
@@ -177,7 +177,6 @@ export CLASSPATH=\$CLASSPATH:\$ZOOKEEPER_CONF:\$ZOOKEEPER_HOME/*:\$ZOOKEEPER_HOM
 export ZOO_LOG_DIR=\${ZOO_LOG_DIR:-/var/log/zookeeper}
 export ZOO_LOG4J_PROP=\${ZOO_LOG4J_PROP:-INFO,ROLLINGFILE}
 export JVMFLAGS=\${JVMFLAGS:--Dzookeeper.log.threshold=INFO}
-export ZOO_DATADIR_AUTOCREATE_DISABLE=\${ZOO_DATADIR_AUTOCREATE_DISABLE:-true}
 env CLASSPATH=\$CLASSPATH /usr/lib/zookeeper/bin/${upstream_script} "\$@"
 EOF
   chmod 755 $wrapper


### PR DESCRIPTION
While this change should not impact the version of ZooKeeper that is currently shipping with bigtop, later versions of ZooKeeper use the ZOO_DATADIR_AUTOCREATE_DISABLE environment variable to decide if the initialization script should create the data directory. We prevent the environment variable from ever being empty, totally preventing datadir autocreation. 

We should not alter this value at all.