### PR TITLE
BIGTOP-3035: Provisioner failed because init is missed in Debian-9

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -32,7 +32,7 @@ case ${ID}-${VERSION_ID} in
         ;;
     debian-9*)
         apt-get update
-        apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib
+        apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv
          ;;
     opensuse-42.3)
         zypper --gpg-auto-import-keys install -y curl sudo unzip wget puppet suse-release ca-certificates-mozilla net-tools tar


### PR DESCRIPTION
In provisioner/docker/docker-compose.yml, /sbin/init is used as entrypoint.
But this cmd is missed on Debian-9, which causes smoke test/provisioner
failure.

Change-Id: I4c3aac74f8299b23966ea8a5c30a1513c734f889
Signed-off-by: Jun He <jun.he@linaro.org>