### PR TITLE
BIGTOP-3355. [Puppet] Make GPG check for repos a configuration and default to true

### DIFF
--- a/bigtop-deploy/puppet/hiera.yaml
+++ b/bigtop-deploy/puppet/hiera.yaml
@@ -5,3 +5,4 @@
   - site
   - "bigtop/%{hadoop_hiera_ha_path}"
   - bigtop/cluster
+  - bigtop/repo

--- a/bigtop-deploy/puppet/hieradata/bigtop/repo.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/repo.yaml
@@ -1,0 +1,5 @@
+bigtop::bigtop_repo_gpg_check: true
+bigtop::bigtop_repo_apt_key: "BB95B97B18226C73CB2838D1DBBF9D42B7B4BD70"
+bigtop::bigtop_repo_yum_key_url: "https://downloads.apache.org/bigtop/KEYS"
+bigtop::bigtop_repo_default_version: "1.4.0"
+

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -97,6 +97,12 @@ create() {
     fi
     if [ -z ${enable_local_repo+x} ]; then
         enable_local_repo=$(get-yaml-config enable_local_repo)
+        if [ $enable_local_repo == true ]; then
+            # When enabling local repo, set gpg check to false
+            gpg_check=false
+        else
+            gpg_check=true
+        fi
     fi
     generate-config "$hadoop_head_node" "$repo" "$components"
 
@@ -130,6 +136,7 @@ generate-config() {
 bigtop::hadoop_head_node: $1
 hadoop::hadoop_storage_dirs: [/data/1, /data/2]
 bigtop::bigtop_repo_uri: $2
+bigtop::bigtop_repo_gpg_check: $gpg_check
 hadoop_cluster_node::cluster_components: $3
 hadoop_cluster_node::cluster_nodes: [$node_list]
 EOF

--- a/provisioner/utils/setup-env-debian.sh
+++ b/provisioner/utils/setup-env-debian.sh
@@ -38,7 +38,8 @@ Pin-Priority: 901
 EOF
     apt-get update
 else
-    apt-get install -y apt-transport-https
+    # Install gpg so that puppet apt module can fetch the gpg key
+    apt-get install -y apt-transport-https gnupg
     echo "local apt = $enable_local_repo ; NOT Enabling local apt. Packages will be pulled from remote..."
 fi
 


### PR DESCRIPTION
I added a little modification (only replaced a package name "gpg" with "gnupg") to the PR @evans-ye submitted in #639 so that it works with Debian 9.

I tested this on Debian 9 and Ubuntu 16.04 as follows:

* Disable local repo (= enable GPG check) on Debian 9:

```
~/repos/bigtop/provisioner/docker$ cat config_debian-9.yaml 

(snip)

docker:
        memory_limit: "4g"
        image: "bigtop/puppet:trunk-debian-9"

repo: "http://repos.bigtop.apache.org/releases/1.4.0/debian/9/$(ARCH)"
distro: debian
components: [hdfs, yarn, mapreduce]
enable_local_repo: false
smoke_test_components: [hdfs, yarn, mapreduce]
~/repos/bigtop/provisioner/docker$ ./docker-hadoop.sh -d -C config_debian-9.yaml -c 1

(snip)

Notice: /Stage[main]/Bigtop_repo/Apt::Key[add_key]/Apt_key[add_key]/ensure: created

(snip)

Notice: Applied catalog in 380.05 seconds
~/repos/bigtop/provisioner/docker$ echo $?
0
~/repos/bigtop/provisioner/docker$ docker exec -it 20200703213349r22366_bigtop_1 apt-key list
/etc/apt/trusted.gpg
--------------------
pub   rsa4096 2019-03-30 [SC]
      BB95 B97B 1822 6C73 CB28  38D1 DBBF 9D42 B7B4 BD70
uid           [ unknown] Evans Ye (CODE SIGNING KEY 2) <evansye@apache.org>
sub   rsa4096 2019-03-30 [E]

(snip)
```

* Enable local repo (= disable GPG check), on Ubuntu 16.04:

```
~/bigtop/provisioner/docker$ cat config_ubuntu-16.04.yaml 

(snip)

docker:
        memory_limit: "4g"
        image:  "bigtop/puppet:trunk-ubuntu-16.04"

repo: "http://repos.bigtop.apache.org/releases/1.4.0/ubuntu/16.04/$(ARCH)"
distro: debian
components: [hdfs, yarn, mapreduce]
enable_local_repo: true
smoke_test_components: [hdfs, yarn, mapreduce]
~/bigtop/provisioner/docker$ ./docker-hadoop.sh -d -C config_ubuntu-16.04.yaml -c 1

(snip)

Notice: /Stage[main]/Bigtop_repo/Apt::Conf[disable_keys]/Apt::Setting[conf-disable_keys]/File[/etc/apt/apt.conf.d/50disable_keys]/ensure: created

(snip)

Notice: Finished catalog run in 284.91 seconds
~/bigtop/provisioner/docker$ echo $?
0
~/bigtop/provisioner/docker$ docker exec -it 20200703_135327_r28971_bigtop_1 apt-key list
/etc/apt/trusted.gpg
--------------------
pub   1024D/437D05B5 2004-09-12
uid                  Ubuntu Archive Automatic Signing Key <ftpmaster@ubuntu.com>
sub   2048g/79164387 2004-09-12

pub   4096R/C0B21F32 2012-05-11
uid                  Ubuntu Archive Automatic Signing Key (2012) <ftpmaster@ubuntu.com>

pub   4096R/EFE21092 2012-05-11
uid                  Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>

pub   1024D/FBB75451 2004-12-30
uid                  Ubuntu CD Image Automatic Signing Key <cdimage@ubuntu.com>

~/bigtop/provisioner/docker$ 
```
