### PR TITLE
BIGTOP-3270 Resolve zk charm deprecation for implicit series

### DIFF
--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/metadata.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/metadata.yaml
@@ -11,6 +11,8 @@ description: >
   This charm provides version 3.4.6 of the Zookeeper application from Apache
   Bigtop.
 tags: []
+series:
+  - xenial
 provides:
   zookeeper:
     interface: zookeeper


### PR DESCRIPTION
This pull request resolves the deprecated warning for implicit series defined in the metadata.yaml when building the charm.

```
$ charm build
build: DEPRECATED: implicit series; specify series in metadata.yaml instead
build: Destination charm directory: /home/jlosito/charms/build/zookeeper
build: Processing layer: layer:options
build: Processing layer: layer:basic
build: Processing layer: layer:metrics
build: Processing layer: layer:nvidia-cuda
build: Processing layer: layer:apache-bigtop-base
build: Processing layer: layer:leadership
build: Processing layer: zookeeper (from .)
build: Processing interface: java
build: Processing interface: zookeeper-quorum
build: Processing interface: zookeeper
build: Processing interface: nrpe-external-master
build: Processing interface: local-monitors
proof: I: `display-name` not provided, add for custom naming in the UI
```

The xenial series added to the zk charm metadata is the default one added after a simple `juju deploy cs:zookeeper` as shown in the following output.

```
$ juju deploy cs:zookeeper
Located charm "cs:zookeeper-53".
Deploying charm "cs:zookeeper-53".

$ juju status
Model      Controller  Cloud/Region         Version  SLA          Timestamp
zookeeper  overlord    localhost/localhost  2.6.9    unsupported  09:55:46-04:00

App        Version  Status  Scale  Charm      Store       Rev  OS      Notes
zookeeper  3.4.6-1  active      1  zookeeper  jujucharms   53  ubuntu  

Unit          Workload  Agent  Machine  Public address  Ports              Message
zookeeper/0*  active    idle   0        10.41.194.66    2181/tcp,9998/tcp  ready  (1 unit; less than 3 is suboptimal)

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.41.194.66  juju-4fbf23-0  xenial      Running
```

closes (https://issues.apache.org/jira/browse/BIGTOP-3270)[#BIGTOP-3270]

Signed-off-by: John Losito <john.losito@canonical.com>