### PR TITLE
BIGTOP-3010: juju bundle refresh (feb 2018)

### DIFF
--- a/bigtop-deploy/juju/hadoop-hbase/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle-local.yaml
@@ -40,7 +40,7 @@ services:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: "cs:xenial/hadoop-client-8"
+    charm: "cs:xenial/hadoop-client-9"
     constraints: "mem=3G"
     num_units: 1
     annotations:

--- a/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
@@ -6,7 +6,7 @@ description: >
   your cloud.
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-34"
+    charm: "cs:xenial/hadoop-namenode-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -15,7 +15,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-36"
+    charm: "cs:xenial/hadoop-resourcemanager-37"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -24,7 +24,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-35"
+    charm: "cs:xenial/hadoop-slave-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -35,7 +35,7 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-34"
+    charm: "cs:xenial/hadoop-plugin-35"
     annotations:
       gui-x: "1000"
       gui-y: "400"
@@ -49,7 +49,7 @@ services:
     to:
       - "4"
   hbase:
-    charm: "cs:xenial/hbase-35"
+    charm: "cs:xenial/hbase-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -60,7 +60,7 @@ services:
       - "2"
       - "3"
   zookeeper:
-    charm: "cs:xenial/zookeeper-40"
+    charm: "cs:xenial/zookeeper-42"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:

--- a/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-hbase/bundle.yaml
@@ -6,7 +6,7 @@ description: >
   your cloud.
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-31"
+    charm: "cs:xenial/hadoop-namenode-34"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -15,7 +15,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-33"
+    charm: "cs:xenial/hadoop-resourcemanager-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -24,7 +24,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-32"
+    charm: "cs:xenial/hadoop-slave-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -35,12 +35,12 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-31"
+    charm: "cs:xenial/hadoop-plugin-34"
     annotations:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: "cs:xenial/hadoop-client-8"
+    charm: "cs:xenial/hadoop-client-9"
     constraints: "mem=3G"
     num_units: 1
     annotations:
@@ -49,7 +49,7 @@ services:
     to:
       - "4"
   hbase:
-    charm: "cs:xenial/hbase-32"
+    charm: "cs:xenial/hbase-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -60,7 +60,7 @@ services:
       - "2"
       - "3"
   zookeeper:
-    charm: "cs:xenial/zookeeper-37"
+    charm: "cs:xenial/zookeeper-40"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:

--- a/bigtop-deploy/juju/hadoop-kafka/README.md
+++ b/bigtop-deploy/juju/hadoop-kafka/README.md
@@ -49,7 +49,7 @@ follows:
     * Colocated on the NameNode unit
   * Slave (DataNode and NodeManager) v2.7.3
     * 3 separate units
-  * Kafka v0.10.1
+  * Kafka v0.10.1.1
   * Flume-Kafka
     * Colocated on the Kafka unit
   * Zookeeper v3.4.6

--- a/bigtop-deploy/juju/hadoop-kafka/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle-local.yaml
@@ -39,7 +39,7 @@ services:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: "cs:xenial/hadoop-client-8"
+    charm: "cs:xenial/hadoop-client-9"
     constraints: "mem=3G"
     num_units: 1
     annotations:

--- a/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
@@ -5,7 +5,7 @@ description: >
   for future analysis with MapReduce. It will run on 9 machines in your cloud.
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-31"
+    charm: "cs:xenial/hadoop-namenode-34"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -14,7 +14,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-33"
+    charm: "cs:xenial/hadoop-resourcemanager-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -23,7 +23,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-32"
+    charm: "cs:xenial/hadoop-slave-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -34,12 +34,12 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-31"
+    charm: "cs:xenial/hadoop-plugin-34"
     annotations:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: "cs:xenial/hadoop-client-8"
+    charm: "cs:xenial/hadoop-client-9"
     constraints: "mem=3G"
     num_units: 1
     annotations:
@@ -57,7 +57,7 @@ services:
     to:
       - "4"
   zookeeper:
-    charm: "cs:xenial/zookeeper-37"
+    charm: "cs:xenial/zookeeper-40"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:
@@ -68,7 +68,7 @@ services:
       - "6"
       - "7"
   kafka:
-    charm: "cs:xenial/kafka-35"
+    charm: "cs:xenial/kafka-39"
     constraints: "mem=3G"
     num_units: 1
     annotations:

--- a/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-kafka/bundle.yaml
@@ -5,7 +5,7 @@ description: >
   for future analysis with MapReduce. It will run on 9 machines in your cloud.
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-34"
+    charm: "cs:xenial/hadoop-namenode-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -14,7 +14,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-36"
+    charm: "cs:xenial/hadoop-resourcemanager-37"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -23,7 +23,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-35"
+    charm: "cs:xenial/hadoop-slave-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -34,7 +34,7 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-34"
+    charm: "cs:xenial/hadoop-plugin-35"
     annotations:
       gui-x: "1000"
       gui-y: "400"
@@ -57,7 +57,7 @@ services:
     to:
       - "4"
   zookeeper:
-    charm: "cs:xenial/zookeeper-40"
+    charm: "cs:xenial/zookeeper-42"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:
@@ -68,7 +68,7 @@ services:
       - "6"
       - "7"
   kafka:
-    charm: "cs:xenial/kafka-39"
+    charm: "cs:xenial/kafka-40"
     constraints: "mem=3G"
     num_units: 1
     annotations:

--- a/bigtop-deploy/juju/hadoop-processing/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle-local.yaml
@@ -39,7 +39,7 @@ services:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: "cs:xenial/hadoop-client-8"
+    charm: "cs:xenial/hadoop-client-9"
     constraints: "mem=3G"
     num_units: 1
     annotations:

--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -5,7 +5,7 @@ description: >
   will run on 5 machines in your cloud.
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-31"
+    charm: "cs:xenial/hadoop-namenode-34"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -14,7 +14,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-33"
+    charm: "cs:xenial/hadoop-resourcemanager-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -23,7 +23,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-32"
+    charm: "cs:xenial/hadoop-slave-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -34,12 +34,12 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-31"
+    charm: "cs:xenial/hadoop-plugin-34"
     annotations:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: "cs:xenial/hadoop-client-8"
+    charm: "cs:xenial/hadoop-client-9"
     constraints: "mem=3G"
     num_units: 1
     annotations:

--- a/bigtop-deploy/juju/hadoop-processing/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-processing/bundle.yaml
@@ -5,7 +5,7 @@ description: >
   will run on 5 machines in your cloud.
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-34"
+    charm: "cs:xenial/hadoop-namenode-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -14,7 +14,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-36"
+    charm: "cs:xenial/hadoop-resourcemanager-37"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -23,7 +23,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-35"
+    charm: "cs:xenial/hadoop-slave-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -34,7 +34,7 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-34"
+    charm: "cs:xenial/hadoop-plugin-35"
     annotations:
       gui-x: "1000"
       gui-y: "400"

--- a/bigtop-deploy/juju/hadoop-spark/README.md
+++ b/bigtop-deploy/juju/hadoop-spark/README.md
@@ -47,7 +47,7 @@ follows:
     * Colocated on the NameNode unit
   * Slave (DataNode and NodeManager) v2.7.3
     * 3 separate units
-  * Spark (Driver in yarn-client mode) v2.1.0
+  * Spark (Driver in yarn-client mode) v2.1.1
   * Client (Hadoop endpoint)
     * Colocated on the Spark unit
   * Plugin (Facilitates communication with the Hadoop cluster)

--- a/bigtop-deploy/juju/hadoop-spark/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle-local.yaml
@@ -39,7 +39,7 @@ services:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: "cs:xenial/hadoop-client-8"
+    charm: "cs:xenial/hadoop-client-9"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -5,7 +5,7 @@ description: >
   data with Spark. It will run on 5 machines in your cloud.
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-31"
+    charm: "cs:xenial/hadoop-namenode-34"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -14,7 +14,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-33"
+    charm: "cs:xenial/hadoop-resourcemanager-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -23,7 +23,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-32"
+    charm: "cs:xenial/hadoop-slave-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -34,12 +34,12 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-31"
+    charm: "cs:xenial/hadoop-plugin-34"
     annotations:
       gui-x: "1000"
       gui-y: "400"
   client:
-    charm: "cs:xenial/hadoop-client-8"
+    charm: "cs:xenial/hadoop-client-9"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -48,7 +48,7 @@ services:
     to:
       - "4"
   spark:
-    charm: "cs:xenial/spark-56"
+    charm: "cs:xenial/spark-59"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     options:

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -5,7 +5,7 @@ description: >
   data with Spark. It will run on 5 machines in your cloud.
 services:
   namenode:
-    charm: "cs:xenial/hadoop-namenode-34"
+    charm: "cs:xenial/hadoop-namenode-35"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -14,7 +14,7 @@ services:
     to:
       - "0"
   resourcemanager:
-    charm: "cs:xenial/hadoop-resourcemanager-36"
+    charm: "cs:xenial/hadoop-resourcemanager-37"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     annotations:
@@ -23,7 +23,7 @@ services:
     to:
       - "0"
   slave:
-    charm: "cs:xenial/hadoop-slave-35"
+    charm: "cs:xenial/hadoop-slave-36"
     constraints: "mem=7G root-disk=32G"
     num_units: 3
     annotations:
@@ -34,7 +34,7 @@ services:
       - "2"
       - "3"
   plugin:
-    charm: "cs:xenial/hadoop-plugin-34"
+    charm: "cs:xenial/hadoop-plugin-35"
     annotations:
       gui-x: "1000"
       gui-y: "400"
@@ -48,7 +48,7 @@ services:
     to:
       - "4"
   spark:
-    charm: "cs:xenial/spark-59"
+    charm: "cs:xenial/spark-60"
     constraints: "mem=7G root-disk=32G"
     num_units: 1
     options:

--- a/bigtop-deploy/juju/spark-processing/README.md
+++ b/bigtop-deploy/juju/spark-processing/README.md
@@ -31,7 +31,7 @@ applications are included to monitor cluster health and syslog activity.
 The applications that comprise this bundle are spread across 6 units as
 follows:
 
-  * Spark (Master and Worker) v2.1.0
+  * Spark (Master and Worker) v2.1.1
     * 2 separate units
   * Zookeeper v3.4.6
     * 3 separate units

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -5,7 +5,7 @@ description: >
   from the spark-shell. It will run on 6 machines in your cloud.
 services:
   spark:
-    charm: "cs:xenial/spark-56"
+    charm: "cs:xenial/spark-59"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
     options:
@@ -18,7 +18,7 @@ services:
       - "0"
       - "1"
   zookeeper:
-    charm: "cs:xenial/zookeeper-37"
+    charm: "cs:xenial/zookeeper-40"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:

--- a/bigtop-deploy/juju/spark-processing/bundle.yaml
+++ b/bigtop-deploy/juju/spark-processing/bundle.yaml
@@ -5,7 +5,7 @@ description: >
   from the spark-shell. It will run on 6 machines in your cloud.
 services:
   spark:
-    charm: "cs:xenial/spark-59"
+    charm: "cs:xenial/spark-60"
     constraints: "mem=7G root-disk=32G"
     num_units: 2
     options:
@@ -18,7 +18,7 @@ services:
       - "0"
       - "1"
   zookeeper:
-    charm: "cs:xenial/zookeeper-40"
+    charm: "cs:xenial/zookeeper-42"
     constraints: "mem=3G root-disk=32G"
     num_units: 3
     annotations:

--- a/bigtop-packages/src/charm/kafka/layer-kafka/README.md
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/README.md
@@ -21,7 +21,7 @@ Software Foundation written in Scala. The project aims to provide a unified,
 high-throughput, low-latency platform for handling real-time data feeds. Learn
 more at [kafka.apache.org][].
 
-This charm deploys version 0.10.1 of the Kafka component from
+This charm deploys version 0.10.1.1 of the Kafka component from
 [Apache Bigtop][].
 
 [kafka.apache.org]: http://kafka.apache.org/

--- a/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
@@ -1,12 +1,11 @@
 options:
   bigtop_version:
     type: string
-    default: '1.2.1'
+    default: 'master'
     description: |
-        Apache Bigtop release version. The default, '1.2.1' will use the
-        current GA release for all hiera data, puppet recipes,
-        and installable packages. Set this to 'master' to use the latest
-        upstream bits.
+        Apache Bigtop release version. The default, 'master' will use the
+        upsteam bits for all hiera data, puppet recipes, and installable
+        packages.
   network_interface:
     default: ""
     type: string

--- a/bigtop-packages/src/charm/kafka/layer-kafka/metadata.yaml
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/metadata.yaml
@@ -4,7 +4,7 @@ maintainer: Juju Big Data <bigdata@lists.ubuntu.com>
 description: >
   Kafka is a high-performance, scalable, distributed messaging system.
 
-  This charm provides version 0.10.1 of the Kafka application from Apache
+  This charm provides version 0.10.1.1 of the Kafka application from Apache
   Bigtop.
 tags: []
 provides:

--- a/bigtop-packages/src/charm/mahout/layer-mahout/README.md
+++ b/bigtop-packages/src/charm/mahout/layer-mahout/README.md
@@ -20,7 +20,7 @@ The Apache Mahout project's goal is to build an environment for quickly
 creating scalable, performant machine learning applications. Learn more at
 [mahout.apache.org][].
 
-This charm deploys version 0.12.2 of the Mahout component from
+This charm deploys version 0.13.0 of the Mahout component from
 [Apache Bigtop][].
 
 [mahout.apache.org]: http://mahout.apache.org/

--- a/bigtop-packages/src/charm/mahout/layer-mahout/metadata.yaml
+++ b/bigtop-packages/src/charm/mahout/layer-mahout/metadata.yaml
@@ -5,7 +5,7 @@ description: >
   The Apache Mahout project's goal is to build an environment for quickly
   creating scalable, performant machine learning applications.
 
-  This charm provides version 0.12.2 of the Mahout application from Apache
+  This charm provides version 0.13.0 of the Mahout application from Apache
   Bigtop.
 tags: []
 subordinate: true

--- a/bigtop-packages/src/charm/spark/layer-spark/README.md
+++ b/bigtop-packages/src/charm/spark/layer-spark/README.md
@@ -19,7 +19,7 @@
 Apache Spark is a fast and general purpose engine for large-scale data
 processing. Learn more at [spark.apache.org][].
 
-This charm deploys version 2.1.0 of the Spark component from [Apache Bigtop][].
+This charm deploys version 2.1.1 of the Spark component from [Apache Bigtop][].
 
 [spark.apache.org]: http://spark.apache.org/
 [Apache Bigtop]: http://bigtop.apache.org/

--- a/bigtop-packages/src/charm/spark/layer-spark/metadata.yaml
+++ b/bigtop-packages/src/charm/spark/layer-spark/metadata.yaml
@@ -4,7 +4,7 @@ maintainer: Juju Big Data <bigdata@lists.ubuntu.com>
 description: >
   Apache Spark is a fast and general engine for large-scale data processing.
 
-  This charm provides version 2.1.0 of the Spark application from Apache Bigtop.
+  This charm provides version 2.1.1 of the Spark application from Apache Bigtop.
 tags: ["analytics"]
 resources:
   sample-data:

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/README.md
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/README.md
@@ -20,7 +20,7 @@ Apache Zeppelin is a web-based notebook that enables interactive data analytics.
 It allows for beautiful data-driven, interactive, and collaborative documents
 with SQL, Scala and more. Learn more at [zeppelin.apache.org][].
 
-This charm deploys version 0.7.0 of the Zeppelin component from
+This charm deploys version 0.7.2 of the Zeppelin component from
 [Apache Bigtop][].
 
 [zeppelin.apache.org]: http://zeppelin.apache.org/

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/metadata.yaml
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/metadata.yaml
@@ -6,7 +6,7 @@ description: >
   analytics. You can make beautiful data-driven, interactive, and collaborative
   documents with SQL, Scala and more.
 
-  This charm provides version 0.7.0 of the Zeppelin application from Apache
+  This charm provides version 0.7.2 of the Zeppelin application from Apache
   Bigtop.
 tags: ["analytics"]
 provides:


### PR DESCRIPTION
Charms were refreshed back when 1.2.1 was released, but the bundle revisions and READMEs in the upstream source were not updated.  This PR fixes that.