### PR TITLE
BIGTOP-3264: Add a new Bigtop Mpack definition for Ambari

### DIFF
--- a/bigtop-deploy/puppet/modules/ambari/README.md
+++ b/bigtop-deploy/puppet/modules/ambari/README.md
@@ -1,0 +1,79 @@
+# Deploy Bigtop with Ambari Management Pack
+[![Ambari](https://ambari.apache.org/images/apache-ambari-project.png)](https://https://ambari.apache.org/)
+
+### Background
+- Apache Ambari is an open-source central management platform for provisioning, managing, monitoring and securing Hadoop clusters.
+- Ambari Management packs allow you to deploy a range of services to the Hadoop-cluster. You can use a management pack to deploy a specific component or service, or to deploy an entire platform, like HDFS.
+- We define a Ambari Management Pack, BGTP, that targets to address the needs of deploying and running Hadoop-related services by Bigtop facilities.
+
+
+### Build and Installation
+Build `DEB`/`RPM` from Bigtop docker provisioner:
+
+```sh
+$ docker run --rm -v `pwd`:/ws --workdir /ws bigtop/slaves:trunk-centos-7 bash -l -c './gradlew allclean ; ./gradlew ambari-pkg'
+```
+
+### Ambari Nodes Preparation and Configuration
+Install Ambari-server and Ambari-agent packages in the nodes respectively: 
+```sh
+Node1: ambari-server 
+Node2: ambari-agent01
+Node3: ambari-agent02
+```
+
+Modify Ambari server hostname to `/etc/ambari-agent/conf/ambari-agent.ini` which is located on Ambari agent nodes:
+```sh
+[server]
+hostname='Ambari-server-hostname'
+url_port=8440
+secured_url_port=8441
+...
+..
+[security]:
+force_https_protocol=PROTOCOL_TLSv1_2
+...
+..
+```
+Disable `HTTPS certificate verification`
+`/etc/python/cert-verification.cfg`:
+```sh
+[https]
+verify=disable
+```
+
+Install `chrony` and start chronyd service for time-sync among nodes.
+```sh
+$ yum install chrony
+$ systemctl start chronyd
+$ systemctl enable chronyd
+```
+
+### BGTP Mpack Installation
+Install bgtp-mapck on Ambari-server:
+```sh
+sudo ambari-server install-mpack --mpack=/path/bgtp-ambari-mpack-1.0.0.0-SNAPSHOT-bgtp-ambari-mpack.tar.gz --purge --verbose
+```
+`/path` is located in Ambari-server: `/var/lib/ambari-server/resources`
+You can modify the location of `/path` in [ install_ambari.sh](https://github.com/apache/bigtop/blob/master/bigtop-packages/src/common/ambari/install_ambari.sh).
+
+### Start Ambari Server and Agents
+Start Ambari-server node:
+```sh
+ambari-server reset
+ambari-server setup
+ambari-server start
+```
+Start Ambari-agent nodes:
+```sh
+ambari-agent restart
+```
+
+### Deploy Hadoop by Ambari facility
+Access Ambari WebUI to take manual depolyment with BGTP Mpack:
+```sh
+ambari-server-ip:8080 
+admin/admin
+```
+Deployment with Ambari-WebUI demo:  [here](https://www.youtube.com/watch?v=vnyUQtF8ZyM).
+

--- a/bigtop-deploy/puppet/modules/ambari/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ambari/manifests/init.pp
@@ -29,7 +29,7 @@ class ambari {
 
     exec {
         "mpack install":
-           command => "/bin/bash -c 'echo yes | /usr/sbin/ambari-server install-mpack --purge --verbose --mpack=/var/lib/ambari-server/resources/odpi-ambari-mpack-1.0.0.0-SNAPSHOT.tar.gz'",
+           command => "/bin/bash -c 'echo yes | /usr/sbin/ambari-server install-mpack --purge --verbose --mpack=/var/lib/ambari-server/resources/bgtp-ambari-mpack-1.0.0.0-SNAPSHOT-bgtp-ambari-mpack.tar.gz'",
            require => [ Package["ambari-server"] ]
     }
 

--- a/bigtop-packages/src/common/ambari/do-component-build
+++ b/bigtop-packages/src/common/ambari/do-component-build
@@ -25,4 +25,4 @@ sed -i "s|http://repo.spring.io|https://repo.spring.io|g" pom.xml
 
 mvn clean package -DskipTests -Drat.skip
 
-(cd contrib/management-packs/odpi-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)
+(cd contrib/management-packs/bgtp-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)

--- a/bigtop-packages/src/common/ambari/do-component-build
+++ b/bigtop-packages/src/common/ambari/do-component-build
@@ -26,4 +26,4 @@ sed -i "s|http://repo.spring.io|https://repo.spring.io|g" pom.xml
 mvn clean package -DskipTests -Drat.skip
 
 (cd contrib/management-packs/odpi-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)
-(cd ../bgtp-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)
+(cd contrib/management-packs/bgtp-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)

--- a/bigtop-packages/src/common/ambari/do-component-build
+++ b/bigtop-packages/src/common/ambari/do-component-build
@@ -23,6 +23,9 @@ export _JAVA_OPTIONS="-Xmx2048m -Djava.awt.headless=true"
 sed -i "s|http://download.java.net|https://download.java.net|g" pom.xml
 sed -i "s|http://repo.spring.io|https://repo.spring.io|g" pom.xml
 
+# Download BGTP-mpack jar
+wget -P contrib/management-packs/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/hooks/before-START/files https://github.com/apache/ambari/raw/trunk/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/hooks/before-START/files/fast-hdfs-resource.jar
+
 mvn clean package -DskipTests -Drat.skip
 
 (cd contrib/management-packs/odpi-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)

--- a/bigtop-packages/src/common/ambari/do-component-build
+++ b/bigtop-packages/src/common/ambari/do-component-build
@@ -25,4 +25,5 @@ sed -i "s|http://repo.spring.io|https://repo.spring.io|g" pom.xml
 
 mvn clean package -DskipTests -Drat.skip
 
-(cd contrib/management-packs/bgtp-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)
+(cd contrib/management-packs/odpi-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)
+(cd ../bgtp-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)

--- a/bigtop-packages/src/common/ambari/install_ambari.sh
+++ b/bigtop-packages/src/common/ambari/install_ambari.sh
@@ -90,7 +90,7 @@ cp -a  $SOURCE_DIR/ambari-common/src/main/unix/ambari-python-wrap ${PREFIX}/${VA
 # Both of these are a stopgap before we get our own stack
 rm -rf ${PREFIX}/var/lib/ambari-server/resources/stacks/HDP*
 mkdir -p ${PREFIX}/var/lib/ambari-server/resources/stacks/Bigtop/2.1
-cp $BUILD_DIR/contrib/management-packs/odpi-ambari-mpack/target/odpi-ambari-mpack-*.tar.gz ${PREFIX}/var/lib/ambari-server/resources
+cp $BUILD_DIR/contrib/management-packs/bgtp-ambari-mpack/target/bgtp-ambari-mpack-*.tar.gz ${PREFIX}/var/lib/ambari-server/resources
 
 # End of Ambari Server
 

--- a/bigtop-packages/src/common/ambari/install_ambari.sh
+++ b/bigtop-packages/src/common/ambari/install_ambari.sh
@@ -90,6 +90,7 @@ cp -a  $SOURCE_DIR/ambari-common/src/main/unix/ambari-python-wrap ${PREFIX}/${VA
 # Both of these are a stopgap before we get our own stack
 rm -rf ${PREFIX}/var/lib/ambari-server/resources/stacks/HDP*
 mkdir -p ${PREFIX}/var/lib/ambari-server/resources/stacks/Bigtop/2.1
+cp $BUILD_DIR/contrib/management-packs/odpi-ambari-mpack/target/odpi-ambari-mpack-*.tar.gz ${PREFIX}/var/lib/ambari-server/resources
 cp $BUILD_DIR/contrib/management-packs/bgtp-ambari-mpack/target/bgtp-ambari-mpack-*.tar.gz ${PREFIX}/var/lib/ambari-server/resources
 
 # End of Ambari Server

--- a/bigtop-tests/smoke-tests/ambari/TestAmbariSimple.groovy
+++ b/bigtop-tests/smoke-tests/ambari/TestAmbariSimple.groovy
@@ -47,10 +47,10 @@ class TestAmbariSmoke {
 
   @Test
   void testStackNameVersion() {
-     ambari.get( path: 'stacks/ODPi' ) { resp, json ->
+     ambari.get( path: 'stacks/BGTP' ) { resp, json ->
        println json
-       assertEquals("ODPi", json.versions.Versions[0].stack_name)
-       assertEquals("2.0", json.versions.Versions[0].stack_version)
+       assertEquals("BGTP", json.versions.Versions[0].stack_name)
+       assertEquals("1.0", json.versions.Versions[0].stack_version)
      } 
   }
 


### PR DESCRIPTION
As the  RFCs for Bigtop-mpack in BIGTOP-3211: 

1. Refer to the Ambari patch: https://github.com/apache/ambari/pull/3073 
2. When Armbari patch is merged by Ambari upstream, we will remove `patch3-AMBARI-MPACK.diff `from Bigtop.
3. Release Bigtop-mpack tarball for users 
4. Remove the odpi here because odpi is inactive and it doesn't work in Ambari now.
