### PR TITLE
BIGTOP-3312: Fix Ambari build failure as maven repo only accepts http…

### DIFF
--- a/bigtop-packages/src/common/ambari/do-component-build
+++ b/bigtop-packages/src/common/ambari/do-component-build
@@ -18,6 +18,11 @@ set -ex
 . `dirname $0`/bigtop.bom
 
 export _JAVA_OPTIONS="-Xmx2048m -Djava.awt.headless=true"
+
+# these two repos haven updated to accpet https access only
+sed -i "s|http://download.java.net|https://download.java.net|g" pom.xml
+sed -i "s|http://repo.spring.io|https://repo.spring.io|g" pom.xml
+
 mvn clean package -DskipTests -Drat.skip
 
 (cd contrib/management-packs/odpi-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)


### PR DESCRIPTION
…s now

Maven repo has been upgrade to accept https access only.
The URLs defined in ambari pom.xml need to be changed to https.

Change-Id: I77ff02631800cd2ba7abfef071e903262039ee17
Signed-off-by: Jun He <jun.he@arm.com>