### PR TITLE
BIGTOP-3090: provisioner failed on fedora-26 when deploying jdk

### DIFF
--- a/bigtop-deploy/puppet/manifests/jdk.pp
+++ b/bigtop-deploy/puppet/manifests/jdk.pp
@@ -60,12 +60,6 @@ class jdk {
         ensure => present,
         noop => $jdk_preinstalled,
       }
-      if ($::operatingsystem == "Fedora") {
-        file { '/usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/cacerts':
-          ensure => 'link',
-          target => '/etc/pki/java/cacerts'
-        }
-      }
     }
     /OpenSuSE/: {
       package { 'jdk':


### PR DESCRIPTION
The puppet recipe of jdk intends to setup cacerts link with pki/java/cacerts
while jdk is not installed. This security failure will cause later bigtop
components installation failure.

Change-Id: Ib728cdf60db9feaddb3f65643ee2134158947254
Signed-off-by: Jun He <jun.he@linaro.org>