### PR TITLE
BIGTOP-3266: Rat check failed for one file with unapproved/unknown li…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,7 @@ rat {
        "provisioner/docker/config/hieradata/PLACEHOLDER",
        "provisioner/docker/config/hosts",
        "bigtop_toolchain/files/*.patch",
+       "bigtop-bigpetstore/bigpetstore-transaction-queue/.dockerignore",
   ]
 }
 


### PR DESCRIPTION
Add .dockerignore to Rat exclude-file list.
