### PR TITLE
BIGTOP-3330: avoid duplicate jars between oozie and oozie-client

### DIFF
--- a/bigtop-packages/src/common/oozie/install_oozie.sh
+++ b/bigtop-packages/src/common/oozie/install_oozie.sh
@@ -232,3 +232,8 @@ cp -R ${BUILD_DIR}/libtools ${SERVER_LIB_DIR}/
 # Provide a convenience symlink to be more consistent with tarball deployment
 ln -s ${DATA_DIR#${SERVER_PREFIX}} ${SERVER_LIB_DIR}/libext
 
+# Remove jars provided by 'oozie-client' from 'oozie' to avoid run-time issues
+# while installing the package.
+for oozie_client_jar_file in $(ls $CLIENT_LIB_DIR/lib); do
+  rm -f $SERVER_LIB_DIR/lib/$oozie_client_jar_file
+done


### PR DESCRIPTION
Add a workaround to the install_oozie.sh script to avoid duplicate
jars between oozie and oozie-client. This issue leads to override
errors when installing the oozie package on Debian (oozie-client
is among its dependencies).

Credis to Olaf Flebbe for the solution.

Tested the packages on a Debian system and it seems working fine.