### PR TITLE
BIGTOP-3078: ignite-shmem failed to build on ppc64le

### DIFF
--- a/bigtop-packages/src/common/ignite-hadoop/patch0-shmem-config.diff
+++ b/bigtop-packages/src/common/ignite-hadoop/patch0-shmem-config.diff
@@ -1,0 +1,14 @@
+diff --git a/ipc/shmem/config.guess b/ipc/shmem/config.guess
+index 499bfa7..b274825 100755
+--- a/ipc/shmem/config.guess
++++ b/ipc/shmem/config.guess
+@@ -979,6 +979,9 @@ EOF
+     ppc:Linux:*:*)
+ 	echo powerpc-unknown-linux-gnu
+ 	exit ;;
++    ppc64le:Linux:*:*)
++	echo powerpc64le-unknown-linux-gnu
++	exit ;;
+     s390:Linux:*:* | s390x:Linux:*:*)
+ 	echo ${UNAME_MACHINE}-ibm-linux
+ 	exit ;;

--- a/bigtop-packages/src/rpm/ignite-hadoop/SPECS/ignite-hadoop.spec
+++ b/bigtop-packages/src/rpm/ignite-hadoop/SPECS/ignite-hadoop.spec
@@ -86,6 +86,7 @@ Source2: install_ignite.sh
 Source3: ignite-hadoop.svc
 Source4: init.d.tmpl
 Source5: ignite-hadoop.default
+#BIGTOP_PATCH_FILES
 BuildArch: noarch
 ## This package _explicitly_ turns off the auto-discovery of required dependencies
 ## to work around OSGI corner case, added to RPM lately. See BIGTOP-2421 for more info.
@@ -140,6 +141,8 @@ Documentation for Ignite platform
 
 %prep
 %setup -n ignite-hadoop-%{vcs_tag}
+
+#BIGTOP_PATCH_COMMANDS
 
 %build
 bash %{SOURCE1}


### PR DESCRIPTION
Ignite-shmem build failed on ppc64le. This is caused by ppc64le is
not supported by its config.guess.

Change-Id: Ife8b1afe185e086034c1fd25fbb20906c0dc15be
Signed-off-by: Jun He <jun.he@linaro.org>