### PR TITLE
BIGTOP-3168: Kafka smoke tests implementation

### DIFF
--- a/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
+++ b/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
@@ -32,7 +32,34 @@ class TestKafkaSmoke {
   static Shell sh = new Shell("/bin/bash -s");
 
   static final String KAFKA_HOME = "/usr/lib/kafka"
-  static final String KAFKA_TOPICS = KAFKA_HOME + "/bin/kafka-topics.sh"
+  static final String KAFKA_CONFIG = KAFKA_HOME + "/config/server.properties "
+  static final String KAFKA_TOPICS = KAFKA_HOME + "/bin/kafka-topics.sh "
+  static final String KAFKA_SERVER_START = KAFKA_HOME + "/bin/kafka-server-start.sh "
+  static final String KAFKA_SERVER_STOP = KAFKA_HOME + "/bin/kafka-server-stop.sh "
+
+  @BeforeClass
+  static void kafkaSetUp() {
+    /* Restart kafka server with new broker id 111
+     * Enable delete.topic.enable
+     */
+    sh.exec(KAFKA_SERVER_STOP);
+    sh.exec(KAFKA_SERVER_START + KAFKA_CONFIG
+      + " --override delete.topic.enable=true"
+      + " --override broker.id=111"
+      + " --override port=9192"
+      + " --override log.dirs=/tmp/kafka-logs-111 &"
+    );
+    assertTrue(" Restart Kafka server failed. " + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);
+  }
+
+  @AfterClass
+  public static void deleteKafkaTopics() {
+    sh.exec(KAFKA_TOPICS
+      + " --zookeeper localhost:2181"
+      + " --delete --topic test"
+    );
+    assertTrue(" Delete Kafka topics failed. " + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);
+  }
 
   @Test
   public void testCreateTopics() {

--- a/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
+++ b/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bigtop.itest.kafka
+
+import org.junit.BeforeClass
+import org.junit.AfterClass
+import org.apache.bigtop.itest.shell.Shell
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
+import org.junit.Test
+import org.apache.bigtop.itest.JarContent
+import org.apache.bigtop.itest.TestUtils
+import org.junit.runner.RunWith
+
+class TestKafkaSmoke {
+  static Shell sh = new Shell("/bin/bash -s");
+
+  static final String ZOOKEEPER_HOME = "/usr/lib/zookeeper"
+  static final String ZK_SERVER = ZOOKEEPER_HOME + "/bin/zkServer.sh"
+
+  static final String KAFKA_HOME = "/usr/lib/kafka"
+  static final String KAFKA_CONFIG = KAFKA_HOME + "/config/server.properties"
+  static final String KAFKA_TOPICS = KAFKA_HOME + "/bin/kafka-topics.sh"
+  static final String KAFKA_SERVER_START = KAFKA_HOME + "/bin/kafka-server-start.sh"
+
+  @Test
+  public void testCreateTopics() {
+    sh.exec(ZK_SERVER + " start");
+    sh.exec(KAFKA_SERVER_START + KAFKA_CONFIG + " &");
+    sh.exec(KAFKA_TOPICS + " --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test");
+    sh.exec(KAFKA_TOPICS + " --list --zookeeper localhost:2181");
+    assertTrue(" Create Kafka topics failed. " + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);
+  }
+}

--- a/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
+++ b/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
@@ -31,18 +31,11 @@ import org.junit.runner.RunWith
 class TestKafkaSmoke {
   static Shell sh = new Shell("/bin/bash -s");
 
-  static final String ZOOKEEPER_HOME = "/usr/lib/zookeeper"
-  static final String ZK_SERVER = ZOOKEEPER_HOME + "/bin/zkServer.sh"
-
   static final String KAFKA_HOME = "/usr/lib/kafka"
-  static final String KAFKA_CONFIG = KAFKA_HOME + "/config/server.properties"
   static final String KAFKA_TOPICS = KAFKA_HOME + "/bin/kafka-topics.sh"
-  static final String KAFKA_SERVER_START = KAFKA_HOME + "/bin/kafka-server-start.sh"
 
   @Test
   public void testCreateTopics() {
-    sh.exec(ZK_SERVER + " start");
-    sh.exec(KAFKA_SERVER_START + KAFKA_CONFIG + " &");
     sh.exec(KAFKA_TOPICS + " --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test");
     sh.exec(KAFKA_TOPICS + " --list --zookeeper localhost:2181");
     assertTrue(" Create Kafka topics failed. " + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);

--- a/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
+++ b/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
@@ -39,17 +39,12 @@ class TestKafkaSmoke {
 
   @BeforeClass
   static void kafkaSetUp() {
-    /* Restart kafka server with new broker id 111
-     * Enable delete.topic.enable
-     */
+    /* Restart kafka server for Enabling 'delete.topic.enable' */
     sh.exec(KAFKA_SERVER_STOP);
     sh.exec(KAFKA_SERVER_START + KAFKA_CONFIG
-      + " --override delete.topic.enable=true"
-      + " --override broker.id=111"
-      + " --override port=9192"
-      + " --override log.dirs=/tmp/kafka-logs-111 &"
+      + " --override delete.topic.enable=true &"
     );
-    assertTrue(" Restart Kafka server failed. " + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);
+    assertTrue("Restart Kafka server failed. ", sh.getRet() == 0);
   }
 
   @AfterClass
@@ -58,7 +53,7 @@ class TestKafkaSmoke {
       + " --zookeeper localhost:2181"
       + " --delete --topic test"
     );
-    assertTrue(" Delete Kafka topics failed. " + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);
+    assertTrue("Delete Kafka topics failed. ", sh.getRet() == 0);
   }
 
   @Test

--- a/bigtop-tests/smoke-tests/kafka/build.gradle
+++ b/bigtop-tests/smoke-tests/kafka/build.gradle
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def tests_to_include() {
+  return [
+      "TestKafkaSmoke.groovy"
+  ];
+}
+
+sourceSets {
+  test {
+    groovy {
+      srcDirs = ["${BIGTOP_HOME}/bigtop-tests/smoke-tests/kafka/"]
+      exclude { FileTreeElement elem -> (doExclude(elem.getName())) }
+    }
+  }
+}
+
+test.doFirst {
+  checkEnv(["KAFKA_HOME"])
+}

--- a/provisioner/utils/smoke-tests.sh
+++ b/provisioner/utils/smoke-tests.sh
@@ -50,6 +50,7 @@ export ZOOKEEPER_HOME=${ZOOKEEPER_HOME:-/usr/lib/zookeeper}
 export GIRAPH_HOME=${GIRAPH_HOME:-/usr/lib/giraph}
 export FLINK_HOME=${FLINK_HOME:-/usr/lib/flink}
 export LIVY_HOME=${LIVY_HOME:-/usr/lib/livy}
+export KAFKA_HOME=${KAFKA_HOME:-/usr/lib/kafka}
 
 echo -e "\n===== START TO RUN SMOKE TESTS: $SMOKE_TESTS =====\n"
 


### PR DESCRIPTION
Add Kafka smoke tests. Kafka depends on ZooKeeper.

Smoke test yaml:
```
components: [zookeeper, kafka]
enable_local_repo: true
smoke_test_components: [kafka]
```