### PR TITLE
BIGTOP-3389 (addendum). Extend timeout for installing R packages again.

### DIFF
--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -49,6 +49,6 @@ class bigtop_toolchain::renv {
   exec { 'install_r_packages':
     cwd     => "/usr/bin",
     command => "/usr/bin/R -e \"install.packages(c('devtools', 'evaluate', 'rmarkdown', 'knitr', 'roxygen2', 'testthat', 'e1071'), repos = 'http://cran.us.r-project.org')\"",
-    timeout => 3000
+    timeout => 6000
   }
 }


### PR DESCRIPTION
Follow-up for #660.