### PR TITLE
BIGTOP-3059: Bump Ambari to 2.6.1

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -481,7 +481,7 @@ bigtop {
     'ambari' {
       name    = 'ambari'
       relNotes = 'Apache Ambari'
-      version { base = '2.5.2'; pkg = '2.5.2.0'; release = 1 }
+      version { base = '2.6.1'; pkg = '2.6.1.0'; release = 1 }
       tarball { destination = "apache-$name-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}/"


### PR DESCRIPTION
Bump Ambari to 2.6.1 release.

Change-Id: I94e17d70bd78ec1d2ff59e914894ad8b0b3c5cae
Signed-off-by: Jun He <jun.he@linaro.org>