### PR TITLE
BIGTOP-3065: Bump Hadoop to 2.8.4

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -144,7 +144,7 @@ bigtop {
     'hadoop' {
       name    = 'hadoop'
       relNotes = 'Apache Hadoop'
-      version { base = '2.8.1'; pkg = base; release = 1 }
+      version { base = '2.8.4'; pkg = base; release = 1 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/common/$name-${version.base}"


### PR DESCRIPTION
Bump to latest release  on 2.8 branch

Change-Id: I58e719ef66174312fd005b0bb0d11711aee69ad0
Signed-off-by: Jun He <jun.he@linaro.org>