### PR TITLE
BIGTOP-3067: Bump Hive to 2.3.3

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -187,7 +187,7 @@ bigtop {
     'hive' {
       name    = 'hive'
       relNotes = 'Apache Hive'
-      version { base = '2.3.2'; pkg = base; release = 1 }
+      version { base = '2.3.3'; pkg = base; release = 1 }
       tarball { destination = "apache-${name}-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}/"


### PR DESCRIPTION
Bump to 2.3.3 for v1.3 release.

Change-Id: I0a2d0ab3d58bcac1aac79db1ebeb1d089f6f435b
Signed-off-by: Jun He <jun.he@linaro.org>