### PR TITLE
BIGTOP-3054: Missing Spark archive caused Zeppelin build failure

### DIFF
--- a/bigtop-packages/src/common/zeppelin/do-component-build
+++ b/bigtop-packages/src/common/zeppelin/do-component-build
@@ -46,7 +46,7 @@ fi
 export MAVEN_OPTS="-Xmx1500m -Xms1500m"
 
 # change spark src download url to apache
-sed -i "s/http\:\/\/d3kbcqa49mib13\.cloudfront\.net/https\:\/\/www\.apache\.org\/dist\/spark\/spark-\$\{spark\.version\}/g" spark-dependencies/pom.xml
+sed -i "s/http\:\/\/d3kbcqa49mib13\.cloudfront\.net/https\:\/\/archive\.apache\.org\/dist\/spark\/spark-\$\{spark\.version\}/g" spark-dependencies/pom.xml
 mvn $BUILD_OPTS clean package
 
 mkdir -p build/dist


### PR DESCRIPTION
Zeppelin uses Spark-2.2.1 archive defined in bigtop.bom. This archive
is moved from www.apache.org to archive.apache.org.
So update zeppelin build script to point to Apache's archive site.

Change-Id: Ib637c36d3623fd856d50122875a0e65b1cc82723
Signed-off-by: Jun He <jun.he@linaro.org>