### PR TITLE
BIGTOP-2101: ignite-hadoop contains an arch-dependent shared lib

### DIFF
--- a/bigtop-packages/src/common/ignite-hadoop/do-component-build
+++ b/bigtop-packages/src/common/ignite-hadoop/do-component-build
@@ -21,4 +21,19 @@ set -ex
 export MAVEN_OPTS="-Xmx512M"
 
 sed -i '/asm-all/{n;s/4.2/5.0.2/}' modules/hadoop/pom.xml
+
+cd ipc/shmem
+# patch and build it
+sed -i 's/\&ipcData->closed\,/(char *)\&ipcData->closed\,/' igniteshmem/org_apache_ignite_internal_util_ipc_shmem_IpcSharedMemoryUtils.cpp
+./configure && make
+# create layout
+mkdir -p META-INF/native/linux64
+cp ./igniteshmem/.libs/libigniteshmem.so META-INF/native/linux64/libigniteshmem.so
+# pack and install
+jar cf ignite-shmem-1.0.0.jar META-INF
+mvn install:install-file -Dfile=ignite-shmem-1.0.0.jar -DgroupId=org.gridgain -DartifactId=ignite-shmem -Dversion=1.0.0 -Dpackaging=jar -DcreateChecksum=true
+# clean up
+rm -rf META-INF
+cd -
+
 mvn clean install -DskipTests -Dhadoop.version=$HADOOP_VERSION -Dspark.version=$SPARK_VERSION -Dignite.edition=hadoop


### PR DESCRIPTION
ignite-shmem contains x86 binary only. A build step is added to create
arch specific library for non-x86 platforms.

Change-Id: I9f4f03ec61250da21c13a915dc7efd5303e95d5b
Signed-off-by: Jun He <jun.he@linaro.org>