### PR TITLE
BIGTOP-3314: Fix flink build failure with upgraded hadoop version

### DIFF
--- a/bigtop-packages/src/common/flink/patch0-fix-ApplicationReport-api.diff
+++ b/bigtop-packages/src/common/flink/patch0-fix-ApplicationReport-api.diff
@@ -1,0 +1,12 @@
+diff --git a/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java b/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
+index 8ee08db..fcd56d0 100644
+--- a/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
++++ b/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
+@@ -98,6 +98,7 @@ public class AbstractYarnClusterTest extends TestLogger {
+ 			yarnApplicationState,
+ 			null,
+ 			null,
++			0,
+ 			1L,
+ 			2L,
+ 			finalApplicationStatus,


### PR DESCRIPTION
Flink 1.6.4 failed to build with new hadoop 2.10.0. The root cause
is ApplicationReport newInstance API is changed.
Add a patch to upgrade API call in flink.

Change-Id: I5ae0f0e786a92f805feace67d5fe2facea0d9314
Signed-off-by: Jun He <jun.he@arm.com>