### PR TITLE
BIGTOP-3358: get_roles() function should fail if a component is not in roles_map

### DIFF
--- a/bigtop-deploy/puppet/manifests/cluster.pp
+++ b/bigtop-deploy/puppet/manifests/cluster.pp
@@ -54,7 +54,7 @@ $roles_map = {
     # mapred is the default app which runs on yarn.
     library => ["mapred-app"],
   },
-  mapred => {
+  mapreduce => {
     library => ["mapred-app"],
   },
   kms => {

--- a/bigtop-deploy/puppet/modules/bigtop-util/lib/puppet/parser/functions/get_roles.rb
+++ b/bigtop-deploy/puppet/modules/bigtop-util/lib/puppet/parser/functions/get_roles.rb
@@ -54,6 +54,8 @@ Puppet::Parser::Functions.newfunction(:get_roles, :type => :rvalue) do |argument
           temp_roles = component_map[role_type]
           roles.concat(temp_roles)
         end
+      else
+        fail Puppet::ParseError, "get_roles(): No such component in roles_map. #{component}"
       end
     end
   end


### PR DESCRIPTION
This PR updates `get_roles.rb` to be faild if there is no such component which is specified in user config.

Before:
```
$ cat config.yaml
docker:
        memory_limit: "4g"
        image: "bigtop/puppet:trunk-centos-7"

repo: "http://repos.bigtop.apache.org/releases/1.4.0/centos/7/$basearch"
distro: centos
components: [foobar]
enable_local_repo: false
smoke_test_components: []
$ ./docker-hadoop.sh -c 1
(snip)
(not failed)
```

After:
```
$ ./docker-hadoop.sh -c 1
(snip)

Error: get_roles(): No such component in roles_map. foobar on node 7541662d9555.bigtop.apache.org
Error: get_roles(): No such component in roles_map. foobar on node 7541662d9555.bigtop.apache.org

[LOG] Failed to provision container 7541662d95558968b99a07be71813b030a0f827243ca7a3d0f6c25c9d6cc784c with exit code 1

```

Also I updated existed config files as I noticed that there is no such component `mapreduce` but `mapred`.