### PR TITLE
BIGTOP-3068: Bump Hama to 0.7.1

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -423,7 +423,7 @@ bigtop {
     'hama' {
       name    = 'hama'
       relNotes = 'Apache Hama'
-      version { base = '0.7.0'; pkg = base; release = 1 }
+      version { base = '0.7.1'; pkg = base; release = 1 }
       tarball { destination = "$name-dist-${version.base}.tar.gz"
                 source      = "$name-dist-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/$name-${version.base}/"


### PR DESCRIPTION
Bump Hama to 0.7.1 for bigtop 1.3 release

Change-Id: I557f36500989e70c4120b43706a19459d0cb4993
Signed-off-by: Yuqi Gu <yuqi.gu@arm.com>