### PR TITLE
BIGTOP-3351: Fix sqoop build error on Ubuntu 18.04

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -161,6 +161,7 @@ class bigtop_toolchain::packages {
         "g++",
         "fuse",
         "reprepro",
+        "rsync",
         "liblzo2-dev",
         "libfuse-dev",
         "libcppunit-dev",


### PR DESCRIPTION
rsync package missing
