### PR TITLE
BIGTOP-3055: Bump GPDB to 5.10.0

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -472,7 +472,7 @@ bigtop {
     'gpdb' {
       name    = 'gpdb'
       relNotes = 'GreenPlum'
-      version { base = '5.0.0'; pkg = '5.0.0'; release = 1 }
+      version { base = '5.10.0'; pkg = '5.10.0'; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "${version.base}.tar.gz" }
       url     { site = "https://github.com/greenplum-db/gpdb/archive/"


### PR DESCRIPTION
GPDB upstream has rolled out 5.10.0 release. Let's bump to this.

Change-Id: I1bcc96e31c4802d4a5cb87b47218b6cd6b3d4f3e
Signed-off-by: Yuqi Gu <yuqi.gu@arm.com>