### PR TITLE
BIGTOP-3005 Add zkpeer-relation-changed hook to zookeeper charm.

### DIFF
--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/reactive/zookeeper.py
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/reactive/zookeeper.py
@@ -196,6 +196,12 @@ def check_cluster_departed(zkpeer, zkpeer_departed):
     check_cluster(zkpeer)
 
 
+@when('zookeeper.started', 'leadership.is_leader', 'zkpeer.changed')
+def check_cluster_changed(zkpeer):
+    check_cluster(zkpeer)
+    zkpeer.dismiss_changed()
+
+
 @when('leadership.changed.restart_queue', 'zkpeer.joined')
 def restart_for_quorum(zkpeer):
     '''


### PR DESCRIPTION
Check quorum status and update config accordingly if zkpeer relation changes.

This change add a zkpeer-relation-changed hook to refresh the configuration of
the server.[\d] lines in zoo.cfg to match any new information received either through the
relation manually, or from juju.

Signed-off-by: José Pekkarinen <jose.pekkarinen@canonical.com>