### PR TITLE
Bps dockerfile

### DIFF
--- a/bigtop-bigpetstore/bigpetstore-transaction-queue/.dockerignore
+++ b/bigtop-bigpetstore/bigpetstore-transaction-queue/.dockerignore
@@ -1,0 +1,3 @@
+.gradle
+.settings
+build

--- a/bigtop-bigpetstore/bigpetstore-transaction-queue/Dockerfile
+++ b/bigtop-bigpetstore/bigpetstore-transaction-queue/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM centos:7
-MAINTAINER jay@apache.org
+LABEL maintainer="jay@apache.org"
 RUN yum update -y
 RUN yum install -y java-1.8.0-openjdk
 

--- a/bigtop-bigpetstore/bigpetstore-transaction-queue/Dockerfile
+++ b/bigtop-bigpetstore/bigpetstore-transaction-queue/Dockerfile
@@ -15,19 +15,10 @@
 FROM centos:7
 MAINTAINER jay@apache.org
 RUN yum update -y
-RUN yum install -y java-1.8.0-openjdk unzip wget
-RUN yum install -y java-1.8.0-openjdk-devel
+RUN yum install -y java-1.8.0-openjdk
 
 WORKDIR /opt/
 
-# Get Bigtop
-# This comes with a gradlew wrapper we can use.
-RUN wget http://www.apache.org/dist/bigtop/bigtop-1.0.0/bigtop-1.0.0-project.tar.gz
-RUN  tar -xvf bigtop-1.0.0-project.tar.gz
+COPY build/libs/bigpetstore-transaction-queue-all-1.0.jar /opt
 
-# Install bigpetstore transaction queue
-WORKDIR /opt/bigtop-1.0.0/bigtop-bigpetstore/bigpetstore-transaction-queue
-RUN /opt/bigtop-1.0.0/gradlew distZip
-RUN unzip build/distributions/bigpetstore-transaction-queue-1.0.zip
-RUN mv ./bigpetstore-transaction-queue-1.0 /opt/bigpetstore-transaction-queue-1.0/
-CMD /opt/bigpetstore-transaction-queue-1.0/bigpetstore-transaction-queue-1.0/bin/bigpetstore-transaction-queue
+ENTRYPOINT ["java", "-jar", "bigpetstore-transaction-queue-all-1.0.jar"]

--- a/bigtop-bigpetstore/bigpetstore-transaction-queue/Dockerfile
+++ b/bigtop-bigpetstore/bigpetstore-transaction-queue/Dockerfile
@@ -12,13 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM centos:7
+FROM gradle:5.6.3-jdk12 as build
+
+ADD . /bigpetstore-transaction-queue
+WORKDIR /bigpetstore-transaction-queue
+
+RUN [ "gradle", "fatJar" ]
+
+FROM openjdk:14-ea-12-jdk-alpine3.10
 LABEL maintainer="jay@apache.org"
-RUN yum update -y
-RUN yum install -y java-1.8.0-openjdk
 
 WORKDIR /opt/
 
-COPY build/libs/bigpetstore-transaction-queue-all-1.0.jar /opt
+COPY --from=build /bigpetstore-transaction-queue/build/libs/bigpetstore-transaction-queue-all-1.0.jar /opt
 
 ENTRYPOINT ["java", "-jar", "bigpetstore-transaction-queue-all-1.0.jar"]

--- a/bigtop-bigpetstore/bigpetstore-transaction-queue/README.md
+++ b/bigtop-bigpetstore/bigpetstore-transaction-queue/README.md
@@ -73,7 +73,7 @@ The command line arguments are:
 From docker
 
 ```
-docker run -t -i jayunit100/bigpetstore-load-generator  /opt/bigpetstore-transaction-queue-1.0/bin/bigpetstore-transaction-queue /tmp/ 1 1 3.0
+docker run -t -i jayunit100/bigpetstore-load-generator /tmp/ 1 1 3.0
 ```
 or Java
 ```
@@ -87,8 +87,7 @@ OR Replace the file path with a REST API root (it will jsonify the transactions,
 From docker
 
 ```
-docker run -t -i jayunit100/bigpetstore-load-generator /opt/bigpetstore-transaction-queue-1.0/bin/bigpetstore-transaction-queue
- http://localhost:3000/restapi/rpush/ 1 5 10000 123
+docker run -t -i jayunit100/bigpetstore-load-generator http://localhost:3000/restapi/rpush/ 1 5 10000 123
 ```
 Or from java
 ```

--- a/bigtop-bigpetstore/bigpetstore-transaction-queue/settings.gradle
+++ b/bigtop-bigpetstore/bigpetstore-transaction-queue/settings.gradle
@@ -1,0 +1,16 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 


### PR DESCRIPTION
The old Dockerfile wasn't building anymore due a 404 on the apache.org link, so I tweaked the Dockerfile to remove the need to call out to an external website for resources.

This does change the container for bps a little bit and will require a change to that container for the documentation updates to be correct.