### PR TITLE
BIGTOP-3144. [Test] QFS smoke test failed on multi-node cluster

### DIFF
--- a/bigtop-deploy/puppet/manifests/cluster.pp
+++ b/bigtop-deploy/puppet/manifests/cluster.pp
@@ -134,7 +134,7 @@ $roles_map = {
   },
   qfs => {
     master => ["qfs-metaserver"],
-    worker => ["qfs-chunkserver"],
+    worker => ["qfs-chunkserver", "qfs-client"],
     client => ["qfs-client"],
   },
   gpdb => {

--- a/bigtop-deploy/puppet/modules/qfs/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/qfs/manifests/init.pp
@@ -165,7 +165,7 @@ class qfs {
       path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
       command => 'find /usr/lib/qfs/ -name "lib*" -exec ln -s {} /usr/lib/hadoop/lib/native \;',
       require => Package["qfs-client"],
-      notify => [ Service["hadoop-yarn-nodemanager"], Service["hadoop-yarn-resourcemanager"] ],
+      notify => [ Service["hadoop-yarn-nodemanager"] ],
     }
   }
 }


### PR DESCRIPTION
* Deploy qfs-client on worker
* remove notify on yarn resource manager 