### PR TITLE
BIGTOP-3353: hive.hwi.war.file configuration is no longer needed

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop_hive/templates/hive-site.xml
+++ b/bigtop-deploy/puppet/modules/hadoop_hive/templates/hive-site.xml
@@ -73,11 +73,6 @@
   <description>Driver class name for a JDBC metastore</description>
 </property>
 
-<property>
-  <name>hive.hwi.war.file</name>
-  <value>/usr/lib/hive/lib/hive-hwi.war</value>
-  <description>This is the WAR file with the jsp content for Hive Web Interface</description>
-</property>
 
 <property>
    <name>hive.server2.allow.user.substitution</name>

--- a/bigtop-packages/src/common/hive/hive-site.xml
+++ b/bigtop-packages/src/common/hive/hive-site.xml
@@ -39,10 +39,4 @@
   <description>Driver class name for a JDBC metastore</description>
 </property>
 
-<property>
-  <name>hive.hwi.war.file</name>
-  <value>/usr/lib/hive/lib/hive-hwi-@VERSION@.war</value>
-  <description>This is the WAR file with the jsp content for Hive Web Interface</description>
-</property>
-
 </configuration>


### PR DESCRIPTION
I confirmed that `hive.hwi.war.file` property exists in:

```
$ git log --oneline -n 1
399a210d (HEAD -> master, origin/master, origin/HEAD) BIGTOP-3347. Fix test failures of Hive ProxyFileSystem against Hadoop 2.10.0. (#633)
$ git grep hive.hwi.war.file
bigtop-deploy/puppet/modules/hadoop_hive/templates/hive-site.xml:  <name>hive.hwi.war.file</name>
bigtop-packages/src/common/hive/hive-site.xml:  <name>hive.hwi.war.file</name>
```


With this PR, I confirmed there is no `hive.hwi.war.file` property anymore.
(Prerequisite: built hive and dependent packages and created local repositoy)

* rpm

```
$ sudo yum install hive*
(snip)
$ grep hive.hwi.war.file /etc/hive/conf/hive-site.xml
$ (no output)
```

<details>
<summary>hive-site.xml</summary>
<pre>
<code>
$ cat /etc/hive/conf/hive-site.xml
<?xml version="1.0"?>
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>

<configuration>

<!-- Hive Configuration can either be stored in this file or in the hadoop configuration files  -->
<!-- that are implied by Hadoop setup variables.                                                -->
<!-- Aside from Hadoop setup variables - this file is provided as a convenience so that Hive    -->
<!-- users do not have to edit hadoop configuration files (that may be managed as a centralized -->
<!-- resource).                                                                                 -->

<!-- Hive Execution Parameters -->

<property>
  <name>javax.jdo.option.ConnectionURL</name>
  <value>jdbc:derby:;databaseName=/var/lib/hive/metastore/metastore_db;create=true</value>
  <description>JDBC connect string for a JDBC metastore</description>
</property>

<property>
  <name>javax.jdo.option.ConnectionDriverName</name>
  <value>org.apache.derby.jdbc.EmbeddedDriver</value>
  <description>Driver class name for a JDBC metastore</description>
</property>

</configuration>
</code>
</pre>
</details>

* Puppet

config.yaml:

```
docker:
        memory_limit: "4g"
        image: "bigtop/puppet:trunk-centos-7"

#repo: "http://repos.bigtop.apache.org/releases/1.4.0/centos/7/$basearch"
distro: centos
components: [hdfs, yarn, hive]
enable_local_repo: true
smoke_test_components: [hdfs, yarn, hive]
```

```
$ cd provisioner/docker/
$ sudo ./docker-hadoop.sh -c 1
(snip)
$ sudo ./docker-hadoop.sh --exec 1 /bin/bash
WARNING: The DOCKER_IMAGE variable is not set. Defaulting to a blank string.
WARNING: The MEM_LIMIT variable is not set. Defaulting to a blank string.
[root@c9606e07aeda /]# grep hive.hwi.war.file /etc/hive/conf/hive-site.xml
[root@c9606e07aeda /]# (no output)
```

<details>
<summary>hive-site.xml</summary>
<pre>
<code>
[root@c9606e07aeda /]# cat /etc/hive/conf/hive-site.xml
<?xml version="1.0"?>
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>

<!-- Licensed to the Apache Software Foundation (ASF) under one or more       -->
<!-- contributor license agreements.  See the NOTICE file distributed with    -->
<!-- this work for additional information regarding copyright ownership.      -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0  -->
<!-- (the "License"); you may not use this file except in compliance with     -->
<!-- the License.  You may obtain a copy of the License at                    -->
<!--                                                                          -->
<!--     http://www.apache.org/licenses/LICENSE-2.0                           -->
<!--                                                                          -->
<!-- Unless required by applicable law or agreed to in writing, software      -->
<!-- distributed under the License is distributed on an "AS IS" BASIS,        -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and      -->
<!-- limitations under the License.                                           -->

<configuration>

<!-- Hive Configuration can either be stored in this file or in the hadoop configuration files  -->
<!-- that are implied by Hadoop setup variables.                                                -->
<!-- Aside from Hadoop setup variables - this file is provided as a convenience so that Hive    -->
<!-- users do not have to edit hadoop configuration files (that may be managed as a centralized -->
<!-- resource).                                                                                 -->

<!-- Hive Execution Parameters -->




<property>
  <name>hbase.zookeeper.quorum</name>
  <value>c9606e07aeda.bigtop.apache.org</value>
  <description>http://wiki.apache.org/hadoop/Hive/HBaseIntegration</description>
</property>




<property>
  <name>hive.support.concurrency</name>
  <value>false</value>
  <description>Enable Hive's Table Lock Manager Service</description>
</property>


<property>
  <name>javax.jdo.option.ConnectionURL</name>
  <value>jdbc:derby:;databaseName=/var/lib/hive/metastore/metastore_db;create=true</value>
  <description>JDBC connect string for a JDBC metastore</description>
</property>

<property>
  <name>javax.jdo.option.ConnectionDriverName</name>
  <value>org.apache.derby.jdbc.EmbeddedDriver</value>
  <description>Driver class name for a JDBC metastore</description>
</property>


<property>
   <name>hive.server2.allow.user.substitution</name>
   <value>true</value>
</property>

<property>
   <name>hive.server2.enable.doAs</name>
   <value>true</value>
</property>

<property>
   <name>hive.server2.thrift.port</name>
   <value>10000</value>
</property>

<property>
   <name>hive.server2.thrift.http.port</name>
   <value>10001</value>
</property>


<property>
   <name>hive.metastore.uris</name>
   <value>thrift://c9606e07aeda.bigtop.apache.org:9083</value>
</property>


<property>
   <name>hive.security.metastore.authorization.manager</name>
   <value>org.apache.hadoop.hive.ql.security.authorization.StorageBasedAuthorizationProvider</value>
</property>



<property>
  <name>hive.metastore.schema.verification</name>
   <value>false</value>
  <description>
    Enforce metastore schema version consistency.
    True: Verify that version information stored in is compatible with one from Hive jars.  Also disable automatic
          schema migration attempt. Users are required to manually migrate schema after Hive upgrade which ensures
          proper metastore schema migration. (Default)
    False: Warn if the version information stored in metastore doesn't match with one from in Hive jars.
  </description>
</property>

<property>
   <name>datanucleus.schema.autoCreateAll</name>
   <value>true</value>
  <description>
    Creates necessary schema on a startup if one does not exist. Reset this to false, after creating it once.
    datanucleus.schema.autoCreateAll is disabled if hive.metastore.schema.verification is true.
  </description>
</property>

</configuration>

</code>
</pre>
</details>

