### PR TITLE
BIGTOP-3077: OpenSuse-42.3 packages install error

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -108,24 +108,13 @@ class bigtop_toolchain::packages {
         "bison",
         "flex",
         "libffi48-devel",
-        "texlive-latex-bin-bin"
+        "texlive-latex-bin-bin",
+        "libapr1",
+        "libapr1-devel"
       ]
       # fix package dependencies: BIGTOP-2120 and BIGTOP-2152 and BIGTOP-2471
-      exec { '/usr/bin/zypper -n install  --force-resolution krb5 libopenssl-devel':
+      exec { '/usr/bin/zypper -n install  --force-resolution krb5 libopenssl-devel libxml2-devel libxslt-devel boost-devel':
       } -> Package <| |>
-      # fix package libapr1
-      exec { 'suse_12.3_repo':
-        command => '/usr/bin/zypper ar --no-gpgcheck http://download.opensuse.org/distribution/12.3/repo/oss/suse/ libapr1',
-        unless => "/usr/bin/zypper lr | grep -q libapr1",
-      }
-      package { 'libapr1':
-        ensure => '1.4.6',
-        require => [Exec['suse_12.3_repo']]
-      }
-      package { 'libapr1-devel':
-        ensure => '1.4.6',
-        require => [Package['libapr1']]
-      }
     }
     /Amazon/: { $pkgs = [
       "unzip",


### PR DESCRIPTION
Update libapr1 to use distro version. Fixed packages dependency issue
on aarch64.

Change-Id: I043b701b4bd5b89eea7488e21ace939624528310
Signed-off-by: Jun He <jun.he@linaro.org>