### PR TITLE
BIGTOP-3091: Set Bigtop repo to higher priority

### DIFF
--- a/bigtop-deploy/puppet/manifests/bigtop_repo.pp
+++ b/bigtop-deploy/puppet/manifests/bigtop_repo.pp
@@ -24,6 +24,7 @@ class bigtop_repo {
           descr    => "Bigtop packages",
           enabled  => 1,
           gpgcheck => 0,
+          priority => 10,
         }
         Yumrepo<||> -> Package<||>
       }


### PR DESCRIPTION
Bigtop repo file in deploy/puppet doesn't have "priority" field.
An example is on Fedora-26, zookeeper is 3.4.9 in distro repo, while
conflicts with 3.4.6 in Bigtop stack. Similiar to BIGTOP-2796.

Change-Id: I2b1231a2cf62a30401784780c92b31ab810fe34b
Signed-off-by: Jun He <jun.he@linaro.org>