### PR TITLE
BIGTOP-3053: Tez failed to build due to bower version is deprecated

### DIFF
--- a/bigtop-packages/src/common/tez/patch0-TEZ-3959.diff
+++ b/bigtop-packages/src/common/tez/patch0-TEZ-3959.diff
@@ -1,0 +1,166 @@
+From a39f02e4073af4ee8d6b6a7bcb06198a10aa5aac Mon Sep 17 00:00:00 2001
+From: Sreenath <ursreenath@gmail.com>
+Date: Wed, 27 Jun 2018 15:32:03 +0530
+Subject: [PATCH 01/11] TEZ-3959. HTTP 502 for bower install (Harish Jaiprakash
+ via Sree)
+
+---
+ tez-ui/src/main/webapp/package.json |  2 +-
+ tez-ui/src/main/webapp/yarn.lock    | 51 +++++++++++------------------
+ 2 files changed, 20 insertions(+), 33 deletions(-)
+
+diff --git a/tez-ui/src/main/webapp/package.json b/tez-ui/src/main/webapp/package.json
+index 0d2a46ffe..a14d21583 100644
+--- a/tez-ui/src/main/webapp/package.json
++++ b/tez-ui/src/main/webapp/package.json
+@@ -25,7 +25,7 @@
+     "node": ">= 0.10.0"
+   },
+   "devDependencies": {
+-    "bower": "1.7.7",
++    "bower": "1.8.4",
+     "broccoli-asset-rev": "2.4.2",
+     "broccoli-funnel": "1.0.1",
+     "broccoli-merge-trees": "1.1.1",
+diff --git a/tez-ui/src/main/webapp/yarn.lock b/tez-ui/src/main/webapp/yarn.lock
+index 866677b01..fbcdd2136 100644
+--- a/tez-ui/src/main/webapp/yarn.lock
++++ b/tez-ui/src/main/webapp/yarn.lock
+@@ -47,10 +47,6 @@ amdefine@>=0.0.4:
+   version "1.0.1"
+   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+ 
+-ansi-regex@*, ansi-regex@^2.0.0:
+-  version "2.1.1"
+-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+-
+ ansi-regex@^0.2.0, ansi-regex@^0.2.1:
+   version "0.2.1"
+   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
+@@ -59,6 +55,10 @@ ansi-regex@^1.0.0:
+   version "1.1.1"
+   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-1.1.1.tgz#41c847194646375e6a1a5d10c3ca054ef9fc980d"
+ 
++ansi-regex@^2.0.0:
++  version "2.1.1"
++  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
++
+ ansi-styles@^1.1.0:
+   version "1.1.0"
+   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.1.0.tgz#eaecbf66cd706882760b2f4691582b8f55d7a7de"
+@@ -187,10 +187,6 @@ ast-types@0.8.12:
+   version "0.8.12"
+   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
+ 
+-ast-types@0.8.15:
+-  version "0.8.15"
+-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
+-
+ ast-types@0.9.6:
+   version "0.9.6"
+   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+@@ -500,7 +496,11 @@ bower-shrinkwrap-resolver-ext@^0.1.0:
+     semver "^5.3.0"
+     string.prototype.endswith "^0.2.0"
+ 
+-bower@1.7.7, bower@^1.3.12:
++bower@1.8.4:
++  version "1.8.4"
++  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.4.tgz#e7876a076deb8137f7d06525dc5e8c66db82f28a"
++
++bower@^1.3.12:
+   version "1.7.7"
+   resolved "https://registry.yarnpkg.com/bower/-/bower-1.7.7.tgz#2fd7ff3ebdcba5a8ffcd84c397c8fdfe9f825f92"
+ 
+@@ -1759,7 +1759,7 @@ ember-truth-helpers@1.3.0:
+   version "1.3.0"
+   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.3.0.tgz#6ed9f83ce9a49f52bb416d55e227426339a64c60"
+   dependencies:
+-    ember-cli-babel "^5.1.5"
++    ember-cli-babel "^5.1.6"
+ 
+ ember-wormhole@^0.3.4:
+   version "0.3.6"
+@@ -2329,7 +2329,7 @@ glob-parent@^2.0.0:
+     minimatch "^2.0.1"
+     once "^1.3.0"
+ 
+-glob@5.0.13, glob@^5.0.10, glob@~5.0.0:
++glob@5.0.13, glob@^5.0.10:
+   version "5.0.13"
+   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.13.tgz#0b6ffc3ac64eb90669f723a00a0ebb7281b33f8f"
+   dependencies:
+@@ -2339,7 +2339,7 @@ glob@5.0.13, glob@^5.0.10, glob@~5.0.0:
+     once "^1.3.0"
+     path-is-absolute "^1.0.0"
+ 
+-glob@5.x, glob@^5.0.15, glob@~5.0.15:
++glob@5.x, glob@^5.0.15, glob@~5.0.0, glob@~5.0.15:
+   version "5.0.15"
+   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+   dependencies:
+@@ -4020,7 +4020,7 @@ realize-package-specifier@~3.0.1:
+     dezalgo "^1.0.1"
+     npm-package-arg "^4.1.1"
+ 
+-recast@0.10.33:
++recast@0.10.33, recast@^0.10.10:
+   version "0.10.33"
+   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
+   dependencies:
+@@ -4029,15 +4029,6 @@ recast@0.10.33:
+     private "~0.1.5"
+     source-map "~0.5.0"
+ 
+-recast@^0.10.10:
+-  version "0.10.43"
+-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
+-  dependencies:
+-    ast-types "0.8.15"
+-    esprima-fb "~15001.1001.0-dev-harmony-fb"
+-    private "~0.1.5"
+-    source-map "~0.5.0"
+-
+ recast@^0.11.17, recast@^0.11.3:
+   version "0.11.23"
+   resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+@@ -4424,10 +4415,6 @@ spdx-expression-parse@~1.0.0:
+   version "1.0.4"
+   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+ 
+-spdx-license-ids@*:
+-  version "2.0.1"
+-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz#02017bcc3534ee4ffef6d58d20e7d3e9a1c3c8ec"
+-
+ spdx-license-ids@^1.0.0, spdx-license-ids@^1.0.2:
+   version "1.2.2"
+   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+@@ -4489,12 +4476,6 @@ stringstream@~0.0.4:
+   version "0.0.5"
+   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
+ 
+-strip-ansi@*, strip-ansi@^3.0.0:
+-  version "3.0.1"
+-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+-  dependencies:
+-    ansi-regex "^2.0.0"
+-
+ strip-ansi@^0.3.0:
+   version "0.3.0"
+   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.3.0.tgz#25f48ea22ca79187f3174a4db8759347bb126220"
+@@ -4507,6 +4488,12 @@ strip-ansi@^2.0.1:
+   dependencies:
+     ansi-regex "^1.0.0"
+ 
++strip-ansi@^3.0.0:
++  version "3.0.1"
++  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
++  dependencies:
++    ansi-regex "^2.0.0"
++
+ strip-ansi@~0.1.0:
+   version "0.1.1"
+   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+-- 
+2.17.1
+


### PR DESCRIPTION
Tez building failed due to the bower version is deprecated. Tez upstream uses
a workaround to upgrade it to 1.8.4.

Change-Id: Ib8ffa59fb4fdfc23599164fda7cbe8af30c44df7
Signed-off-by: Jun He <jun.he@linaro.org>