### PR TITLE
BIGTOP-3042: HDFS TestHDFSQuota doesn't match Hadoop's definition

### DIFF
--- a/bigtop-tests/test-artifacts/hadoop/src/main/groovy/org/apache/bigtop/itest/hadoop/hdfs/TestHDFSQuota.groovy
+++ b/bigtop-tests/test-artifacts/hadoop/src/main/groovy/org/apache/bigtop/itest/hadoop/hdfs/TestHDFSQuota.groovy
@@ -136,8 +136,6 @@ public class TestHDFSQuota {
     assertTrue("setSpaceQuota should not have worked", shHDFS.getRet() != 0);
     shHDFS.exec("hadoop dfsadmin -setQuota 0 $testQuotaFolder1");
     assertTrue("setQuota should not have worked", shHDFS.getRet() != 0);
-    shHDFS.exec("hadoop dfsadmin -setSpaceQuota 0 $testQuotaFolder1");
-    assertTrue("setSpaceQuota should not have worked", shHDFS.getRet() != 0);
     shHDFS.exec("hadoop dfsadmin -setQuota $LARGE $testQuotaFolder1");
     assertTrue("setQuota failed", shHDFS.getRet() == 0);
     shHDFS.exec("hadoop dfsadmin -setSpaceQuota $LARGE $testQuotaFolder1");


### PR DESCRIPTION
The smoke test case for HDFS, TestHDFSQuota:testInputValues, it asserts fail
on setSpaceQuota to 0, while this doesn't match Hadoop's definition for SpaceQuota.
This produces false failure, and should be removed from testcases.

Change-Id: I5e18a15e9b45a1057174717a37008b3c92bab0e9
Signed-off-by: Jun He <jun.he@linaro.org>