### PR TITLE
BIGTOP-3285. Bump Kafka to 2.4.0

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -351,7 +351,7 @@ bigtop {
     'kafka' {
       name    = 'kafka'
       relNotes = 'Apache Kafka'
-      version { base = '0.10.2.2'; pkg = base; release = 1 }
+      version { base = '2.4.0'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
I confirmed Kafka's latest stable version 2.4.0. 
I confirmed this patch worked on CentOS 8 at least.

The following log is smoke test running log.
```
[root@ip-172-31-16-186 bigtop]# cd bigtop-tests/smoke-tests/kafka
[root@ip-172-31-16-186 kafka]# ../../../gradlew test -Psmoke.tests --stacktrace
<============-> 93% EXECUTING [5s]
> :bigtop-tests:smoke-tests:kafka:test > 0 tests completed
> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
<============-> 93% EXECUTING [5s]cessed session termination for sessionid: 0x1000054bf270002 (org.apache.zookeeper.server.PrepRequestProcessor)
> :bigtop-tests:smoke-tests:kafka:test > 0 tests completedr client /172.31.16.186:53550 which had sessionid 0x1000054bf270002 (org.apache.zookeep> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
[2020-02-12 13:41:04,737] INFO Accepted socket connection from /172.31.16.186:53574 (org.apache.zookeeper.server.NIOServerCnxnFactory)
<============-> 93% EXECUTING [5s]ent attempting to establish new session at /172.31.16.186:53574 (org.apache.zookeeper.server.ZooKeeperServer)
> :bigtop-tests:smoke-tests:kafka:test > 0 tests completed54bf270005 with negotiated timeout 6000 for client /172.31.16.186:53574 (org.apache.zoo> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
[2020-02-12 13:41:04,803] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x1 zxid:0x39 txntype:-1 reqpath:n/a Error Path:/consumers Error:KeeperErrorCode = NodeExists for /consumers (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,811] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x2 zxid:0x3a txntype:-1 reqpath:n/a Error Path:/brokers/ids Error:KeeperErrorCode = NodeExists for /brokers/ids (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,813] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x3 zxid:0x3b txntype:-1 reqpath:n/a Error Path:/brokers/topics Error:KeeperErrorCode = NodeExists for /brokers/topics (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,814] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x4 zxid:0x3c txntype:-1 reqpath:n/a Error Path:/config/changes Error:KeeperErrorCode = NodeExists for /config/changes (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,816] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x5 zxid:0x3d txntype:-1 reqpath:n/a Error Path:/admin/delete_topics Error:KeeperErrorCode = NodeExists for /admin/delete_topics (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,818] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x6 zxid:0x3e txntype:-1 reqpath:n/a Error Path:/brokers/seqid Error:KeeperErrorCode = NodeExists for /brokers/seqid (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,819] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x7 zxid:0x3f txntype:-1 reqpath:n/a Error Path:/isr_change_notification Error:KeeperErrorCode = NodeExists for /isr_change_notification (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,821] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x8 zxid:0x40 txntype:-1 reqpath:n/a Error Path:/latest_producer_id_block Error:KeeperErrorCode = NodeExists for /latest_producer_id_block (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,823] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0x9 zxid:0x41 txntype:-1 reqpath:n/a Error Path:/log_dir_event_notification Error:KeeperErrorCode = NodeExists for /log_dir_event_notification (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,825] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0xa zxid:0x42 txntype:-1 reqpath:n/a Error Path:/config/topics Error:KeeperErrorCode = NodeExists for /config/topics (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,826] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0xb zxid:0x43 txntype:-1 reqpath:n/a Error Path:/config/clients Error:KeeperErrorCode = NodeExists for /config/clients (org.apache.zookeeper.server.PrepRequestProcessor)
[2020-02-12 13:41:04,827] INFO Got user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0xc zxid:0x44 txntype:-1 reqpath:n/a Error Path:/config/users Error:KeeperErrorCode = NodeExists for /config/users (org.apache.zookeeper.server.PrepRequestProcessor)
<============-> 93% EXECUTING [6s] user-level KeeperException when processing sessionid:0x1000054bf270005 type:create cxid:0xd zxid:0x45 txntype:> :bigtop-tests:smoke-tests:kafka:test > 0 tests completedrCode = NodeExists for /config/brokers (org.apache.zookeeper.server.PrepRequestProcesso> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
<============-> 93% EXECUTING [7s] user-level KeeperException when processing sessionid:0x1000054bf270005 type:multi cxid:0x28 zxid:0x4a txntype:> :bigtop-tests:smoke-tests:kafka:test > 0 tests completeddmin/preferred_replica_election Error:KeeperErrorCode = NoNode for /admin/preferred_rep> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
[2020-02-12 13:41:06,886] INFO Accepted socket connection from /0:0:0:0:0:0:0:1:57578 (org.apache.zookeeper.server.NIOServerCnxnFactory)
<============-> 93% EXECUTING [7s]ent attempting to establish new session at /0:0:0:0:0:0:0:1:57578 (org.apache.zookeeper.server.ZooKeeperServer)
> :bigtop-tests:smoke-tests:kafka:test > 0 tests completed54bf270006 with negotiated timeout 30000 for client /0:0:0:0:0:0:0:1:57578 (org.apache.> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
<============-> 93% EXECUTING [8s] user-level KeeperException when processing sessionid:0x1000054bf270006 type:setData cxid:0x4 zxid:0x4c txntype> :bigtop-tests:smoke-tests:kafka:test > 0 tests completedrErrorCode = NoNode for /config/topics/test (org.apache.zookeeper.server.PrepRequestPro> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
<============-> 93% EXECUTING [9s]cessed session termination for sessionid: 0x1000054bf270006 (org.apache.zookeeper.server.PrepRequestProcessor)
> :bigtop-tests:smoke-tests:kafka:test > 0 tests completedr client /0:0:0:0:0:0:0:1:57578 which had sessionid 0x1000054bf270006 (org.apache.zooke> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
[2020-02-12 13:41:08,608] INFO Accepted socket connection from /127.0.0.1:45292 (org.apache.zookeeper.server.NIOServerCnxnFactory)
[2020-02-12 13:41:08,610] INFO Client attempting to establish new session at /127.0.0.1:45292 (org.apache.zookeeper.server.ZooKeeperServer)
[2020-02-12 13:41:08,612] INFO Established session 0x1000054bf270007 with negotiated timeout 30000 for client /127.0.0.1:45292 (org.apache.zookeeper.server.ZooKeeperServer)
<============-> 93% EXECUTING [10s]essed session termination for sessionid: 0x1000054bf270007 (org.apache.zookeeper.server.PrepRequestProcessor)
> :bigtop-tests:smoke-tests:kafka:test > 1 test completed> :bigtop-tests:smoke-tests:kafka:test > Executing test org.apache.bigtop.itest.kafka.TestKafkaSmoke
[2020-02-12 13:41:09,988] INFO Accepted socket connection from /0:0:0:0:0:0:0:1:57582 (org.apache.zookeeper.server.NIOServerCnxnFactory)
[2020-02-12 13:41:09,990] INFO Client attempting to establish new session at /0:0:0:0:0:0:0:1:57582 (org.apache.zookeeper.server.ZooKeeperServer)
[2020-02-12 13:41:09,991] INFO Established session 0x1000054bf270008 with negotiated timeout 30000 for client /0:0:0:0:0:0:0:1:57582 (org.apache.zookeeper.server.ZooKeeperServer)

> Task :bigtop-tests:smoke-tests:kafka:testNow testing...

BUILD SUCCESSFUL in 12s
6 actionable tasks: 6 executed
```