### PR TITLE
BIGTOP-3152: No need to Force the use of Netty over Hadoop RPC in Giraph

### DIFF
--- a/bigtop-deploy/puppet/modules/giraph/templates/giraph-site.xml
+++ b/bigtop-deploy/puppet/modules/giraph/templates/giraph-site.xml
@@ -22,12 +22,6 @@ under the License.
 
 <configuration>
   <property>
-    <name>giraph.useNetty</name>
-    <value>true</value>
-    <description>Force the use of Netty over Hadoop RPC to avoid issues with different versions of Hadoop</description>
-  </property>
-
-  <property>
     <name>giraph.zkList</name>
     <value><%= @zookeeper_quorum %></value>
     <description>Prefer external Zookeeper over the embedded one</description>


### PR DESCRIPTION
For workaround for GIRAPH-198 originally, giraph activated netty rpc by setting giraph.useNetty from command line.
In GIRAPH-200 later, giraph removed hadoop RPC and keep just netty by default.
So we can remove the Netty configuration accordingly.
