### PR TITLE
BIGTOP-3002: For Kafka, it should be possible to set the broker.id config and log.dirs config.

### DIFF
--- a/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
@@ -22,6 +22,8 @@ class kafka {
   }
 
   class server(
+      $broker_id = undef,
+      $log_dirs = undef,
       $bind_addr = undef,
       $port = "9092",
       $zookeeper_connection_string = "localhost:2181",

--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
@@ -17,12 +17,20 @@
 ############################# Server Basics #############################
 
 # The id of the broker. This must be set to a unique integer for each broker.
+<% if @broker_id.nil? -%>
 broker.id=-1
 
 # Enable automatic broker id generation on the server. When enabled the value
 # configured for reserved.broker.max.id should be reviewed.
 broker.id.generation.enable=true
 reserved.broker.max.id=1000
+<% else -%>
+broker.id=<%= @broker_id %>
+
+# Disable automatic broker id generation on the server.
+broker.id.generation.enable=false
+#reserved.broker.max.id=1000
+<% end -%>
 
 ############################# Socket Server Settings #############################
 
@@ -64,7 +72,11 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma seperated list of directories under which to store log files
+<% if @log_dirs.nil? -%>
 log.dirs=/tmp/kafka-logs
+<% else -%>
+log.dirs=<%= @log_dirs %>
+<% end -%>
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across


### PR DESCRIPTION
Added 2 new parameters: broker_id, log_dirs. Both do not necessarily
need to be set. It is only when they are set , the parameters are used
in the server.properties file.