### PR TITLE
Remove the advertise.host.name override.

### DIFF
--- a/bigtop-packages/src/charm/kafka/layer-kafka/lib/charms/layer/bigtop_kafka.py
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/lib/charms/layer/bigtop_kafka.py
@@ -62,7 +62,6 @@ class Kafka(object):
         bigtop = Bigtop()
         bigtop.render_site_yaml(roles=roles, overrides=override)
         bigtop.trigger_puppet()
-        self.set_advertise()
         self.restart()
 
     def restart(self):
@@ -74,15 +73,3 @@ class Kafka(object):
 
     def stop(self):
         host.service_stop('kafka-server')
-
-    def set_advertise(self):
-        short_host = check_output(['hostname', '-s']).decode('utf8').strip()
-
-        # Configure server.properties
-        # NB: We set the advertised.host.name below to our short hostname
-        # to kafka (admin will still have to expose kafka and ensure the
-        # external client can resolve the short hostname to our public ip).
-        kafka_server_conf = '/etc/kafka/conf/server.properties'
-        utils.re_edit_in_place(kafka_server_conf, {
-            r'^#?advertised.host.name=.*': 'advertised.host.name=%s' % short_host,
-        })


### PR DESCRIPTION
The short host name used in `set_advertise` to rewrite `advertised.host.name` is not guaranteed to be resolvable by other kafka members of a cluster, or kafka clients. The comment on this removed code
seems to suggest that an admin should configure this short name to
resolve on clients outside of juju. The problem is, these short names also must resolve on all kafka
cluster nodes, and then each client will need to resolve the short name of
each cluster member. Otherwise, the cluster basically unusable -- clients fail to find a leader.

While being able to configure `advertised.host.name` is potentially
useful, IMO there should be a config option that sets this value in the
puppet module template. The charm should not be modifying `server.properties` after puppet has
generated it.

By removing `set_advertise`, the charm becomes more useful -- if
the config option `network_interface` is set, host.name is defined and all the kafka nodes
in a cluster can resolve the implicit default `advertised.host.name`, which is
the IP address of the configured interface. Clients can connect to this
IP address.