### PR TITLE
BIGTOP-3106: Update links in download page

### DIFF
--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -35,31 +35,31 @@
 			<ul>
 				<li>
 					The latest release of Apache Bigtop software framework <br/>
-					<a href="https://www.apache.org/dyn/closer.lua/bigtop/bigtop-1.3.0/">Bigtop 1.3.0</a> (<a href="https://archive.apache.org/dist/bigtop/bigtop-1.3.0/bigtop-1.3.0-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.3.0/bigtop-1.3.0-project.tar.gz.sha256">sha256</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.3.0/bigtop-1.3.0-project.tar.gz.sha512">sha512</a>)
+					<a href="https://www.apache.org/dyn/closer.cgi/bigtop/bigtop-1.3.0/bigtop-1.3.0-project.tar.gz">Bigtop 1.3.0</a> (<a href="https://apache.org/dist/bigtop/bigtop-1.3.0/bigtop-1.3.0-project.tar.gz.asc">pgp</a> <a href="https://apache.org/dist/bigtop/bigtop-1.3.0/bigtop-1.3.0-project.tar.gz.sha256">sha256</a> <a href="https://apache.org/dist/bigtop/bigtop-1.3.0/bigtop-1.3.0-project.tar.gz.sha512">sha512</a>)
 				</li>
 				<li>
 					Repositories of instsallable binary packages built with latest release
 					of the Apache Bitop project <br/>
-					<a href="https://www.apache.org/dyn/closer.lua/bigtop/bigtop-1.3.0/repos/">Installable binary artifacts</a>
+					<a href="https://www.apache.org/dyn/closer.cgi/bigtop/bigtop-1.3.0/repos/">Installable binary artifacts</a>
 				</li>
 			</ul>
 			<subsection name="Previous Releases" id="archived"></subsection>
 			<ul>
 				<li>
 					1.2.1 released on 2017-11-12<br/>
-					<a href="https://www.apache.org/dyn/closer.lua/bigtop/bigtop-1.2.1/">Bigtop 1.2.1</a>(<a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.1/bigtop-1.2.1-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.1/bigtop-1.2.1-project.tar.gz.md5">md5</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.1/bigtop-1.2.1-project.tar.gz.sha1">sha1</a>)
+					<a href="https://www.apache.org/dyn/closer.cgi/bigtop/bigtop-1.2.1/bigtop-1.2.1-project.tar.gz">Bigtop 1.2.1</a>(<a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.1/bigtop-1.2.1-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.1/bigtop-1.2.1-project.tar.gz.md5">md5</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.1/bigtop-1.2.1-project.tar.gz.sha1">sha1</a>)
 				</li>
 				<li>
 					1.2.0 released on 2017-03-30<br/>
-					<a href="https://www.apache.org/dyn/closer.lua/bigtop/bigtop-1.2.0/">Bigtop 1.2.0</a>(<a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.0/bigtop-1.2.0-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.0/bigtop-1.2.0-project.tar.gz.asc.md5">md5</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.0/bigtop-1.2.0-project.tar.gz.asc.sha1">sha1</a>)
+					<a href="https://www.apache.org/dyn/closer.cgi/bigtop/bigtop-1.2.0/bigtop-1.2.0-project.tar.gz">Bigtop 1.2.0</a>(<a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.0/bigtop-1.2.0-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.0/bigtop-1.2.0-project.tar.gz.asc.md5">md5</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.2.0/bigtop-1.2.0-project.tar.gz.asc.sha1">sha1</a>)
 				</li>
 				<li>
 					1.1.0 released on 2016-01-31<br/>
-					<a href="https://www.apache.org/dyn/closer.lua/bigtop/bigtop-1.1.0/">Bigtop 1.1.0</a>(<a href="https://archive.apache.org/dist/bigtop/bigtop-1.1.0/bigtop-1.1.0-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.1.0/bigtop-1.1.0-project.tar.gz.md5">md5</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.1.0/bigtop-1.1.0-project.tar.gz.sha1">sha1</a>)
+					<a href="https://www.apache.org/dyn/closer.cgi/bigtop/bigtop-1.1.0/bigtop-1.1.0-project.tar.gz">Bigtop 1.1.0</a>(<a href="https://archive.apache.org/dist/bigtop/bigtop-1.1.0/bigtop-1.1.0-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.1.0/bigtop-1.1.0-project.tar.gz.md5">md5</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.1.0/bigtop-1.1.0-project.tar.gz.sha1">sha1</a>)
 				</li>
 				<li>
 					1.0.0 released on 2015-08-12<br/>
-					<a href="https://www.apache.org/dyn/closer.lua/bigtop/bigtop-1.0.0/">Bigtop 1.0.0</a>(<a href="https://archive.apache.org/dist/bigtop/bigtop-1.0.0/bigtop-1.0.0-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.0.0/bigtop-1.0.0-project.tar.gz.md5">md5</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.0.0/bigtop-1.0.0-project.tar.gz.sha1">sha1</a>)
+					<a href="https://www.apache.org/dyn/closer.cgi/bigtop/bigtop-1.0.0/bigtop-1.0.0-project.tar.gz">Bigtop 1.0.0</a>(<a href="https://archive.apache.org/dist/bigtop/bigtop-1.0.0/bigtop-1.0.0-project.tar.gz.asc">pgp</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.0.0/bigtop-1.0.0-project.tar.gz.md5">md5</a> <a href="https://archive.apache.org/dist/bigtop/bigtop-1.0.0/bigtop-1.0.0-project.tar.gz.sha1">sha1</a>)
 				</li>
 			</ul>
 		</section>


### PR DESCRIPTION
Links in download page should:
1. be links to release artifacts, not links to directories.
2. link to the asc and sha files should refer to archives only for non-current
   releases
3. current release links should point to apache.org/dist

Signed-off-by: Jun He <jun.he@linaro.org>