### PR TITLE
BIGTOP-3276. Update supported distros in the toolchain manifests for v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,16 @@ __On all systems, Building Apache Bigtop requires certain set of tools__
   This build task expected Puppet to be installed; user has to have sudo permissions. The task will pull down and install
   all development dependencies, frameworks and SDKs, required to build the stack on your platform.
 
+  Before executing the above command, user can use the following script to install Puppet:
+
+    sudo bigtop_toolchain/bin/puppetize.sh
+
+  Note for CentOS (and RHEL, which is not supported officially but on a best effort basis) 8 users: on these distros,
+  puppetize.sh installs the puppet command into /opt/puppetlabs/bin, which is not included usually in secure_path defined in /etc/sudoers.
+  So users may have to add that path to secure_path manually.
+  Also, RHEL 8 users may have to enable their subscriptions themselves for using EPEL.
+  cf. https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F
+
   To immediately set environment after running toolchain, run
 
     . /etc/profile.d/bigtop.sh

--- a/bigtop-deploy/puppet/README.md
+++ b/bigtop-deploy/puppet/README.md
@@ -103,7 +103,7 @@ gradle toolchain-puppetmodules # if you already have JAVA installed
 or
 
 ```
-puppet apply --modulepath=<path_to_bigtop> -e "include bigtop_toolchain::puppet-modules"
+puppet apply --modulepath=<path_to_bigtop> -e "include bigtop_toolchain::puppet_modules"
 ```
 
 This will install the following module(s) for you:

--- a/bigtop_toolchain/README.md
+++ b/bigtop_toolchain/README.md
@@ -20,11 +20,11 @@ bigtop-toolchain
 
 Puppet module for configuring a host for building BigTop. It installs:
 
-**Apache Ant 1.9.4**
+**Apache Ant 1.9**
 
-**OpenJDK 1.7**
+**OpenJDK 1.8**
 
-**Apache Maven 3.2.5**
+**Apache Maven 3.5**
 
 **Gradle 2.4**
 
@@ -52,11 +52,11 @@ Or installed as a whole with:
 	  include bigtop_toolchain::installer
 	}
 
-It will create a user jenkins with the required  environment variables set for
+It will create a user jenkins with the required environment variables set for
 building BigTop:
 ```
 MAVEN_HOME=/usr/local/maven
-JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk.x86_64
+JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64
 ANT_HOME=/usr/local/ant
 GRADLE_HOME=/usr/local/gradle
 PATH=$MAVEN_HOME/bin:$ANT_HOME/bin:$FORREST_HOME/bin:$GRADLE_HOME/bin:$PATH
@@ -74,7 +74,7 @@ where <path_to_bigtop> is the cloned git repo.
 This is a separated set of manifests that helps to setup tools for Bigtop deployment.
 The usage is as below:
 
-	puppet apply --modulepath=<path_to_bigtop> -e "include bigtop_toolchain::deployment-tools"
+	puppet apply --modulepath=<path_to_bigtop> -e "include bigtop_toolchain::deployment_tools"
 
 By applying the snippet, Vagrant will be installed(the Docker installation will be added soon).
 
@@ -86,7 +86,7 @@ As Groovy isn't required (yet!) for creation of a Bigtop stack, this environment
 In case you system doesn't have already installed version of Bigtop recommended Groovy environment,
 you should be able to so easily by running
 
-	puppet apply --modulepath=<path_to_bigtop> -e "include bigtop_toolchain::development-tools"
+	puppet apply --modulepath=<path_to_bigtop> -e "include bigtop_toolchain::development_tools"
 
 Potentially, we'll be adding more development tools in this manifest.
 

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -21,22 +21,18 @@ if [ -f /etc/os-release ]; then
 fi
 
 case ${ID}-${VERSION_ID} in
-    fedora-26)
-      dnf -y install yum-utils
-      dnf -y check-update
-      dnf -y install hostname findutils curl sudo unzip wget puppet puppetlabs-stdlib procps-ng
+    fedora-31)
+        dnf -y install yum-utils
+        dnf -y check-update
+        dnf -y install hostname findutils curl sudo unzip wget puppet puppetlabs-stdlib procps-ng
         ;;
-    ubuntu-16.04)
+    ubuntu-16.04 | ubuntu-18.04)
         apt-get update
         apt-get -y install wget curl sudo unzip puppet software-properties-common puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib
         ;;
-    debian-9*)
+    debian-9* | debian-10*)
         apt-get update
         apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv
-         ;;
-    opensuse-42.3)
-        zypper --gpg-auto-import-keys install -y curl sudo unzip wget puppet suse-release ca-certificates-mozilla net-tools tar
-        puppet module install puppetlabs-stdlib
         ;;
     centos-7*)
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
@@ -46,6 +42,12 @@ case ${ID}-${VERSION_ID} in
         # puppet in distro is updated.
         yum -y install hostname curl sudo unzip wget puppet
         puppet module install puppetlabs-stdlib --version 4.12.0
+        ;;
+    centos-8* | rhel-8*)
+        rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm
+        dnf -y check-update
+        dnf -y install puppet-agent
+        /opt/puppetlabs/bin/puppet module install puppetlabs-stdlib
         ;;
     *)
         echo "Unsupported OS ${ID}-${VERSION_ID}."

--- a/bigtop_toolchain/manifests/cleanup.pp
+++ b/bigtop_toolchain/manifests/cleanup.pp
@@ -15,7 +15,7 @@
 
 class bigtop_toolchain::cleanup {
   $packager_cleanup = $operatingsystem ? {
-    /(?i:(centos|fedora|amazon))/ => 'yum clean all',
+    /(?i:(centos|fedora|redhat|amazon))/ => 'yum clean all',
     /(?i:(SLES|opensuse))/ => 'zypper clean -a',
     /Ubuntu|Debian/        => 'apt-get clean',
   } 

--- a/bigtop_toolchain/manifests/deployment_tools.pp
+++ b/bigtop_toolchain/manifests/deployment_tools.pp
@@ -13,31 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class bigtop_toolchain::puppet-modules {
-
-  exec { 'install-puppet-stdlib':
-    path    => '/usr/bin:/bin',
-    command => 'puppet module install puppetlabs-stdlib',
-    creates => '/etc/puppet/modules/stdlib',
-  }
-
-  case $operatingsystem{
-    /Ubuntu|Debian/: {
-      if versioncmp($::puppetversion, '4') < 0 {
-        $version = '--version 2.4.0'
-      } else {
-        $version = ''
-      }
-      exec { 'install-puppet-apt':
-        path    => '/usr/bin:/bin',
-        command => "puppet module install puppetlabs-apt ${version}",
-        creates => '/etc/puppet/modules/apt',
-      }
-    }
-  }
-
-  stage { 'first':
-    before => Stage['main'],
-  }
-  class { 'bigtop_toolchain::puppet-modules-prereq': stage => 'first' }
+class bigtop_toolchain::deployment_tools {
+  include bigtop_toolchain::vagrant
 }

--- a/bigtop_toolchain/manifests/development_tools.pp
+++ b/bigtop_toolchain/manifests/development_tools.pp
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class bigtop_toolchain::puppet-modules-prereq {
-
-  if versioncmp($::puppetversion,'3.0.0') < 0 {
-    fail("bigtop_toolchain::puppet-modules requires Puppet 3.0.0+, but found: $::puppetversion")
-  }
+class bigtop_toolchain::development_tools {
+  include bigtop_toolchain::groovy
 }

--- a/bigtop_toolchain/manifests/env.pp
+++ b/bigtop_toolchain/manifests/env.pp
@@ -25,10 +25,17 @@ class bigtop_toolchain::env {
     'x86_64' : { $arch = "x86_64"}
   }
   case $operatingsystem {
-    'Ubuntu','Debian': {
+    'Debian': {
+      if $::operatingsystemmajrelease =~ /^\d$/ {
+        $javahome = "/usr/lib/jvm/${java}-openjdk-$arch"
+      } else {
+        $javahome = "/usr/lib/jvm/adoptopenjdk-8-hotspot-$arch"
+      }
+    }
+    'Ubuntu': {
       $javahome = "/usr/lib/jvm/${java}-openjdk-$arch"
     }
-    'Fedora','Centos', 'Amazon': {
+    'Fedora','Centos','RedHat','Amazon': {
       $javahome = "/usr/lib/jvm/${java}"
     }
     'OpenSuSE' : {

--- a/bigtop_toolchain/manifests/gnupg.pp
+++ b/bigtop_toolchain/manifests/gnupg.pp
@@ -16,7 +16,7 @@
 class bigtop_toolchain::gnupg {
 
   case $operatingsystem {
-    /(?i:(centos|fedora))/: {
+    /(?i:(centos|fedora|redhat))/: {
        $pkg = "gnupg2"
        $cmd = "gpg2"
     }

--- a/bigtop_toolchain/manifests/puppet_modules.pp
+++ b/bigtop_toolchain/manifests/puppet_modules.pp
@@ -13,6 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class bigtop_toolchain::deployment-tools {
-  include bigtop_toolchain::vagrant
+class bigtop_toolchain::puppet_modules {
+
+  exec { 'install-puppet-stdlib':
+    path    => '/usr/bin:/bin',
+    command => 'puppet module install puppetlabs-stdlib',
+    creates => '/etc/puppet/modules/stdlib',
+  }
+
+  case $operatingsystem{
+    /Ubuntu|Debian/: {
+      if versioncmp($::puppetversion, '4') < 0 {
+        $version = '--version 2.4.0'
+      } else {
+        $version = ''
+      }
+      exec { 'install-puppet-apt':
+        path    => '/usr/bin:/bin',
+        command => "puppet module install puppetlabs-apt ${version}",
+        creates => '/etc/puppet/modules/apt',
+      }
+    }
+  }
+
+  stage { 'first':
+    before => Stage['main'],
+  }
+  class { 'bigtop_toolchain::puppet_modules_prereq': stage => 'first' }
 }

--- a/bigtop_toolchain/manifests/puppet_modules_prereq.pp
+++ b/bigtop_toolchain/manifests/puppet_modules_prereq.pp
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class bigtop_toolchain::development-tools {
-  include bigtop_toolchain::groovy
+class bigtop_toolchain::puppet_modules_prereq {
+
+  if versioncmp($::puppetversion,'3.0.0') < 0 {
+    fail("bigtop_toolchain::puppet_modules requires Puppet 3.0.0+, but found: $::puppetversion")
+  }
 }

--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -18,7 +18,7 @@ class bigtop_toolchain::renv {
   require bigtop_toolchain::packages
 
   case $operatingsystem{
-    /(?i:(centos|fedora|Amazon))/: {
+    /(?i:(centos|fedora|redhat|Amazon))/: {
       $pkgs = [
         "R",
         "R-devel",

--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ task toolchain(type:Exec,
   if ('3.7' <= version && version < '4') {
     command.addAll(['--parser', 'future'])
   }
-  command.addAll(["--modulepath=${projectDir.absolutePath}:/etc/puppet/modules:/usr/share/puppet/modules",
+  command.addAll(["--modulepath=${projectDir.absolutePath}:/etc/puppet/modules:/usr/share/puppet/modules:/etc/puppetlabs/code/environments/production/modules",
     '-e', 'include bigtop_toolchain::installer'])
   workingDir '.'
   commandLine command
@@ -242,7 +242,7 @@ task "toolchain-puppetmodules"(type:Exec,
   def command = [
       'sudo', 'puppet', 'apply', '-d',
       "--modulepath=${projectDir.absolutePath}", '-e',
-      'include bigtop_toolchain::puppet-modules'
+      'include bigtop_toolchain::puppet_modules'
   ]
   workingDir '.'
   commandLine command
@@ -253,7 +253,7 @@ task "toolchain-devtools"(type:Exec,
   def command = [
       'sudo', 'puppet', 'apply', '-d',
       "--modulepath=${projectDir.absolutePath}", '-e',
-      'include bigtop_toolchain::development-tools'
+      'include bigtop_toolchain::development_tools'
   ]
   workingDir '.'
   commandLine command


### PR DESCRIPTION
This PR adds CentOS 8 (and RHEL 8 for user convenience, as a non-official support), Debian 10, Fedora 31, and Ubuntu 18.04 and drops Fedora 26 and openSUSE 42 to/from bigtop_toolchain.

I confirmed that the following commands worked as expected:

```
$ sudo bigtop_toolchain/bin/puppetize.sh
$ sudo puppet apply --modulepath=$(pwd):/etc/puppet/modules:/usr/share/puppet/modules:/etc/puppetlabs/code/environments/production/modules -d -e 'include bigtop_toolchain::jdk'
$ ./gradlew toolchain
```

on the following distros, on an x86_64 arch machine.

- CentOS 7, 8
- Debian 9, 10
- Fedora 31
- Ubuntu 16.04, 18.04