### PR TITLE
BIGTOP-3004: Fix HBase build failure on Debian/Fedora

### DIFF
--- a/bigtop-packages/src/common/hbase/patch3-HBASE-17352.diff
+++ b/bigtop-packages/src/common/hbase/patch3-HBASE-17352.diff
@@ -1,0 +1,13 @@
+diff --git a/hbase-assembly/pom.xml b/hbase-assembly/pom.xml
+index 185e681..b9d8dcc 100644
+--- a/hbase-assembly/pom.xml
++++ b/hbase-assembly/pom.xml
+@@ -138,7 +138,7 @@
+                 <argument>bash</argument>
+                 <argument>-c</argument>
+                 <argument>cat maven-shared-archive-resources/META-INF/NOTICE \
+-                  `find ${project.build.directory}/dependency -iname NOTICE -or -iname NOTICE.txt` \
++                  `find ${project.build.directory}/dependency -iname NOTICE -or -iname NOTICE.txt`
+                 </argument>
+               </arguments>
+               <outputFile>${project.build.directory}/NOTICE.aggregate</outputFile>


### PR DESCRIPTION
Debian/Fedora uses bash-4.4.12 which treats the extra
trailing backslash as error. HBase has patch for this
and should be backported.

Change-Id: I11353ec0fcdca6e04373c0dac34e0e23aa757f30
Signed-off-by: Jun He <jun.he@linaro.org>