### PR TITLE
BIGTOP-3076: QFS build failed on ppc64le

### DIFF
--- a/bigtop-packages/src/common/qfs/patch0-gf_cpu.diff
+++ b/bigtop-packages/src/common/qfs/patch0-gf_cpu.diff
@@ -1,0 +1,16 @@
+diff --git a/ext/gf-complete/src/gf_cpu.c b/ext/gf-complete/src/gf_cpu.c
+index f1afa2b..a0c9b10 100644
+--- a/ext/gf-complete/src/gf_cpu.c
++++ b/ext/gf-complete/src/gf_cpu.c
+@@ -206,10 +206,9 @@ void gf_cpu_identify(void)
+ 
+ #else // defined(__arm__) || defined(__aarch64__)
+ 
+-int gf_cpu_identify(void)
++void gf_cpu_identify(void)
+ {
+     gf_cpu_identified = 1;
+-    return 0;
+ }
+ 
+ #endif


### PR DESCRIPTION
QFS build failed on ppc64le, this is caused by conflict definition of
gf_cpu_identify.

Change-Id: Ibc52b426a27c6ed27c71a0e8fabeaaa91577d000
Signed-off-by: Jun He <jun.he@linaro.org>