### PR TITLE
BIGTOP-3131. Apex smoke test requires mvn to compile test jar

### DIFF
--- a/provisioner/utils/smoke-tests.sh
+++ b/provisioner/utils/smoke-tests.sh
@@ -61,6 +61,11 @@ if [[ $SMOKE_TESTS == *"qfs"* ]]; then
     prep hadoop-qfs
 fi
 
+if [[ $SMOKE_TESTS == *"apex"* ]]; then
+    puppet apply --modulepath=/bigtop-home -e 'include bigtop_toolchain::maven'
+    export PATH=/usr/local/maven/bin:$PATH
+fi
+
 ALL_SMOKE_TASKS=""
 for s in `echo $SMOKE_TESTS | sed -e 's#,# #g'`; do
   ALL_SMOKE_TASKS="$ALL_SMOKE_TASKS bigtop-tests:smoke-tests:$s:test"


### PR DESCRIPTION
Install mvn via bigtop_toolchain when apex smoke test specified.