### PR TITLE
BIGTOP-3204. Bump Flink to 1.6.4

### DIFF
--- a/bigtop-deploy/puppet/modules/flink/templates/flink-conf.yaml
+++ b/bigtop-deploy/puppet/modules/flink/templates/flink-conf.yaml
@@ -26,6 +26,14 @@ jobmanager.web.port: <%= @ui_port %>
 taskmanager.tmp.dirs: <%= @storage_dirs.join(":") %>
 <% end %>
 
+# Starting from Flink v1.5, there is a rewrite of Flink’s deployment and process
+# model (internally known as FLIP-6). A new option 'mode' was introduced to
+# indicate which executions to use. However, the way Bigtop puppet deploys
+# 'flink-jobmanager' and 'flink-taskmanager', ie. calling 'flink-daemon.sh 
+# jobmanager' and 'flink-daemon.sh taskmanager', is legacy. Without setting
+# mode to 'legacy', flink's built-in exmaples fail with error
+# "JobSubmissionException: Failed to submit JobGraph"
+mode: legacy
 
 # For performance reasons its highly recommended to allocate as much memory to the
 # Flink TaskManager as possible by setting 'taskmanager.heap.mb'.

--- a/bigtop-packages/src/common/flink/install_flink.sh
+++ b/bigtop-packages/src/common/flink/install_flink.sh
@@ -102,7 +102,6 @@ install -d -m 0755 $PREFIX/$LIB_DIR
 install -d -m 0755 $PREFIX/$LIB_DIR/bin
 install -d -m 0755 $PREFIX/$LIB_DIR/lib
 install -d -m 0755 $PREFIX/$LIB_DIR/examples
-install -d -m 0755 $PREFIX/$LIB_DIR/resources
 install -d -m 0755 $PREFIX/$CONF_DIR
 install -d -m 0755 $PREFIX/var/log/flink
 install -d -m 0755 $PREFIX/var/log/flink-cli
@@ -120,7 +119,6 @@ cp -a ${BUILD_DIR}/conf/* $PREFIX/$CONF_DIR
 ln -s /etc/flink/conf $PREFIX/$LIB_DIR/conf
 
 cp -ra ${BUILD_DIR}/examples/* $PREFIX/${LIB_DIR}/examples/
-cp -ra ${BUILD_DIR}/resources/* $PREFIX/${LIB_DIR}/resources/
 
 cp ${BUILD_DIR}/{LICENSE,NOTICE,README.txt} ${PREFIX}/${LIB_DIR}/
 

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -277,7 +277,7 @@ bigtop {
     'flink' {
       name    = 'flink'
       relNotes = 'Apache Flink'
-      version { base = '1.4.2'; pkg = base; release = 1 }
+      version { base = '1.6.4'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
Bump Flink version from 1.4.2 to 1.6.4. There are three changes involved:
    1. obviously, version number
    2. in Flink 1.6.4, there is no 'resources' folder any more. Removed it.
    3. set mode to 'legacy'
    
    Starting from Flink v1.5, there is a rewrite of Flink’s deployment and process
    model (internally known as FLIP-6). A new option 'mode' was introduced to
    indicate which executions to use. However, the way Bigtop puppet deploys
    'flink-jobmanager' and 'flink-taskmanager', ie. calling 'flink-daemon.sh
    jobmanager' and 'flink-daemon.sh taskmanager', is legacy. Without setting
    mode to 'legacy', flink's built-in exmaples fail with error
    "JobSubmissionException: Failed to submit JobGraph"
    
