### PR TITLE
Broken building hadoop/hive. Fix ad6349c7d for debian-based distros.

### DIFF
--- a/packages.gradle
+++ b/packages.gradle
@@ -388,6 +388,14 @@ def genTasks = { target ->
       from "${BASE_DIR}/bigtop-packages/src/templates/init.d.tmpl"
       into "$DEB_BLD_DIR/debian"
     }
+    copy {
+      from "${BASE_DIR}/bigtop-packages/src/scripts"
+      into "$DEB_BLD_DIR/debian"
+    }
+    copy {
+      from "${BASE_DIR}/bigtop-packages/src/extensions"
+      into "$DEB_BLD_DIR/debian"
+    }
     fileTree ("$BASE_DIR/bigtop-packages/src/common/$NAME") {
       include '**/*'
     }.copy { into "$DEB_BLD_DIR/debian" }


### PR DESCRIPTION
Hi.

Current trunk of Apache Bigtop are broken when you try to build hadoop or hive components on debian based distros.

In commit https://github.com/apache/bigtop/commit/ad6349c7d8885e347dfdf8a93c70acccc3efd8a0 you added some scripts for rpms, but forgot added copy blocks in deb.