### PR TITLE
BIGTOP-2889: Remove HADOOP_HOME_WARN_SUPPRESS setting.

### DIFF
--- a/bigtop-packages/src/common/hadoop/hadoop.default
+++ b/bigtop-packages/src/common/hadoop/hadoop.default
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export HADOOP_HOME_WARN_SUPPRESS=true
 export HADOOP_HOME=/usr/lib/hadoop
 export HADOOP_PREFIX=/usr/lib/hadoop
 


### PR DESCRIPTION
Small fix. `HADOOP_HOME` is not deprecated now and `HADOOP_HOME_WARN_SUPPRESS` is not effective.