### PR TITLE
BIGTOP-3003: Ant-1.9.9 tarball is removed from Apache mirrors

### DIFF
--- a/bigtop_toolchain/manifests/ant.pp
+++ b/bigtop_toolchain/manifests/ant.pp
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 class bigtop_toolchain::ant {
-  $ant =  'apache-ant-1.9.9'
+  $ant =  'apache-ant-1.9.10'
 
   $apache_prefix = nearest_apache_mirror()
 


### PR DESCRIPTION
As from 06-Feb, ant-1.9.10 is released and distributed
to Apache mirrors. Ant-1.9.9 is removed and can only
be found at Apache's archive. So update the download
base url.

Change-Id: I8175684444b08a1607ee04589f5d252dac5588e2
Signed-off-by: Jun He <jun.he@linaro.org>