### PR TITLE
BIGTOP-3082: Fix build failure with flume-1.8+kafka-0.10.2.2

### DIFF
--- a/bigtop-packages/src/common/flume/patch0-FLUME-2662.diff
+++ b/bigtop-packages/src/common/flume/patch0-FLUME-2662.diff
@@ -1,11 +1,13 @@
---- apache-flume-1.7.0-src/pom.xml.	2016-11-19 20:56:05.683682127 +0100
-+++ apache-flume-1.7.0-src/pom.xml	2016-11-19 20:56:22.707682094 +0100
-@@ -951,7 +951,7 @@
-       <dependency>
-         <groupId>commons-io</groupId>
-         <artifactId>commons-io</artifactId>
--        <version>2.1</version>
-+        <version>2.4</version>
-       </dependency>
- 
-       <dependency>
+diff --git a/pom.xml b/pom.xml
+index 3c82a47..bdd998d 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -58,7 +58,7 @@ limitations under the License.
+     <commons-collections.version>3.2.2</commons-collections.version>
+     <commons-compress.version>1.4.1</commons-compress.version>
+     <commons-dbcp.version>1.4</commons-dbcp.version>
+-    <commons-io.version>2.1</commons-io.version>
++    <commons-io.version>2.4</commons-io.version>
+     <commons-lang.version>2.5</commons-lang.version>
+     <curator.version>2.6.0</curator.version>
+     <derby.version>10.11.1.1</derby.version>

--- a/bigtop-packages/src/common/flume/patch1-FLUME-3026_rebased.diff
+++ b/bigtop-packages/src/common/flume/patch1-FLUME-3026_rebased.diff
@@ -1,5 +1,5 @@
 diff --git a/flume-ng-channels/flume-kafka-channel/src/test/java/org/apache/flume/channel/kafka/TestKafkaChannel.java b/flume-ng-channels/flume-kafka-channel/src/test/java/org/apache/flume/channel/kafka/TestKafkaChannel.java
-index 5e5f2d0..917cee2 100644
+index 5e5f2d0..63607f7 100644
 --- a/flume-ng-channels/flume-kafka-channel/src/test/java/org/apache/flume/channel/kafka/TestKafkaChannel.java
 +++ b/flume-ng-channels/flume-kafka-channel/src/test/java/org/apache/flume/channel/kafka/TestKafkaChannel.java
 @@ -20,6 +20,7 @@ package org.apache.flume.channel.kafka;
@@ -15,13 +15,13 @@ index 5e5f2d0..917cee2 100644
      int replicationFactor = 1;
      Properties topicConfig = new Properties();
 -    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig);
-+    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig, 
++    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig,
 +                           RackAwareMode.Disabled$.MODULE$);
    }
  
    public static void deleteTopic(String topicName) {
 diff --git a/flume-ng-sinks/flume-ng-kafka-sink/src/test/java/org/apache/flume/sink/kafka/TestKafkaSink.java b/flume-ng-sinks/flume-ng-kafka-sink/src/test/java/org/apache/flume/sink/kafka/TestKafkaSink.java
-index 7c66420..bc2a299 100644
+index d92c71f..66c6fe3 100644
 --- a/flume-ng-sinks/flume-ng-kafka-sink/src/test/java/org/apache/flume/sink/kafka/TestKafkaSink.java
 +++ b/flume-ng-sinks/flume-ng-kafka-sink/src/test/java/org/apache/flume/sink/kafka/TestKafkaSink.java
 @@ -21,6 +21,7 @@ package org.apache.flume.sink.kafka;
@@ -32,18 +32,25 @@ index 7c66420..bc2a299 100644
  import kafka.message.MessageAndMetadata;
  import kafka.utils.ZkUtils;
  
-@@ -551,7 +552,8 @@ public class TestKafkaSink {
+@@ -674,7 +675,8 @@ public class TestKafkaSink {
          ZkUtils.apply(testUtil.getZkUrl(), sessionTimeoutMs, connectionTimeoutMs, false);
      int replicationFactor = 1;
      Properties topicConfig = new Properties();
 -    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig);
-+    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig, 
++    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig,
 +                           RackAwareMode.Disabled$.MODULE$);
    }
  
    public static void deleteTopic(String topicName) {
+@@ -698,4 +700,4 @@ public class TestKafkaSink {
+     return newTopic;
+   }
+ 
+-}
+\ No newline at end of file
++}
 diff --git a/flume-ng-sources/flume-kafka-source/src/test/java/org/apache/flume/source/kafka/KafkaSourceEmbeddedKafka.java b/flume-ng-sources/flume-kafka-source/src/test/java/org/apache/flume/source/kafka/KafkaSourceEmbeddedKafka.java
-index 53bd65c..ae5348c 100644
+index 53bd65c..ba75623 100644
 --- a/flume-ng-sources/flume-kafka-source/src/test/java/org/apache/flume/source/kafka/KafkaSourceEmbeddedKafka.java
 +++ b/flume-ng-sources/flume-kafka-source/src/test/java/org/apache/flume/source/kafka/KafkaSourceEmbeddedKafka.java
 @@ -17,6 +17,7 @@
@@ -59,13 +66,13 @@ index 53bd65c..ae5348c 100644
      int replicationFactor = 1;
      Properties topicConfig = new Properties();
 -    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig);
-+    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig, 
++    AdminUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor, topicConfig,
 +                           RackAwareMode.Disabled$.MODULE$);
    }
  
  }
 diff --git a/flume-ng-sources/flume-kafka-source/src/test/java/org/apache/flume/source/kafka/TestKafkaSource.java b/flume-ng-sources/flume-kafka-source/src/test/java/org/apache/flume/source/kafka/TestKafkaSource.java
-index d1daceb..cda91f9 100644
+index 7804fa2..2d5bbf8 100644
 --- a/flume-ng-sources/flume-kafka-source/src/test/java/org/apache/flume/source/kafka/TestKafkaSource.java
 +++ b/flume-ng-sources/flume-kafka-source/src/test/java/org/apache/flume/source/kafka/TestKafkaSource.java
 @@ -20,7 +20,7 @@ package org.apache.flume.source.kafka;
@@ -78,15 +85,15 @@ index d1daceb..cda91f9 100644
  import kafka.utils.ZkUtils;
  import org.apache.avro.io.BinaryEncoder;
 diff --git a/pom.xml b/pom.xml
-index f62c99a..fb2340f 100644
+index 3c82a47..2276355 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -52,7 +52,7 @@ limitations under the License.
-     <elasticsearch.version>0.90.1</elasticsearch.version>
-     <hadoop2.version>2.4.0</hadoop2.version>
-     <thrift.version>0.7.0</thrift.version>
+@@ -77,7 +77,7 @@ limitations under the License.
+     <jetty.version>6.1.26</jetty.version>
+     <joda-time.version>2.9.9</joda-time.version>
+     <junit.version>4.10</junit.version>
 -    <kafka.version>0.9.0.1</kafka.version>
-+    <kafka.version>0.10.1.0</kafka.version>
++    <kafka.version>0.10.2.2</kafka.version>
      <kite.version>1.0.0</kite.version>
      <hive.version>1.0.0</hive.version>
-     <xalan.verion>2.7.1</xalan.verion>
+     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -235,7 +235,7 @@ bigtop {
     'flume' {
       name    = 'flume'
       relNotes = 'Apache Flume'
-      version { base = '1.7.0'; pkg = base; release = 1 }
+      version { base = '1.8.0'; pkg = base; release = 1 }
       tarball { destination = "apache-$name-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/${version.base}/"
@@ -383,7 +383,7 @@ bigtop {
     'kafka' {
       name    = 'kafka'
       relNotes = 'Apache Kafka'
-      version { base = '0.10.1.1'; pkg = base; release = 1 }
+      version { base = '0.10.2.2'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
When upgrading flume to 1.8 and kafka to 0.10.2.2, the build of flume
is failed due to API changes and scala upgrade in kafka.
This patch rebased FLUME-2662/FLUME-3026 patches to flume-1.8, and for
the scala conflicts, used Anton's patch which can be found here:
https://lists.apache.org/thread.html/%3CCAJZrK_tN49GM+vCCiB+rjLL==82U=7nswoapwWmyJbVAS5F=QA@mail.gmail.com%3E

Change-Id: Idf8d00c22ef60d82783056fea556e9a6f517054a
Signed-off-by: Jun He <jun.he@linaro.org>