### PR TITLE
BIGTOP-3236: Zeppelin smoke tests implementation

### DIFF
--- a/bigtop-packages/src/common/zeppelin/do-component-build
+++ b/bigtop-packages/src/common/zeppelin/do-component-build
@@ -42,6 +42,17 @@ fi
 
 export MAVEN_OPTS="-Xmx1500m -Xms1500m"
 
+# BIGTOP-2742:
+# The default zeppelin PIDFILE includes the literal $(hostname) string, which is carried into the init script's pidfile declaration.
+# But pidfile does not subshell out to generate the expected string.
+# The zeppelin process does indeed start up, but systemctl reports a failure because it's looking for a non-existent pidfile.
+#
+# Workaround:
+#   Remove unnecessary $HOSTNAME from zeppelin-daemon.sh and also make the same adjustment to zeppelin.svc.
+# TODO:
+#   Request the issue to zeppelin upstream, If accepted, remove this workaround.
+sed -i "s/^.*ZEPPELIN_PID=.*$/ZEPPELIN_PID=\"\$\{ZEPPELIN_PID_DIR\}\/zeppelin\-\$\{ZEPPELIN_IDENT_STRING\}\.pid\"/" bin/zeppelin-daemon.sh
+
 mvn $BUILD_OPTS clean package
 
 mkdir -p build/dist

--- a/bigtop-packages/src/common/zeppelin/zeppelin.svc
+++ b/bigtop-packages/src/common/zeppelin/zeppelin.svc
@@ -19,7 +19,10 @@ EXEC_PATH="/usr/lib/zeppelin/bin/zeppelin-daemon.sh"
 SVC_USER="zeppelin"
 WORKING_DIR="/var/lib/zeppelin"
 CONF_DIR="/etc/zeppelin/conf"
-PIDFILE="/var/run/zeppelin/zeppelin-${SVC_USER}-\$(hostname).pid"
+
+# PIDFILE="/var/run/zeppelin/zeppelin-${SVC_USER}-\$(hostname).pid"
+# Remove $hostname. The adjustment was aligned to 'zeppelin-daemon.sh'.
+PIDFILE="/var/run/zeppelin/zeppelin-${SVC_USER}.pid"
 
 generate_start_script() {
 cat <<'__EOT__'

--- a/bigtop-tests/smoke-tests/zeppelin/TestZeppelinSmoke.groovy
+++ b/bigtop-tests/smoke-tests/zeppelin/TestZeppelinSmoke.groovy
@@ -34,14 +34,11 @@ class TestZeppelinSmoke {
 
   private static String ZEPPELIN_HOME = System.getenv("ZEPPELIN_HOME");
 
-  /* Align with the version defined in bigtop.bom*/
-  private static String ZEPPELIN_VERSION = "0.7.3";
-
   @Test
   public void InstallIntperTest() {
     sh.exec(ZEPPELIN_HOME
       + "/bin/install-interpreter.sh "
-      + "--name shell --artifact org.apache.zeppelin:zeppelin-shell:${ZEPPELIN_VERSION}"
+      + "--name cassandra,scio,md,python,flink,hbase,bigquery,jdbc"
     );
     logError(sh);
     assertTrue("Install Interpreter failed." + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);

--- a/bigtop-tests/smoke-tests/zeppelin/TestZeppelinSmoke.groovy
+++ b/bigtop-tests/smoke-tests/zeppelin/TestZeppelinSmoke.groovy
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit.BeforeClass
+import org.junit.AfterClass
+import org.apache.bigtop.itest.shell.Shell
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
+import org.junit.Test
+import org.apache.bigtop.itest.JarContent
+import org.apache.bigtop.itest.TestUtils
+import org.junit.runner.RunWith
+import org.apache.bigtop.itest.shell.Shell
+import static org.apache.bigtop.itest.LogErrorsUtils.logError
+import static org.junit.Assert.assertTrue
+
+class TestZeppelinSmoke {
+  static Shell sh = new Shell("/bin/bash -s");
+
+  static final String ZEPPELIN_HOME = System.getenv("ZEPPELIN_HOME");
+
+  @Test
+  public void InstallIntperTest() {
+    sh.exec(ZEPPELIN_HOME
+      + "/bin/install-interpreter.sh "
+      + "--name shell --artifact org.apache.zeppelin:zeppelin-shell:0.7.3"
+    );
+    logError(sh);
+    assertTrue("Install Interpreter failed." + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);
+
+    sh.exec("su -s /bin/bash zeppelin -c \"cd /var/lib/zeppelin && /usr/lib/zeppelin/bin/zeppelin-daemon.sh --config '/etc/zeppelin/conf' restart > /dev/null 2>&1\" ");
+    logError(sh);
+    assertTrue("Zeppelin restart failed." + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);
+  }
+}

--- a/bigtop-tests/smoke-tests/zeppelin/TestZeppelinSmoke.groovy
+++ b/bigtop-tests/smoke-tests/zeppelin/TestZeppelinSmoke.groovy
@@ -32,13 +32,16 @@ import static org.junit.Assert.assertTrue
 class TestZeppelinSmoke {
   static Shell sh = new Shell("/bin/bash -s");
 
-  static final String ZEPPELIN_HOME = System.getenv("ZEPPELIN_HOME");
+  private static String ZEPPELIN_HOME = System.getenv("ZEPPELIN_HOME");
+
+  /* Align with the version defined in bigtop.bom*/
+  private static String ZEPPELIN_VERSION = "0.7.3";
 
   @Test
   public void InstallIntperTest() {
     sh.exec(ZEPPELIN_HOME
       + "/bin/install-interpreter.sh "
-      + "--name shell --artifact org.apache.zeppelin:zeppelin-shell:0.7.3"
+      + "--name shell --artifact org.apache.zeppelin:zeppelin-shell:${ZEPPELIN_VERSION}"
     );
     logError(sh);
     assertTrue("Install Interpreter failed." + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);

--- a/bigtop-tests/smoke-tests/zeppelin/build.gradle
+++ b/bigtop-tests/smoke-tests/zeppelin/build.gradle
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def tests_to_include() {
+  return [
+      "TestZeppelinSmoke.groovy"
+  ];
+}
+
+sourceSets {
+  test {
+    groovy {
+      srcDirs = ["${BIGTOP_HOME}/bigtop-tests/smoke-tests/zeppelin/"]
+      exclude { FileTreeElement elem -> (doExclude(elem.getName())) }
+    }
+  }
+}
+
+test.doFirst {
+  checkEnv(["ZEPPELIN_HOME", "ZOOKEEPER_HOME", "HADOOP_HOME"])
+}

--- a/provisioner/utils/setup-env-debian.sh
+++ b/provisioner/utils/setup-env-debian.sh
@@ -24,6 +24,8 @@ apt-get -y install rng-tools
 sed -i.bak 's@#HRNGDEVICE=/dev/null@HRNGDEVICE=/dev/urandom@' /etc/default/rng-tools
 service rng-tools start
 
+apt-get install -y locales
+
 if [ $enable_local_repo == "true" ]; then
     echo "deb file:///bigtop-home/output/apt bigtop contrib" > /etc/apt/sources.list.d/bigtop-home_output.list
     # In BIGTOP-2796 repo installed by puppet has priority 900, here we set higher priority for local repo

--- a/provisioner/utils/setup-env-debian.sh
+++ b/provisioner/utils/setup-env-debian.sh
@@ -24,6 +24,7 @@ apt-get -y install rng-tools
 sed -i.bak 's@#HRNGDEVICE=/dev/null@HRNGDEVICE=/dev/urandom@' /etc/default/rng-tools
 service rng-tools start
 
+# The testing process would be broken due to "No such file or derictory: /etc/default/locale" in ubuntu16.04.
 apt-get install -y locales
 
 if [ $enable_local_repo == "true" ]; then

--- a/provisioner/utils/smoke-tests.sh
+++ b/provisioner/utils/smoke-tests.sh
@@ -54,6 +54,7 @@ export LIVY_HOME=${LIVY_HOME:-/usr/lib/livy}
 export KAFKA_HOME=${KAFKA_HOME:-/usr/lib/kafka}
 export YCSB_HOME=${YCSB_HOME:-/usr/lib/ycsb}
 export TEZ_HOME=${TEZ_HOME:-/usr/lib/tez}
+export ZEPPELIN_HOME=${ZEPPELIN_HOME:-/usr/lib/zeppelin}
 
 echo -e "\n===== START TO RUN SMOKE TESTS: $SMOKE_TESTS =====\n"
 


### PR DESCRIPTION
The Smoke tests deployment by provisioner would be broken due to [BIGTOP-2742](https://issues.apache.org/jira/browse/BIGTOP-2742), but actually zeppelin server has been started.