### PR TITLE
BIGTOP-3380. Bump Tomcat to 8.5.57.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -341,7 +341,7 @@ bigtop {
     'bigtop-tomcat' {
       name    = "bigtop-tomcat"
       relNotes = "Apache Tomcat"
-      version { base = '8.5.50'; pkg = base; release = 1 }
+      version { base = '8.5.57'; pkg = base; release = 1 }
       tarball { source      = "apache-tomcat-${version.base}-src.tar.gz"
                 destination = "apache-tomcat-${version.base}.tar.gz" }
       url     { download_path = "/tomcat/tomcat-8/v${version.base}/src"


### PR DESCRIPTION
Please refer to [BIGTOP-3380](https://issues.apache.org/jira/browse/BIGTOP-3380) for the background.