### PR TITLE
BIGTOP-3288. Update support distros in the Docker build scripts for v1.5.0

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -24,7 +24,11 @@ case ${ID}-${VERSION_ID} in
     fedora-31)
         dnf -y install yum-utils
         dnf -y check-update
-        dnf -y install hostname findutils curl sudo unzip wget puppet puppetlabs-stdlib procps-ng
+        dnf -y install hostname findutils curl sudo unzip wget puppet procps-ng
+        # On Fedora 31, the puppetlabs-stdlib package provided by the distro installs the module
+        # into /usr/share/puppet/modules, but it's not recognized as the default module path.
+        # So we install that module in the same way as CentOS 7.
+        puppet module install puppetlabs-stdlib --version 4.12.0
         ;;
     ubuntu-16.04 | ubuntu-18.04)
         apt-get update
@@ -46,8 +50,11 @@ case ${ID}-${VERSION_ID} in
     centos-8* | rhel-8*)
         rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm
         dnf -y check-update
-        dnf -y install puppet-agent
+        dnf -y install hostname curl sudo unzip wget puppet-agent 'dnf-command(config-manager)'
         /opt/puppetlabs/bin/puppet module install puppetlabs-stdlib
+        # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.
+        # As a workaround for that, enable the former here in advance of running the Puppet manifests.
+        dnf config-manager --set-enabled PowerTools
         ;;
     *)
         echo "Unsupported OS ${ID}-${VERSION_ID}."

--- a/docker/bigtop-slaves/Dockerfile.template
+++ b/docker/bigtop-slaves/Dockerfile.template
@@ -19,6 +19,8 @@ MAINTAINER dev@bigtop.apache.org
 
 COPY bigtop_toolchain PUPPET_MODULES
 
-RUN  UPDATE_SOURCE && puppet apply -e "include bigtop_toolchain::installer" || if [ $? -ne 2 ]; then exit 1; fi
+RUN if [ -f ~/.bash_profile ]; then . ~/.bash_profile; fi && \
+    UPDATE_SOURCE && \
+    puppet apply -e "include bigtop_toolchain::installer" || if [ $? -ne 2 ]; then exit 1; fi
 COPY . /tmp/bigtop
 RUN cd /tmp/bigtop && ./gradlew && cd && rm -rf /tmp/*

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -41,7 +41,11 @@ fi
 # setup puppet/modules path and update cmds
 case ${OS} in
     ubuntu)
-        PUPPET_MODULES="/etc/puppet/modules/bigtop_toolchain"
+        if [ "${VERSION}" > "16.04" ]; then
+            PUPPET_MODULES="/usr/share/puppet/modules/bigtop_toolchain"
+        else
+            PUPPET_MODULES="/etc/puppet/modules/bigtop_toolchain"
+        fi
         UPDATE_SOURCE="apt-get clean \&\& apt-get update"
         ;;
     debian)
@@ -53,8 +57,13 @@ case ${OS} in
         UPDATE_SOURCE="dnf clean all \&\& dnf updateinfo"
         ;;
     centos)
-        PUPPET_MODULES="/etc/puppet/modules/bigtop_toolchain"
-        UPDATE_SOURCE="yum clean all \&\& yum updateinfo"
+        if [ "${VERSION}" -gt "7" ]; then
+            PUPPET_MODULES="/etc/puppetlabs/code/environments/production/modules/bigtop_toolchain"
+            UPDATE_SOURCE="dnf clean all \&\& dnf updateinfo"
+        else
+            PUPPET_MODULES="/etc/puppet/modules/bigtop_toolchain"
+            UPDATE_SOURCE="yum clean all \&\& yum updateinfo"
+        fi
         ;;
     opensuse)
         PUPPET_MODULES="/etc/puppet/modules/bigtop_toolchain"


### PR DESCRIPTION
* Add CentOS 8, Debian 10, Fedora 31, and Ubuntu 18.04 to the build scripts for bigtop-puppet and bigtop-slaves.
* Fix some issues in puppetize.sh.

I confirmed the bigtop-puppet and bigtop-slaves images for all supported distros in v1.5.0 were successfully created, as follows:

```
$ cd docker/bigtop-puppet
$ for i in centos-7 centos-8 debian-9 debian-10 fedora-31 ubuntu-16.04 ubuntu-18.04; do ./build.sh trunk-$i; done
$ echo $?
0
$ cd ../bigtop-slaves
$ for i in centos-7 centos-8 debian-9 debian-10 fedora-31 ubuntu-16.04 ubuntu-18.04; do ./build.sh trunk-$i; done
$ echo $?
0
$ docker images
REPOSITORY                                                            TAG                        IMAGE ID            CREATED             SIZE
bigtop/slaves                                                         trunk-ubuntu-18.04         5d2db18c670f        5 hours ago         3.12GB
bigtop/slaves                                                         trunk-ubuntu-16.04         26d1a5881973        5 hours ago         3.83GB
bigtop/slaves                                                         trunk-fedora-31            d0292c83cb80        6 hours ago         3.42GB
bigtop/slaves                                                         trunk-debian-10            0c48ea9c651d        7 hours ago         3.9GB
bigtop/slaves                                                         trunk-debian-9             557e89f4f191        7 hours ago         4.5GB
bigtop/slaves                                                         trunk-centos-8             02fd52a19acb        8 hours ago         3.5GB
bigtop/slaves                                                         trunk-centos-7             3a8b3fd444ec        9 hours ago         2.75GB
bigtop/puppet                                                         trunk-ubuntu-18.04         57f634dd4421        45 hours ago        240MB
bigtop/puppet                                                         trunk-ubuntu-16.04         1e9a2ff715af        45 hours ago        311MB
bigtop/puppet                                                         trunk-fedora-31            72bb7a0ea1d3        45 hours ago        517MB
bigtop/puppet                                                         trunk-debian-10            6521db959f31        45 hours ago        309MB
bigtop/puppet                                                         trunk-debian-9             ede43569af9f        45 hours ago        282MB
bigtop/puppet                                                         trunk-centos-8             c0055b386672        45 hours ago        394MB
bigtop/puppet                                                         trunk-centos-7             0a5c34699142        45 hours ago        409MB
```