### PR TITLE
BIGTOP-3062: Bump flink to 1.4.2

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -330,7 +330,7 @@ bigtop {
     'flink' {
       name    = 'flink'
       relNotes = 'Apache Flink'
-      version { base = '1.1.3'; pkg = base; release = 1 }
+      version { base = '1.4.2'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
Bump flink to 1.4.2 for Bigtop 1.3 release

Change-Id: Icd527338d6663d7baa7e1a3690667f95c1e12320
Signed-off-by: Yuqi Gu <yuqi.gu@arm.com>