### PR TITLE
Update bigtop-detect-javahome for variable typo

### DIFF
--- a/bigtop-packages/src/common/bigtop-utils/bigtop-detect-javahome
+++ b/bigtop-packages/src/common/bigtop-utils/bigtop-detect-javahome
@@ -31,7 +31,7 @@ JAVA8_HOME_CANDIDATES=(
     '/usr/lib/jvm/java-1.8.0-oracle'
 )
 
-OPENJAVA8_HOME__CANDIDATES=(
+OPENJAVA8_HOME_CANDIDATES=(
     '/usr/lib/jvm/java-1.8.0-openjdk-amd64'
     '/usr/lib/jvm/java-1.8.0-openjdk-ppc64el'
     '/usr/lib/jvm/java-1.8.0-openjdk'


### PR DESCRIPTION
In line 56 and line 60, $OPENJAVA8_HOME_CANDIDATES can only be empty because there was a typo in defining variable $OPENJAVA8_HOME__CANDIDATES in line 34.   There are two _ between "HOME" and "CANDIDATES" in line 34. But There is only one _  between "HOME" and "CANDIDATES" when using the variable in line 56 and line 60. For other variable using one _ as the separator instead of two _ , I suggest changing variable $OPENJAVA8_HOME__CANDIDATES(with two _ between "HOME" and "CANDIDATES") in line 34 to $OPENJAVA8_HOME_CANDIDATES(with only one _ between "HOME" and "CANDIDATES")