### PR TITLE
BIGTOP-3371. Unable to build Apache Ambari on RHEL8.

### DIFF
--- a/bigtop-packages/src/common/ambari/patch4-AMBARI-CentOS8.diff
+++ b/bigtop-packages/src/common/ambari/patch4-AMBARI-CentOS8.diff
@@ -12,10 +12,10 @@ index 07b0b68319..9cfc2daeb5 100644
 +rpm.dependency.list=openssl,\nRequires: zlib,\nRequires: python2 >= 2.6
 +deb.dependency.list=openssl, zlibc, python (>= 2.6)
 diff --git a/ambari-common/src/main/python/resource_management/core/providers/package/__init__.py b/ambari-common/src/main/python/resource_management/core/providers/package/__init__.py
-index 799cf3eed0..ade58292cb 100644
+index 799cf3eed0..bc066e6318 100644
 --- a/ambari-common/src/main/python/resource_management/core/providers/package/__init__.py
 +++ b/ambari-common/src/main/python/resource_management/core/providers/package/__init__.py
-@@ -359,9 +359,8 @@ class RPMBasedPackageProvider(PackageProvider):
+@@ -359,17 +359,13 @@ class RPMBasedPackageProvider(PackageProvider):
    INSTALLED_PACKAGE_VERSION_COMMAND = "rpm -q --queryformat '%{{version}}-%{{release}}' \"{0}\""
  
    def rpm_check_package_available(self, name):
@@ -27,6 +27,15 @@ index 799cf3eed0..ade58292cb 100644
  
      name_regex = re.escape(name).replace("\\?", ".").replace("\\*", ".*") + '$'
      regex = re.compile(name_regex)
+ 
+-    for package in packages:
+-      if regex.match(package['name']):
+-        return True
+-    return False
++    return any(regex.match(package) for package in packages)
+ 
+   def get_installed_package_version(self, package_name):
+     version = None
 diff --git a/ambari-common/src/main/python/resource_management/core/providers/package/yumrpm.py b/ambari-common/src/main/python/resource_management/core/providers/package/yumrpm.py
 index da2a3b1de1..503644137c 100644
 --- a/ambari-common/src/main/python/resource_management/core/providers/package/yumrpm.py

--- a/bigtop-packages/src/common/ambari/patch4-AMBARI-CentOS8.diff
+++ b/bigtop-packages/src/common/ambari/patch4-AMBARI-CentOS8.diff
@@ -1,0 +1,59 @@
+diff --git a/ambari-agent/src/main/package/dependencies.properties b/ambari-agent/src/main/package/dependencies.properties
+index 07b0b68319..9cfc2daeb5 100644
+--- a/ambari-agent/src/main/package/dependencies.properties
++++ b/ambari-agent/src/main/package/dependencies.properties
+@@ -28,5 +28,5 @@
+ # Such a format is respected by install_ambari_tarball.py by default, 
+ # however should be encouraged manually in pom.xml.
+ 
+-rpm.dependency.list=openssl,\nRequires: rpm-python,\nRequires: zlib,\nRequires: python >= 2.6
+-deb.dependency.list=openssl, zlibc, python (>= 2.6)
+\ No newline at end of file
++rpm.dependency.list=openssl,\nRequires: zlib,\nRequires: python2 >= 2.6
++deb.dependency.list=openssl, zlibc, python (>= 2.6)
+diff --git a/ambari-common/src/main/python/resource_management/core/providers/package/__init__.py b/ambari-common/src/main/python/resource_management/core/providers/package/__init__.py
+index 799cf3eed0..ade58292cb 100644
+--- a/ambari-common/src/main/python/resource_management/core/providers/package/__init__.py
++++ b/ambari-common/src/main/python/resource_management/core/providers/package/__init__.py
+@@ -359,9 +359,8 @@ class RPMBasedPackageProvider(PackageProvider):
+   INSTALLED_PACKAGE_VERSION_COMMAND = "rpm -q --queryformat '%{{version}}-%{{release}}' \"{0}\""
+ 
+   def rpm_check_package_available(self, name):
+-    import rpm # this is faster then calling 'rpm'-binary externally.
+-    ts = rpm.TransactionSet()
+-    packages = ts.dbMatch()
++    import os
++    packages = os.popen("rpm -qa --queryformat '%{name} '").read().split()
+ 
+     name_regex = re.escape(name).replace("\\?", ".").replace("\\*", ".*") + '$'
+     regex = re.compile(name_regex)
+diff --git a/ambari-common/src/main/python/resource_management/core/providers/package/yumrpm.py b/ambari-common/src/main/python/resource_management/core/providers/package/yumrpm.py
+index da2a3b1de1..503644137c 100644
+--- a/ambari-common/src/main/python/resource_management/core/providers/package/yumrpm.py
++++ b/ambari-common/src/main/python/resource_management/core/providers/package/yumrpm.py
+@@ -305,10 +305,7 @@ class YumProvider(RPMBasedPackageProvider):
+     yum in inconsistant state (locked, used, having invalid repo). Once packages are installed
+     we should not rely on that.
+     """
+-    if os.geteuid() == 0: 
+-      return self.yum_check_package_available(name)
+-    else:
+-      return self.rpm_check_package_available(name)
++    return self.rpm_check_package_available(name)
+ 
+   def yum_check_package_available(self, name):
+     """
+diff --git a/ambari-server/src/main/package/dependencies.properties b/ambari-server/src/main/package/dependencies.properties
+index 01244a8375..70205d5dc6 100644
+--- a/ambari-server/src/main/package/dependencies.properties
++++ b/ambari-server/src/main/package/dependencies.properties
+@@ -28,6 +28,6 @@
+ # Such a format is respected by install_ambari_tarball.py by default, 
+ # however should be encouraged manually in pom.xml.
+ 
+-rpm.dependency.list=postgresql-server >= 8.1,\nRequires: openssl,\nRequires: python >= 2.6
++rpm.dependency.list=postgresql-server >= 8.1,\nRequires: openssl,\nRequires: python2 >= 2.6
+ rpm.dependency.list.suse=postgresql-server >= 8.1,\nRequires: openssl,\nRequires: python-xml,\nRequires: python >= 2.6
+-deb.dependency.list=openssl, postgresql (>= 8.1), python (>= 2.6), curl
+\ No newline at end of file
++deb.dependency.list=openssl, postgresql (>= 8.1), python (>= 2.6), curl

--- a/bigtop-packages/src/rpm/ambari/SPECS/ambari.spec
+++ b/bigtop-packages/src/rpm/ambari/SPECS/ambari.spec
@@ -71,7 +71,7 @@ AMBARI_VERSION=%{ambari_version} bash $RPM_SOURCE_DIR/install_ambari.sh \
 Summary: Ambari Server
 Group: Development/Libraries
 # BIGTOP-3139: install initscripts to workaround service command not available issue
-Requires: openssl, postgresql-server >= 8.1, python >= 2.6, curl, initscripts
+Requires: openssl, postgresql-server >= 8.1, python2 >= 2.6, curl, initscripts
 AutoProv: no
 AutoReqProv: no
 %description server
@@ -260,7 +260,7 @@ exit 0
 %package agent
 Summary: Ambari Agent
 Group: Development/Libraries
-Requires: openssl, zlib, python >= 2.6, rpm-python
+Requires: openssl, zlib, python2 >= 2.6
 AutoProv: no
 AutoReqProv: no
 %description agent

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -257,4 +257,12 @@ class bigtop_toolchain::packages {
   exec { "flake8 and whell Installation":
     command => "/usr/bin/pip3 freeze --all; /usr/bin/pip3 --version; /usr/bin/pip3 install -q flake8 wheel",
   }
+
+  if ($operatingsystem == 'Fedora' and versioncmp($operatingsystemmajrelease, '31') >= 0) or
+     ($osfamily == 'RedHat' and $operatingsystem != 'Fedora' and versioncmp($operatingsystemmajrelease, '8') >= 0) {
+    file { '/usr/bin/python':
+      ensure => 'link',
+      target => '/usr/bin/python2',
+    }
+  }
 }


### PR DESCRIPTION
@guyuqi @mattAndruff @masatana Would you review if possible? In this PR, I intended:

* Specify python package name explicitly as 'python2' in spec files so that they work with CentOS 8 and Fedora 31
* Replace Ambari functions that depend on the rpm-python package, which is not provided on CentOS 8, with an implementation using the `rpm` command
* Define the `python` command as an alias of `python2` on CentOS 8 and Fedora 31, which don't provide unversioned python command by default

I confirmed that Ambari, Livy and Zeppelin (the latter of two use Python3, in contrast to Ambari) are successfully built on CentOS 7, 8 and Fedora 31 with this PR.