### PR TITLE
BIGTOP-3033: Spark build on OpenSUSE is failed

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -107,7 +107,8 @@ class bigtop_toolchain::packages {
         "libevent-devel",
         "bison",
         "flex",
-        "libffi48-devel"
+        "libffi48-devel",
+        "texlive-latex-bin-bin"
       ]
       # fix package dependencies: BIGTOP-2120 and BIGTOP-2152 and BIGTOP-2471
       exec { '/usr/bin/zypper -n install  --force-resolution krb5 libopenssl-devel':


### PR DESCRIPTION
Spark building on OpenSUSE is failed as pdflatex is missing.
Add package to install list.

Change-Id: Ib3914ab05fd37418a5aa798fa37b88cb54e4079e
Signed-off-by: Jun He <jun.he@linaro.org>