### PR TITLE
BIGTOP-2988: Incorrect use "dnf update" in puppetize.sh

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -23,7 +23,7 @@ fi
 case ${ID}-${VERSION_ID} in
     fedora-26)
       dnf -y install yum-utils
-      dnf -y update
+      dnf -y check-update
       dnf -y install hostname findutils curl sudo unzip wget puppet puppetlabs-stdlib
         ;;
     ubuntu-16.04)


### PR DESCRIPTION
The cmd "dnf -y update" is not correctly used as the
purpose here is to "synchronize the package index
files from their sources".
For this purpose the cmd should be "dnf check-update"

Change-Id: I9ed7b7b631f5fabc00a4ef679d30a68f5c68b539
Signed-off-by: Jun He <jun.he@linaro.org>