### PR TITLE
BIGTOP-3031: Auto find latest maven dist

### DIFF
--- a/bigtop_toolchain/lib/puppet/parser/functions/latest_maven_binary.rb
+++ b/bigtop_toolchain/lib/puppet/parser/functions/latest_maven_binary.rb
@@ -13,26 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class bigtop_toolchain::maven {
-  $mvnversion = latest_maven_binary("3.5.[0-9]*")
-  $mvn = "apache-maven-$mvnversion"
-
-  $apache_prefix = nearest_apache_mirror()
-
-  exec {"/usr/bin/wget $apache_prefix/maven/maven-3/$mvnversion/binaries/$mvn-bin.tar.gz":
-    cwd     => "/usr/src",
-    unless  => "/usr/bin/test -f /usr/src/$mvn-bin.tar.gz",
-  }
-
-  exec {"/bin/tar xvzf /usr/src/$mvn-bin.tar.gz":
-    cwd         => '/usr/local',
-    creates     => "/usr/local/$mvn",
-    require     => Exec["/usr/bin/wget $apache_prefix/maven/maven-3/$mvnversion/binaries/$mvn-bin.tar.gz"],
-  }
-  
-  file {'/usr/local/maven':
-    ensure  => link,
-    target  => "/usr/local/$mvn",
-    require => Exec["/bin/tar xvzf /usr/src/$mvn-bin.tar.gz"],
-  }
-}
+module Puppet::Parser::Functions
+    newfunction(:latest_maven_binary, :type => :rvalue) do |args|
+        versionmask=args[0]
+        # We are using main mirror here because can't be sure about Apache Server config on every mirror. It could be Nginx, btw.
+        %x(curl --stderr /dev/null 'https://www.apache.org/dist/maven/maven-3/?F=0&V=1' | grep -o '<li>.*href="#{versionmask}/"' | grep -o '#{versionmask}').chomp
+    end
+end


### PR DESCRIPTION
Similar to ant, maven dist binaries may get updated from time to time on
Apache mirrors. A better way is to auto find latest maven-3 binary release.
Used the same way in BIGTOP-3022.

Change-Id: I0384a656701f62bd7ef7fc40cd6ab85533ba49fc
Signed-off-by: Jun He <jun.he@linaro.org>