### PR TITLE
BIGTOP-3317: fix broken symlink for hadoop-hdfs.jar

### DIFF
--- a/bigtop-packages/src/deb/oozie/rules
+++ b/bigtop-packages/src/deb/oozie/rules
@@ -46,7 +46,7 @@ override_dh_auto_install:
 	ln -sf /usr/lib/hadoop/client/hadoop-annotations.jar debian/oozie/usr/lib/oozie/lib/
 	ln -sf /usr/lib/hadoop/client/hadoop-auth.jar debian/oozie/usr/lib/oozie/lib/
 	ln -sf /usr/lib/hadoop/client/hadoop-common.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-hdfs.jar debian/oozie/usr/lib/oozie/lib/
+	ln -sf /usr/lib/hadoop/client/hadoop-hdfs-client.jar debian/oozie/usr/lib/oozie/lib/
 	ln -sf /usr/lib/hadoop/client/hadoop-mapreduce-client-app.jar debian/oozie/usr/lib/oozie/lib/
 	ln -sf /usr/lib/hadoop/client/hadoop-mapreduce-client-common.jar debian/oozie/usr/lib/oozie/lib/
 	ln -sf /usr/lib/hadoop/client/hadoop-mapreduce-client-core.jar debian/oozie/usr/lib/oozie/lib/

--- a/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
+++ b/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
@@ -156,7 +156,7 @@ Requires: bigtop-utils >= 0.7
 %__ln_s -f %{lib_hadoop}/client/hadoop-annotations.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
 %__ln_s -f %{lib_hadoop}/client/hadoop-auth.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
 %__ln_s -f %{lib_hadoop}/client/hadoop-common.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-hdfs.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
+%__ln_s -f %{lib_hadoop}/client/hadoop-hdfs-client.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
 %__ln_s -f %{lib_hadoop}/client/hadoop-mapreduce-client-app.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
 %__ln_s -f %{lib_hadoop}/client/hadoop-mapreduce-client-common.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
 %__ln_s -f %{lib_hadoop}/client/hadoop-mapreduce-client-core.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/


### PR DESCRIPTION
On Debian 9 the hadoop-hdfs.jar is broken, and causes failures like
oozie sharedlib creation on HDFS. This change replaces it with
hadoop-hdfs-client.jar, that seems to work.