### PR TITLE
[Puppet] Make GPG check for repos a configuration and default to true

### DIFF
--- a/bigtop-deploy/puppet/hiera.yaml
+++ b/bigtop-deploy/puppet/hiera.yaml
@@ -5,3 +5,4 @@
   - site
   - "bigtop/%{hadoop_hiera_ha_path}"
   - bigtop/cluster
+  - bigtop/repo

--- a/bigtop-deploy/puppet/hieradata/bigtop/repo.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/repo.yaml
@@ -1,0 +1,5 @@
+bigtop::bigtop_repo_gpg_check: true
+bigtop::bigtop_repo_apt_key: "BB95B97B18226C73CB2838D1DBBF9D42B7B4BD70"
+bigtop::bigtop_repo_yum_key_url: "https://downloads.apache.org/bigtop/KEYS"
+bigtop::bigtop_repo_default_version: "1.4.0"
+

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -97,6 +97,12 @@ create() {
     fi
     if [ -z ${enable_local_repo+x} ]; then
         enable_local_repo=$(get-yaml-config enable_local_repo)
+        if [ $enable_local_repo == true ]; then
+            # When enabling local repo, set gpg check to false
+            gpg_check=false
+        else
+            gpg_check=true
+        fi
     fi
     generate-config "$hadoop_head_node" "$repo" "$components"
 
@@ -130,6 +136,7 @@ generate-config() {
 bigtop::hadoop_head_node: $1
 hadoop::hadoop_storage_dirs: [/data/1, /data/2]
 bigtop::bigtop_repo_uri: $2
+bigtop::bigtop_repo_gpg_check: $gpg_check
 hadoop_cluster_node::cluster_components: $3
 hadoop_cluster_node::cluster_nodes: [$node_list]
 EOF

--- a/provisioner/utils/setup-env-debian.sh
+++ b/provisioner/utils/setup-env-debian.sh
@@ -35,7 +35,8 @@ Pin-Priority: 901
 EOF
     apt-get update
 else
-    apt-get install -y apt-transport-https
+    # Install gpg so that puppet apt module can fetch the gpg key
+    apt-get install -y apt-transport-https gpg
     echo "local apt = $enable_local_repo ; NOT Enabling local apt. Packages will be pulled from remote..."
 fi
 


### PR DESCRIPTION
Tested via:
```
./docker-hadoop.sh -d -C config_debian-9.yaml -c 3
./docker-hadoop.sh -d -C config_centos-7.yaml -c 3
```
Also changes the value of gpg_check to true/false and see whether the change reflected to the deployed env.