### PR TITLE
BIGTOP-3390. Building Alluxio fails on Fedora 31.

### DIFF
--- a/bigtop-packages/src/rpm/alluxio/SPECS/alluxio.spec
+++ b/bigtop-packages/src/rpm/alluxio/SPECS/alluxio.spec
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+%define        alluxio_name alluxio
 
 Name:           alluxio
 Version:        %{alluxio_version}
@@ -29,7 +30,6 @@ Source3:       init.d.tmpl
 Source4:       alluxio-master.svc
 Source5:       alluxio-worker.svc
 #BIGTOP_PATCH_FILES
-%define        alluxio_name alluxio
 %define        alluxio_home /usr/lib/%{alluxio_name}
 %define        alluxio_services master worker
 %define        var_lib /var/lib/%{alluxio_name}


### PR DESCRIPTION
I confirmed that building alluxio succeeded on Fedora 31 and CentOS 7/8 (as regression test) with this PR.