### PR TITLE
BIGTOP-3024: Zeppelin build is failed after Spark is bumpped to 2.2.1

### DIFF
--- a/bigtop-packages/src/common/zeppelin/do-component-build
+++ b/bigtop-packages/src/common/zeppelin/do-component-build
@@ -45,6 +45,8 @@ fi
 
 export MAVEN_OPTS="-Xmx1500m -Xms1500m"
 
+# change spark src download url to apache
+sed -i "s/http\:\/\/d3kbcqa49mib13\.cloudfront\.net/https\:\/\/www\.apache\.org\/dist\/spark\/spark-\$\{spark\.version\}/g" spark-dependencies/pom.xml
 mvn $BUILD_OPTS clean package
 
 mkdir -p build/dist


### PR DESCRIPTION
After Spark is bumpped to 2.2.1 by BIGTOP-2991, zeppelin build is failed.
The root cause is zeppelin now try to download spark-2.2.1.tgz and
spark-2.2.1-bin-without-hadoop.tgz from http://d3kbcqa49mib13.cloudfront.net.
This site currently doesn't offer spark 2.2.1 related packages.
So the download link need to be updated to apache site:
https://www.apache.org/dist/spark/

Change-Id: Icea4dc0ac6d65104c7a071e7b044161423dffec5
Signed-off-by: Jun He <jun.he@linaro.org>