### PR TITLE
BIGTOP-3313: Bump solor to 6.6.6

### DIFF
--- a/bigtop-packages/src/common/solr/do-component-build
+++ b/bigtop-packages/src/common/solr/do-component-build
@@ -18,10 +18,11 @@ set -ex
 
 . `dirname $0`/bigtop.bom
 
-IVY_MIRROR_PROP=${IVY_MIRROR_PROP:-http://repo1.maven.org/maven2/}
+IVY_MIRROR_PROP=${IVY_MIRROR_PROP:-https://repo1.maven.org/maven2}
 BUILD_OPTS="-Dversion=${FULL_VERSION} -Dhadoop.version=${HADOOP_VERSION} \
             -Dslf4j.binding=slf4j-log4j12 -Dexclude.from.war=nothing   \
             -Divy.home=${HOME}/.ivy2 -Drepo.maven.org=$IVY_MIRROR_PROP \
+            -Divy_bootstrap_url1=$IVY_MIRROR_PROP \
             -Divy_install_path=${HOME}/.ant/lib -lib ${HOME}/.ant/lib  \
             -Dreactor.repo=file://${HOME}/.m2/repository"
 

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -255,7 +255,7 @@ bigtop {
     'solr' {
       name    = 'solr'
       relNotes = 'Apache Solr'
-      version { base = '6.6.0'; pkg = base; release = 1 }
+      version { base = '6.6.6'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tgz"
                 source      = destination }
       url     { download_path = "lucene/$name/${version.base}"


### PR DESCRIPTION
Bump solr to latest version of 6.x branch.
Also updated maven repo to https access

Change-Id: I7f09d72d51d6c89b172e796189261590b37444c4
Signed-off-by: Jun He <jun.he@arm.com>