### PR TITLE
BIGTOP-3018:detect-javahome script has a typo in variable name

### DIFF
--- a/bigtop-packages/src/common/bigtop-utils/bigtop-detect-javahome
+++ b/bigtop-packages/src/common/bigtop-utils/bigtop-detect-javahome
@@ -31,7 +31,7 @@ JAVA8_HOME_CANDIDATES=(
     '/usr/lib/jvm/java-1.8.0-oracle'
 )
 
-OPENJAVA8_HOME__CANDIDATES=(
+OPENJAVA8_HOME_CANDIDATES=(
     '/usr/lib/jvm/java-1.8.0-openjdk-amd64'
     '/usr/lib/jvm/java-1.8.0-openjdk-ppc64el'
     '/usr/lib/jvm/java-1.8.0-openjdk'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3018