### PR TITLE
BIGTOP-2897 Bump Phonenix to 4.11-HBASE-1.3

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -347,8 +347,8 @@ bigtop {
        * to the base HBase version. Update as needed whenever changing the
        * HBase version in the BOM.
        */
-      phoenix.hbase ='HBase-1.1'
-      version { base = "4.9.0-${phoenix.hbase}"; pkg = '4.9.0'; release = 1 }
+      phoenix.hbase ='HBase-1.3'
+      version { base = "4.11.0-${phoenix.hbase}"; pkg = '4.11.0'; release = 1 }
       tarball { destination = "$name-${version.base}-src.tar.gz"
                 source      = "apache-$name-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/apache-$name-${version.base}/src"


### PR DESCRIPTION
We have to bump Phoenix as part of Hadoop upgrade.
See BIGTOP-2882 for reference.