### PR TITLE
BIGTOP-3014: juju: use charm-env for shebangs

### DIFF
--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/actions/smoke-test
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/actions/smoke-test
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-namenode/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-plugin/actions/smoke-test
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-plugin/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-plugin/actions/smoke-test
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-plugin/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/mrbench
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/mrbench
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/nnbench
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/nnbench
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/parseBenchmark.py
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/parseBenchmark.py
@@ -1,3 +1,5 @@
+#!/usr/local/sbin/charm-env python3
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/parseBenchmark.py
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/parseBenchmark.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/smoke-test
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/smoke-test
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/teragen
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/teragen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/terasort
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/terasort
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/testdfsio
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-resourcemanager/actions/testdfsio
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-slave/actions/smoke-test
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-slave/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hadoop/layer-hadoop-slave/actions/smoke-test
+++ b/bigtop-packages/src/charm/hadoop/layer-hadoop-slave/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.layer.apache_bigtop_base import Bigtop  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.layer.apache_bigtop_base import Bigtop
+from charms.reactive import is_state
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/perf-test
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/perf-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/restart
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/restart
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/restart
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/restart
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
-from charms.layer.bigtop_hbase import HBase  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.reactive import is_state
+from charms.layer.bigtop_hbase import HBase
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/smoke-test
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/start
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/start
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/start
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
-from charms.layer.bigtop_hbase import HBase  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.reactive import is_state
+from charms.layer.bigtop_hbase import HBase
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/start-hbase-master
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/start-hbase-master
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/start-hbase-master
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/start-hbase-master
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/start-hbase-regionserver
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/start-hbase-regionserver
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/start-hbase-regionserver
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/start-hbase-regionserver
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
-from charms.layer.bigtop_hbase import HBase  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.reactive import is_state
+from charms.layer.bigtop_hbase import HBase
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop-hbase-master
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop-hbase-master
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop-hbase-master
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop-hbase-master
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop-hbase-regionserver
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop-hbase-regionserver
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop-hbase-regionserver
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/actions/stop-hbase-regionserver
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hive/layer-hive/actions/restart
+++ b/bigtop-packages/src/charm/hive/layer-hive/actions/restart
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hive/layer-hive/actions/restart
+++ b/bigtop-packages/src/charm/hive/layer-hive/actions/restart
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.layer.bigtop_hive import Hive  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.layer.bigtop_hive import Hive
+from charms.reactive import is_state
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/hive/layer-hive/actions/smoke-test
+++ b/bigtop-packages/src/charm/hive/layer-hive/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/hive/layer-hive/actions/smoke-test
+++ b/bigtop-packages/src/charm/hive/layer-hive/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.layer.apache_bigtop_base import Bigtop  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.layer.apache_bigtop_base import Bigtop
+from charms.reactive import is_state
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/create-topic
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/create-topic
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/create-topic
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/create-topic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/list-topics
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/list-topics
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/list-topics
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/list-topics
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/list-zks
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/list-zks
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/list-zks
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/list-zks
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/read-topic
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/read-topic
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/read-topic
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/read-topic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -17,13 +17,11 @@
 
 import kafkautils
 import subprocess
-import sys
-sys.path.append('lib')  # Add our helpers to our path.
 
-from charmhelpers.core import hookenv, host  # noqa: E402
-from charms.layer.apache_bigtop_base import get_layer_opts  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
-from jujubigdata import utils  # noqa: E402
+from charmhelpers.core import hookenv, host
+from charms.layer.apache_bigtop_base import get_layer_opts
+from charms.reactive import is_state
+from jujubigdata import utils
 
 
 if not is_state('kafka.started'):

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/smoke-test
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/smoke-test
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/write-topic
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/write-topic
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/kafka/layer-kafka/actions/write-topic
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/actions/write-topic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -17,13 +17,11 @@
 
 import kafkautils
 import subprocess
-import sys
-sys.path.append('lib')  # Add our helpers to our path.
 
-from charmhelpers.core import hookenv, host  # noqa: E402
-from charms.layer.apache_bigtop_base import get_layer_opts  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
-from jujubigdata import utils  # noqa: E402
+from charmhelpers.core import hookenv, host
+from charms.layer.apache_bigtop_base import get_layer_opts
+from charms.reactive import is_state
+from jujubigdata import utils
 
 
 if not is_state('kafka.started'):

--- a/bigtop-packages/src/charm/mahout/layer-mahout/actions/smoke-test
+++ b/bigtop-packages/src/charm/mahout/layer-mahout/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/pig/layer-pig/actions/smoke-test
+++ b/bigtop-packages/src/charm/pig/layer-pig/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/pig/layer-pig/actions/smoke-test
+++ b/bigtop-packages/src/charm/pig/layer-pig/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,13 +16,12 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.layer.apache_bigtop_base import Bigtop  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
-from jujubigdata.utils import run_as  # noqa: E402
-from path import Path  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.layer.apache_bigtop_base import Bigtop
+from charms.reactive import is_state
+from jujubigdata.utils import run_as
+from path import Path
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/list-jobs
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/list-jobs
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/pagerank
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/reinstall
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/reinstall
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/reinstall
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/reinstall
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/remove-job
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/remove-job
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/restart-spark-job-history-server
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/restart-spark-job-history-server
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/restart-spark-job-history-server
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/restart-spark-job-history-server
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/spark-submit
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/spark-submit
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/sparkbench
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/sparkbench
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/local/sbin/charm-env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/sparkpi
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/sparkpi
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/sparkpi
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/sparkpi
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/start-spark-job-history-server
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/start-spark-job-history-server
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/start-spark-job-history-server
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/start-spark-job-history-server
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/stop-spark-job-history-server
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/stop-spark-job-history-server
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/spark/layer-spark/actions/stop-spark-job-history-server
+++ b/bigtop-packages/src/charm/spark/layer-spark/actions/stop-spark-job-history-server
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/reinstall
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/reinstall
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/reinstall
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/reinstall
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv, unitdata  # noqa: E402
-from charms.layer.apache_bigtop_base import Bigtop, get_package_version  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
+from charmhelpers.core import hookenv, unitdata
+from charms.layer.apache_bigtop_base import Bigtop, get_package_version
+from charms.reactive import is_state
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/restart
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/restart
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/restart
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/restart
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
-from charms.layer.bigtop_zeppelin import Zeppelin  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.reactive import is_state
+from charms.layer.bigtop_zeppelin import Zeppelin
 
 
 def fail(msg):

--- a/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/smoke-test
+++ b/bigtop-packages/src/charm/zeppelin/layer-zeppelin/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/actions/restart
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/actions/restart
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/actions/restart
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/actions/restart
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')  # Add our helpers to our path.
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.layer.bigtop_zookeeper import Zookeeper  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.layer.bigtop_zookeeper import Zookeeper
+from charms.reactive import is_state
 
 
 def main():

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/actions/smoke-test
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/local/sbin/charm-env python
+#!/usr/local/sbin/charm-env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/actions/smoke-test
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/actions/smoke-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +16,10 @@
 # limitations under the License.
 
 import sys
-sys.path.append('lib')
 
-from charmhelpers.core import hookenv  # noqa: E402
-from charms.layer.apache_bigtop_base import Bigtop  # noqa: E402
-from charms.reactive import is_state  # noqa: E402
+from charmhelpers.core import hookenv
+from charms.layer.apache_bigtop_base import Bigtop
+from charms.reactive import is_state
 
 
 def fail(msg):


### PR DESCRIPTION
See [BIGTOP-3014](https://issues.apache.org/jira/browse/BIGTOP-3014) for the meats.

Lots of files changed here, but it's just the shebangs and a few simplifications (no longer need to `sys.path.append('lib')`).  Tested well on Mar 13:

http://bigtop.charm.qa/