### PR TITLE
BIGTOP-3352: Fix qfs build error on Ubuntu 18.04

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -172,6 +172,7 @@ class bigtop_toolchain::packages {
         "devscripts",
         "build-essential",
         "dh-make",
+        "dh-python",
         "libfuse2",
         "libjansi-java",
         "python2.7-dev",


### PR DESCRIPTION
dh-python package missing.
