### PR TITLE
BIGTOP-3369: RHEL8 does not have PowerTools repo but CodeReady Builder

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -47,7 +47,7 @@ case ${ID}-${VERSION_ID} in
         yum -y install hostname curl sudo unzip wget puppet
         puppet module install puppetlabs-stdlib --version 4.12.0
         ;;
-    centos-8* | rhel-8*)
+    centos-8*)
         rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm
         dnf -y check-update
         dnf -y install hostname curl sudo unzip wget puppet-agent 'dnf-command(config-manager)'
@@ -55,6 +55,15 @@ case ${ID}-${VERSION_ID} in
         # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.
         # As a workaround for that, enable the former here in advance of running the Puppet manifests.
         dnf config-manager --set-enabled PowerTools
+        ;;
+    rhel-8*)
+        rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm
+        dnf -y check-update
+        dnf -y install hostname curl sudo unzip wget puppet-agent 'dnf-command(config-manager)'
+        puppet module install puppetlabs-stdlib
+        # Enabling the CodeReady repositories via Puppet doesn't seem to work in some cases.
+        # As a workaround for that, enable the former here in advance of running the Puppet manifests.
+        dnf config-manager --set-enabled codeready-builder-for-rhel-8-rhui-rpms
         ;;
     *)
         echo "Unsupported OS ${ID}-${VERSION_ID}."


### PR DESCRIPTION
Update puppetize.sh to use CodeReady repo when the environment is RHEL8.

I tested this change w/ RHEL8 on AWS EC2.

Note that if you want to run puppetize.sh, you may have to add /opt/puppetlabs/bin in secure_path as noted in [README.md](https://github.com/apache/bigtop/blob/master/README.md#for-developers-building-the-entire-distribution-from-scratch) and re-login.

(Though this is out-of-scope of this PR, should we automate this process?)