### PR TITLE
fix bug: spark/do-component-build

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -20,7 +20,7 @@ pig: evans ye, daniel dai
 puppet recipes: jay vyas, cos, evans ye, rvs
 qfs: kstinson <kstinson@quantcast.com>
 smoke-tests: jay vyas, david capwell
-spark: jay vyas, youngwoo kim
+spark: jay vyas, youngwoo kim, zewen chi
 sqoop: sean mackrory, youngwoo kim
 tajo: yeongeon kim
 test-artifacts and test-execution repos:

--- a/bigtop-packages/src/common/spark/do-component-build
+++ b/bigtop-packages/src/common/spark/do-component-build
@@ -44,4 +44,4 @@ SPARK_SKIP_TESTS=$([ "$SPARK_RUN_TESTS" = "true" ] && echo false || echo true)
 # This is also the point that we can run the tests if desired, since tests must
 # be run after Spark has already been packaged.
 # See http://spark.apache.org/docs/latest/building-spark.html#spark-tests-in-maven
-mvn $BUILD_OPTS install -DskipTests=$SPARK_SKIP_TESTS
+./build/mvn $BUILD_OPTS install -DskipTests=$SPARK_SKIP_TESTS


### PR DESCRIPTION
The mvn command in the last line of spark/do-component-build uses "mvn", but here should be "./build/mvn".

make-distribution.sh will only run "mvn clean package", so in order to get the Spark packages installed in the local Maven repository (or to run the tests), we need to run "mvn install" again.

make-distribution.sh uses "./build/mvn" but in do-component-build "mvn" is used, which may be in wrong version.

This may cause that  "mvn install" build failure after "mvn clean package" build successfully.