### PR TITLE
BIGTOP-3061: Fix ClassNotFound issue for crunch build

### DIFF
--- a/bigtop-packages/src/common/crunch/patch0-CRUNCH-671.diff
+++ b/bigtop-packages/src/common/crunch/patch0-CRUNCH-671.diff
@@ -1,0 +1,36 @@
+From 923ea820a0d2285569e92da14c5b35e675589600 Mon Sep 17 00:00:00 2001
+From: Jun He <jun.he@linaro.org>
+Date: Thu, 9 Aug 2018 05:49:09 +0000
+Subject: [PATCH] CRUNCH-671: Failed to generate reports using "mvn site"
+
+Crunch build failed due to "ClassNotFound" in doxia.
+This is caused by maven-project-info-reports-plugin updated to 3.0.0, depends on
+doxia-site-renderer 1.8 (which has org.apache.maven.doxia.siterenderer.DocumentContent
+this class), while maven-site-plugin:3.3 depends on doxia-site-renderer:1.4 (which
+doesn't have org.apache.maven.doxia.siterenderer.DocumentContent)
+Specify maven-site-plugin to 3.7 can resolve this.
+
+Signed-off-by: Jun He <jun.he@linaro.org>
+---
+ pom.xml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/pom.xml b/pom.xml
+index e3b6d8d..11b87fd 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -839,6 +839,11 @@ under the License.
+           </execution>
+         </executions>
+       </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-site-plugin</artifactId>
++        <version>3.7.1</version>
++      </plugin>
+       </plugins>
+     </pluginManagement>
+   </build>
+-- 
+2.7.4
+


### PR DESCRIPTION
Crunch build failed due to "ClassNotFound" in doxia.
This is caused by maven-project-info-reports-plugin updated to 3.0.0, and rely
on doxia-site-renderer 1.8 (which has org.apache.maven.doxia.siterenderer.DocumentContent
this class), but maven-site-plugin:3.3 rely on doxia-site-renderer:1.4 (which
don't have org.apache.maven.doxia.siterenderer.DocumentContent)
Upgrade maven-site-plugin can resolve this.

Change-Id: I3c2a2bf717fa070b61b4c1788a52874361910dbc
Signed-off-by: Jun He <jun.he@linaro.org>