### PR TITLE
BIGTOP-3013: remove bigtop_version override for kafka

### DIFF
--- a/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
@@ -1,11 +1,4 @@
 options:
-  bigtop_version:
-    type: string
-    default: 'master'
-    description: |
-        Apache Bigtop release version. The default, 'master' will use the
-        upsteam bits for all hiera data, puppet recipes, and installable
-        packages.
   network_interface:
     default: ""
     type: string


### PR DESCRIPTION
Since kafka is no longer available in the bigtop repos, we need to
install it from a CI repo. This should be a 1.2.1 repo, not master.
Remove the bigtop_version override from config.yaml to ensure
1.2.1 is used.

This will coincide with a PR to layer-apache-bigtop-base that handles
repo_url construction specifically for kafka.