### PR TITLE
BIGTOP-3081: Update HBase/Ignite-hadoop arch info

### DIFF
--- a/bigtop-packages/src/deb/hbase/control
+++ b/bigtop-packages/src/deb/hbase/control
@@ -21,7 +21,7 @@ Standards-Version: 3.9.4
 Homepage: http://hbase.apache.org/
 
 Package: hbase
-Architecture: all
+Architecture: any
 Depends: adduser, zookeeper (>= 3.3.1), hadoop-client, bigtop-utils (>= 0.7)
 # Any system that can prevent clock skew is recommended, but if it conflicts with one of these, apt-get will remove it by default
 Recommends: ntp | chrony

--- a/bigtop-packages/src/deb/ignite-hadoop/control
+++ b/bigtop-packages/src/deb/ignite-hadoop/control
@@ -21,7 +21,7 @@ Standards-Version: 3.9.4
 Homepage: http://ignite.apache.org/
 
 Package: ignite-hadoop
-Architecture: all
+Architecture: any
 Depends: adduser, hadoop-hdfs, hadoop-mapreduce, bigtop-utils (>= 0.8)
 Description: Ignite is an open-source, distributed, in-memory computation platform
  .

--- a/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
+++ b/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
@@ -92,7 +92,6 @@ Source5: hbase.default
 Source6: hbase.nofiles.conf
 Source7: regionserver-init.d.tpl
 #BIGTOP_PATCH_FILES
-BuildArch: noarch
 Requires: coreutils, /usr/sbin/useradd, /sbin/chkconfig, /sbin/service
 Requires: hadoop-client, zookeeper >= 3.3.1, bigtop-utils >= 0.7
 

--- a/bigtop-packages/src/rpm/ignite-hadoop/SPECS/ignite-hadoop.spec
+++ b/bigtop-packages/src/rpm/ignite-hadoop/SPECS/ignite-hadoop.spec
@@ -87,7 +87,6 @@ Source3: ignite-hadoop.svc
 Source4: init.d.tmpl
 Source5: ignite-hadoop.default
 #BIGTOP_PATCH_FILES
-BuildArch: noarch
 ## This package _explicitly_ turns off the auto-discovery of required dependencies
 ## to work around OSGI corner case, added to RPM lately. See BIGTOP-2421 for more info.
 Requires: coreutils, /usr/sbin/useradd, /sbin/chkconfig, /sbin/service


### PR DESCRIPTION
Both HBase and ignite-hadoop introduce arch dependency during build.
So the output packages should be arch dependent. The arch info in
package files should be updated to reflect these.

Signed-off-by: Jun He <jun.he@linaro.org>