### PR TITLE
BIGTOP-3311: Fix Alluxio build failure with upgraded hadoop version

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -20,5 +20,6 @@ set -ex
 
 t="hadoop.version"
 sed -i "s#<$t>.*</$t>#<$t>${HADOOP_VERSION}</$t>#" pom.xml
+sed -i "s|http://repo.spring.io|https://repo.spring.io|g" pom.xml
 
 mvn clean install -DskipTests -Pspark -Pyarn "$@"

--- a/bigtop-packages/src/common/alluxio/patch1-fix-hadoop-version-check.diff
+++ b/bigtop-packages/src/common/alluxio/patch1-fix-hadoop-version-check.diff
@@ -1,0 +1,13 @@
+diff --git a/integration/yarn/pom.xml b/integration/yarn/pom.xml
+index 7196350..e11713c 100644
+--- a/integration/yarn/pom.xml
++++ b/integration/yarn/pom.xml
+@@ -90,7 +90,7 @@
+               <rules>
+                 <requireProperty>
+                   <property>hadoop.version</property>
+-                  <regex>[^12]\..*|2\.[4-9]\..*</regex>
++                  <regex>[^12]\..*|2\.([4-9]|[1-9]\d{1,})\..*</regex>
+                   <regexMessage>
+                     hadoop.version must be 2.4.0 or later to build yarn integration.
+                   </regexMessage>

--- a/bigtop-packages/src/rpm/alluxio/SPECS/alluxio.spec
+++ b/bigtop-packages/src/rpm/alluxio/SPECS/alluxio.spec
@@ -28,6 +28,7 @@ Source2:       install_alluxio.sh
 Source3:       init.d.tmpl
 Source4:       alluxio-master.svc
 Source5:       alluxio-worker.svc
+#BIGTOP_PATCH_FILES
 %define        alluxio_name alluxio
 %define        alluxio_home /usr/lib/%{alluxio_name}
 %define        alluxio_services master worker
@@ -78,6 +79,8 @@ are frequently read.
 
 %prep
 %setup -n %{alluxio_name}-%{alluxio_base_version}
+
+#BIGTOP_PATCH_COMMANDS
 
 %build
 bash $RPM_SOURCE_DIR/do-component-build


### PR DESCRIPTION
Alluxio build failed after hadoop is bumpped to 2.10.0. The reason is
the version check regex in integration/yarn/pom.xml doesn't cover
version higher than 2.9.x.
Spring release repo is upgraded to https access.

Change-Id: I83e38af640881e8d61213d58a636af7d50393cdb
Signed-off-by: Jun He <jun.he@arm.com>