### PR TITLE
Add toggles for zk nagios checks

### DIFF
--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
@@ -39,6 +39,11 @@ options:
     description: |
       A comma-separated list of nagios servicegroups.
       If left empty, the nagios_context will be used as the servicegroup
+  open_file_descriptor_count_check:
+    default: true
+    type: boolean
+    description: |
+      Whether to enable the open file descriptor count check.
   open_file_descriptor_count_warn:
     default: 500
     type: int
@@ -49,6 +54,11 @@ options:
     type: int
     description: |
       The allowed open file descriptor count before a critical alert is triggered.
+  ephemerals_count_check:
+    default: true
+    type: boolean
+    description: |
+      Whether to enable the ephemerals count check.
   ephemerals_count_warn:
     default: 10000
     type: int
@@ -59,6 +69,11 @@ options:
     type: int
     description: |
       The allowed ephemerals count before a critical alert is triggered.
+  avg_latency_check:
+    default: true
+    type: boolean
+    description: |
+      Whether to enable the average latency check.
   avg_latency_warn:
     default: 500
     type: int
@@ -69,6 +84,11 @@ options:
     type: int
     description: |
       The allowed average latency before a critical alert is triggered.
+  max_latency_check:
+    default: true
+    type: boolean
+    description: |
+      Whether to enable the maximum latency check.
   max_latency_warn:
     default: 1000
     type: int
@@ -79,6 +99,11 @@ options:
     type: int
     description: |
       The allowed maximum latency before a critical alert is triggered.
+  min_latency_check:
+    default: true
+    type: boolean
+    description: |
+      Whether to enable the minimum latency check.
   min_latency_warn:
     default: 500
     type: int
@@ -89,6 +114,11 @@ options:
     type: int
     description: |
       The allowed minimum latency before a critical alert is triggered.
+  outstanding_requests_check:
+    default: true
+    type: boolean
+    description: |
+      Whether to enable the outstanding requests check.
   outstanding_requests_warn:
     default: 20
     type: int
@@ -99,6 +129,11 @@ options:
     type: int
     description: |
       The allowed outstanding requests before a critical alert is triggered.
+  watch_count_check:
+    default: true
+    type: boolean
+    description: |
+      Whether to enable the watch count check.
   watch_count_warn:
     default: 100
     type: int

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/reactive/zookeeper.py
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/reactive/zookeeper.py
@@ -45,50 +45,71 @@ def nrpe_external_master_available(nagios):
 def setup_nagios(nagios):
     config = hookenv.config()
     unit_name = hookenv.local_unit()
-    checks = [
-        {
-            'name': 'zk_open_file_descriptor_coun',
-            'description': 'ZK_Open_File_Descriptors_Count',
-            'warn': config['open_file_descriptor_count_warn'],
-            'crit': config['open_file_descriptor_count_crit']
-        },
-        {
-            'name': 'zk_ephemerals_count',
-            'description': 'ZK_Ephemerals_Count',
-            'warn': config['ephemerals_count_warn'],
-            'crit': config['ephemerals_count_crit']
-        },
-        {
-            'name': 'zk_avg_latency',
-            'description': 'ZK_Avg_Latency',
-            'warn': config['avg_latency_warn'],
-            'crit': config['avg_latency_crit']
-        },
-        {
-            'name': 'zk_max_latency',
-            'description': 'ZK_Max_Latency',
-            'warn': config['max_latency_warn'],
-            'crit': config['max_latency_crit']
-        },
-        {
-            'name': 'zk_min_latency',
-            'description': 'ZK_Min_Latency',
-            'warn': config['min_latency_warn'],
-            'crit': config['min_latency_crit']
-        },
-        {
-            'name': 'zk_outstanding_requests',
-            'description': 'ZK_Outstanding_Requests',
-            'warn': config['outstanding_requests_warn'],
-            'crit': config['outstanding_requests_crit']
-        },
-        {
-            'name': 'zk_watch_count',
-            'description': 'ZK_Watch_Count',
-            'warn': config['watch_count_warn'],
-            'crit': config['watch_count_crit']
-        },
-    ]
+    checks = []
+    if config['open_file_descriptor_count_check']:
+        checks.append(
+            {
+                'name': 'zk_open_file_descriptor_count',
+                'description': 'ZK_Open_File_Descriptors_Count',
+                'warn': config['open_file_descriptor_count_warn'],
+                'crit': config['open_file_descriptor_count_crit']
+            }
+        )
+    if config['ephemerals_count_check']:
+        checks.append(
+            {
+                'name': 'zk_ephemerals_count',
+                'description': 'ZK_Ephemerals_Count',
+                'warn': config['ephemerals_count_warn'],
+                'crit': config['ephemerals_count_crit']
+            }
+        )
+    if config['avg_latency_check']:
+        checks.append(
+            {
+                'name': 'zk_avg_latency',
+                'description': 'ZK_Avg_Latency',
+                'warn': config['avg_latency_warn'],
+                'crit': config['avg_latency_crit']
+            }
+        )
+    if config['max_latency_check']:
+        checks.append(
+            {
+                'name': 'zk_max_latency',
+                'description': 'ZK_Max_Latency',
+                'warn': config['max_latency_warn'],
+                'crit': config['max_latency_crit']
+            }
+        )
+    if config['min_latency_check']:
+        checks.append(
+            {
+                'name': 'zk_min_latency',
+                'description': 'ZK_Min_Latency',
+                'warn': config['min_latency_warn'],
+                'crit': config['min_latency_crit']
+            }
+        )
+    if config['outstanding_requests_check']:
+        checks.append(
+            {
+                'name': 'zk_outstanding_requests',
+                'description': 'ZK_Outstanding_Requests',
+                'warn': config['outstanding_requests_warn'],
+                'crit': config['outstanding_requests_crit']
+            }
+        )
+    if config['watch_count_check']:
+        checks.append(
+            {
+                'name': 'zk_watch_count',
+                'description': 'ZK_Watch_Count',
+                'warn': config['watch_count_warn'],
+                'crit': config['watch_count_crit']
+            }
+        )
+
     check_cmd = ['/usr/local/lib/nagios/plugins/check_zookeeper.py',
                  '-o', 'nagios', '-s', 'localhost:2181']
     for check in checks:


### PR DESCRIPTION
This pull request adds toggle switches for each of the local-monitor checks specific to zookeeper. The idea is that if one doesn't want one of the checks to run, one can set the associated *_check = false via `juju config zookeeper *_check=false`. 

Signed-off-by: John Losito <john.losito@canonical.com>

closes [BIGTOP-3269](https://issues.apache.org/jira/browse/BIGTOP-3269)

@kwmonroe 