### PR TITLE
BIGTOP-2818: Ambari downloads jdk

### DIFF
--- a/bigtop-deploy/puppet/modules/ambari/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ambari/manifests/init.pp
@@ -35,8 +35,8 @@ class ambari {
 
     exec {
         "server setup":
-           command => "/usr/sbin/ambari-server setup -s",
-           require => [ Package["ambari-server"], Exec["mpack install"] ]
+           command => "/usr/sbin/ambari-server setup -j $(readlink -f /usr/bin/java | sed 's/jre\/bin\/java//') -s",
+           require => [ Package["ambari-server"], Package["jdk"], Exec["mpack install"] ]
     }
 
     service { "ambari-server":


### PR DESCRIPTION
Ambari server uses jdk package from Hortonworks by default. This package
is not aligned with distro provided, and only x86 is supported.
Update Ambari server deploy script to use system JDK.

Change-Id: If062a9a4d689ed31276a944e68254b2fda9a264e
Signed-off-by: Jun He <jun.he@linaro.org>