### PR TITLE
BIGTOP-3030: Remove phantomjs dependecy in build

### DIFF
--- a/bigtop-packages/src/common/ambari/patch2-AMBARI-phantomjs.diff
+++ b/bigtop-packages/src/common/ambari/patch2-AMBARI-phantomjs.diff
@@ -1,0 +1,36 @@
+diff --git a/ambari-admin/src/main/resources/ui/admin-web/package.json b/ambari-admin/src/main/resources/ui/admin-web/package.json
+index efcd9d4..785e674 100644
+--- a/ambari-admin/src/main/resources/ui/admin-web/package.json
++++ b/ambari-admin/src/main/resources/ui/admin-web/package.json
+@@ -23,8 +23,6 @@
+     "karma-chrome-launcher": "0.1.4",
+     "karma-jasmine": "0.1.5",
+     "karma-ng-html2js-preprocessor": "^0.1.0",
+-    "karma-phantomjs-launcher": "0.1",
+-    "phantomjs": "1.9.20",
+     "protractor": "1.0.0"
+   },
+   "scripts": {
+diff --git a/ambari-web/package.json b/ambari-web/package.json
+index 92ac968..7dd43f4 100644
+--- a/ambari-web/package.json
++++ b/ambari-web/package.json
+@@ -19,10 +19,7 @@
+     "cssstyle": "0.2.3"
+   },
+   "devDependencies": {
+-    "phantomjs": "~2.1.0",
+     "mocha":"2.5.3",
+-    "mocha-phantomjs": "~4.1.0",
+-    "mocha-phantomjs-core": "~2.1.0",
+     "chai":"~3.5.0",
+     "sinon":"=1.7.3",
+     "sinon-chai":"~2.8.0",
+@@ -31,7 +28,6 @@
+     "karma-mocha": "0.1.1",
+     "karma-chai": "~0.1.0",
+     "karma-sinon": "~1.0.2",
+-    "karma-phantomjs-launcher": "1.0.2",
+     "karma-coverage": "~0.2.0",
+     "karma-commonjs-require": "~0.0.1",
+     "karma-ember-precompile-brunch": "^0.0.1"


### PR DESCRIPTION
Upstream Ambari depends on phantomjs to build. And at present phantomjs provides
only x86* prebuilt binaries. This leads to build failure on non-x86 platforms.

As phantomjs is used for test, no runtime dep, it can be removed from build to
solve this failure.

Change-Id: I06b4fa48705024bb5de9a9167c337db546abbc36
Signed-off-by: Jun He <jun.he@linaro.org>