### PR TITLE
BIGTOP-3015: hadoop-spark bundle correction

### DIFF
--- a/bigtop-deploy/juju/hadoop-spark/README.md
+++ b/bigtop-deploy/juju/hadoop-spark/README.md
@@ -48,14 +48,12 @@ follows:
   * Slave (DataNode and NodeManager) v2.7.3
     * 3 separate units
   * Spark (Driver in yarn-client mode) v2.1.1
-  * Client (Hadoop endpoint)
-    * Colocated on the Spark unit
   * Plugin (Facilitates communication with the Hadoop cluster)
-    * Colocated on the Spark/Client unit
+    * Colocated on the Spark unit
   * Ganglia (Web interface for monitoring cluster metrics)
-    * Colocated on the Spark/Client unit
+    * Colocated on the Spark unit
   * Rsyslog (Aggregate cluster syslog events in a single location)
-    * Colocated on the Spark/Client unit
+    * Colocated on the Spark unit
 
 Deploying this bundle results in a fully configured Apache Bigtop
 cluster on any supported cloud, which can be scaled to meet workload

--- a/bigtop-deploy/juju/hadoop-spark/bundle-local.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle-local.yaml
@@ -38,15 +38,6 @@ services:
     annotations:
       gui-x: "1000"
       gui-y: "400"
-  client:
-    charm: "cs:xenial/hadoop-client-9"
-    constraints: "mem=7G root-disk=32G"
-    num_units: 1
-    annotations:
-      gui-x: "1250"
-      gui-y: "400"
-    to:
-      - "4"
   spark:
     charm: "/home/ubuntu/charms/xenial/spark"
     constraints: "mem=7G root-disk=32G"
@@ -91,7 +82,6 @@ relations:
   - [plugin, namenode]
   - [plugin, resourcemanager]
   - [spark, plugin]
-  - [client, plugin]
   - ["ganglia-node:juju-info", "namenode:juju-info"]
   - ["ganglia-node:juju-info", "resourcemanager:juju-info"]
   - ["ganglia-node:juju-info", "slave:juju-info"]

--- a/bigtop-deploy/juju/hadoop-spark/bundle.yaml
+++ b/bigtop-deploy/juju/hadoop-spark/bundle.yaml
@@ -38,15 +38,6 @@ services:
     annotations:
       gui-x: "1000"
       gui-y: "400"
-  client:
-    charm: "cs:xenial/hadoop-client-9"
-    constraints: "mem=7G root-disk=32G"
-    num_units: 1
-    annotations:
-      gui-x: "1250"
-      gui-y: "400"
-    to:
-      - "4"
   spark:
     charm: "cs:xenial/spark-60"
     constraints: "mem=7G root-disk=32G"
@@ -91,7 +82,6 @@ relations:
   - [plugin, namenode]
   - [plugin, resourcemanager]
   - [spark, plugin]
-  - [client, plugin]
   - ["ganglia-node:juju-info", "namenode:juju-info"]
   - ["ganglia-node:juju-info", "resourcemanager:juju-info"]
   - ["ganglia-node:juju-info", "slave:juju-info"]

--- a/bigtop-deploy/juju/hadoop-spark/tests/01-bundle.py
+++ b/bigtop-deploy/juju/hadoop-spark/tests/01-bundle.py
@@ -48,8 +48,7 @@ class TestBundle(unittest.TestCase):
         cls.d.setup(timeout=3600)
 
         # we need units reporting ready before we attempt our smoke tests
-        cls.d.sentry.wait_for_messages({'client': re.compile('ready'),
-                                        'namenode': re.compile('ready'),
+        cls.d.sentry.wait_for_messages({'namenode': re.compile('ready'),
                                         'resourcemanager': re.compile('ready'),
                                         'slave': re.compile('ready'),
                                         'spark': re.compile('ready'),


### PR DESCRIPTION
This change removes the "hadoop-plugin" charm from the "hadoop-spark" bundles and tests as it isn't needed in the bundle.

Fixes: https://issues.apache.org/jira/browse/BIGTOP-3015