### PR TITLE
BIGTOP-2910: zeppelin charm: support bigtop upgrade

### DIFF
--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions.yaml
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions.yaml
@@ -1,7 +1,10 @@
-smoke-test:
+reinstall:
   description: >
-    Verify that Zeppelin is working by running one of
-    the example notebook paragraphs, using the REST server.
+    Reinstall Zeppelin with the version available in the repo.
 restart:
   description: >
     Restart Zeppelin.
+smoke-test:
+  description: >
+    Verify that Zeppelin is working by running one of the example notebook
+    paragraphs, using the REST server.

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/reinstall
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/reinstall
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('lib')
+
+from charmhelpers.core import hookenv, unitdata  # noqa: E402
+from charms.layer.apache_bigtop_base import Bigtop, get_package_version  # noqa: E402
+from charms.reactive import is_state  # noqa: E402
+
+
+def fail(msg):
+    hookenv.action_set({'outcome': 'failure'})
+    hookenv.action_fail(msg)
+    sys.exit()
+
+
+if not is_state('bigtop.version.changed'):
+    fail('No Bigtop version changes were found; nothing to reinstall.')
+
+if not unitdata.kv().get('zeppelin.version.repo', False):
+    fail('Charm is not prepared to run the reinstall action.')
+
+# Call the base reinstall method and ensure zeppelin packages
+# are removed prior to reinstalling new versions via puppet apply.
+bigtop = Bigtop()
+result = bigtop.reinstall_repo_packages(remove_pkgs='zeppelin')
+
+if bigtop.check_bigtop_repo_package('zeppelin'):
+    # Ruh roh. We expect this to be None since we just did a reinstall
+    # with the current repo. There should be no different version available.
+    fail('Unexpected zeppelin version found after reinstalling')
+
+if result == 'success':
+    # Set appropriate status output
+    app_version = get_package_version('zeppelin') or 'unknown'
+    hookenv.application_version_set(app_version)
+    hookenv.status_set('active', 'reinstall was successful')
+
+    # Remove our version unitdata and report success
+    unitdata.kv().unset('zeppelin.version.repo')
+    hookenv.action_set({'outcome': 'success'})
+else:
+    fail('Reinstall failed; hiera data and package repos have been restored '
+         'to the previous working state.')

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/tests/03-zeppelin-spark-smoke.py
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/tests/03-zeppelin-spark-smoke.py
@@ -20,7 +20,7 @@ import re
 import unittest
 
 
-class TestDeploy(unittest.TestCase):
+class TestSmokeSpark(unittest.TestCase):
     """
     Smoke test for Apache Bigtop Zeppelin using remote Spark resources.
     """


### PR DESCRIPTION
See [BIGTOP-2910](https://issues.apache.org/jira/browse/BIGTOP-2910) for details.

Make the zeppelin charm react to `bigtop_version` changes, informing the user if a new zepp deb is available.  Do the actual apt upgrade via a `reinstall` action.