### PR TITLE
BIGTOP-3361: No libcrypt.so.1 in Fedora-31

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -24,7 +24,7 @@ case ${ID}-${VERSION_ID} in
     fedora-31)
         dnf -y install yum-utils
         dnf -y check-update
-        dnf -y install hostname findutils curl sudo unzip wget puppet procps-ng
+        dnf -y install hostname findutils curl sudo unzip wget puppet procps-ng libxcrypt-compat
         # On Fedora 31, the puppetlabs-stdlib package provided by the distro installs the module
         # into /usr/share/puppet/modules, but it's not recognized as the default module path.
         # So we install that module in the same way as CentOS 7.


### PR DESCRIPTION
libcrypt.so.1 is not available in Fedora-31 for Arm64 (both in bigtop/puppet and bigtop/slaves) and x86( just in bigtop/puppet).
It would cause some dependency issues when some pacakges need to link it such as jffi.
Add libxcrypt-compat in Bigtop_toolchain to fix it.
