### PR TITLE
BIGTOP-2899 remove h2 pig classifier in Oozie code

### DIFF
--- a/bigtop-packages/src/common/oozie/patch0-ADH-204-remove-h2-pig-classifier-in-Oozie-code.diff
+++ b/bigtop-packages/src/common/oozie/patch0-ADH-204-remove-h2-pig-classifier-in-Oozie-code.diff
@@ -1,0 +1,27 @@
+From a9591e083a6c5a63a38e46792fd65687764bdf64 Mon Sep 17 00:00:00 2001
+From: Anton Chevychalov <cab@arenadata.io>
+Date: Fri, 29 Sep 2017 19:06:01 +0300
+Subject: [PATCH] ADH-204 remove h2 pig classifier in Oozie code
+
+There is a regression in Pig relase 0.17
+After PIG-4923 they drop h2 classifer.
+There is only one jar now and it suports Hadoop 2
+---
+ pom.xml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 9daf6b1..5d92d77 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -1902,7 +1902,6 @@
+             <properties>
+                 <hadoop.version>2.4.0</hadoop.version>
+                 <hadoop.majorversion>2</hadoop.majorversion>
+-                <pig.classifier>h2</pig.classifier>
+                 <sqoop.classifier>hadoop200</sqoop.classifier>
+                 <jackson.version>1.9.13</jackson.version>
+             </properties>
+-- 
+2.7.4
+


### PR DESCRIPTION
There is a regression in Pig relase 0.17
After PIG-4923 they drop h2 classifer.
There is only one jar now and it suports Hadoop 2