### PR TITLE
BIGTOP-3316: Fix HBase build failure on Arm platform

### DIFF
--- a/bigtop-packages/src/common/hbase/do-component-build
+++ b/bigtop-packages/src/common/hbase/do-component-build
@@ -33,8 +33,12 @@ fi
 rm -f hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestBulkLoad.java
 
 if [ $HOSTTYPE = "aarch64" ] ; then
-   sed -i '/<version>1.5.0-alpha.6<\/version>/,+1d' ./pom.xml
-   sed -i '/<artifactId>asciidoctorj-pdf<\/artifactId>/a\<version>1.5.0-alpha.6<\/version>\n</dependency>\n<dependency>\n<groupId>org.jruby<\/groupId>\n<artifactId>jruby-complete<\/artifactId>\n<version>9.1.8.0<\/version>\n<\/dependency>' ./pom.xml
+  sed -i '/asciidoctorj-pdf/!{p;d;};n;n;a'\
+'\          <dependency>\n'\
+'\             <groupId>org.jruby<\/groupId>\n'\
+'\             <artifactId>jruby-complete<\/artifactId>\n'\
+'\             <version>9.1.8.0</version>\n'\
+'\          <\/dependency>' pom.xml
 fi
 
 MVN_ARGS="-DskipTests "


### PR DESCRIPTION
After HBase is bumped to 1.5.0, jruby patch command in build
script doesn't apply due to regex not match.
This patch refines sed command to make it more versatile to
various asciidoctorj-pdf versions.

Change-Id: Ib414ba3e7b66cf08e2080c75e1c83c563fa88224
Signed-off-by: Jun He <jun.he@arm.com>