### PR TITLE
BIGTOP-3392. All packaging jobs are failing on Fedora 31 for aarch64 and ppc64le.

### DIFF
--- a/bigtop-ci/build.sh
+++ b/bigtop-ci/build.sh
@@ -17,7 +17,7 @@
 BIGTOP_HOME=`cd $(dirname $0)/.. && pwd`
 
 usage() {
-    echo "usage build.sh --prefix trunk|1.3.0|1.2.1|... --os debian-8|centos-7|... --target hadoop|tez|... [--nexus]"
+    echo "usage build.sh --prefix trunk|1.4.0|1.3.0|... --os debian-9|centos-7|... --target hadoop|tez|... [--nexus] [--docker-run-option ...]"
     exit 1 # unknown option
 }
 
@@ -46,6 +46,10 @@ case $key in
     CONFIGURE_NEXUS="configure-nexus"
     shift
     ;;
+    --docker-run-option)
+    DOCKER_RUN_OPTION="$2"
+    shift
+    ;;
     *)
     usage
     ;;
@@ -72,7 +76,7 @@ if [ "x86_64" != $ARCH ]; then
 fi
 
 # Start up build container
-CONTAINER_ID=`docker run -d $NEXUS $IMAGE_NAME /sbin/init`
+CONTAINER_ID=`docker run -d $DOCKER_RUN_OPTION $NEXUS $IMAGE_NAME /sbin/init`
 trap "docker rm -f $CONTAINER_ID" EXIT
 
 # Copy bigtop repo into container

--- a/packages.gradle
+++ b/packages.gradle
@@ -628,13 +628,14 @@ def genTasks = { target ->
   }
   task "$target-pkg-ind" (
           description: "Invoking a native binary packaging for $target in Docker. Usage: \$ ./gradlew " +
-                  "-POS=[centos-7|fedora-26|debian-9|ubuntu-16.04|opensuse-42.3] " +
-                  "-Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] $target-pkg-ind " +
+                  "-POS=[centos-7|fedora-31|debian-9|ubuntu-16.04] " +
+                  "-Pprefix=[trunk|1.4.0|1.3.0|1.2.1|...] $target-pkg-ind " +
                   "-Pnexus=[true|false]",
           group: PACKAGES_GROUP) doLast {
     def _prefix = project.hasProperty("prefix") ? prefix : "trunk"
     def _OS = project.hasProperty("OS") ? OS : "centos-7"
     def _target_pkg = "$target-pkg"
+    def _docker_run_option = project.hasProperty("docker-run-option") ? this.'docker-run-option' : ""
     def additionalConfigKeys = ['git_repo', 'git_ref', 'git_dir', 'git_commit_hash', 'base_version']
     additionalConfigKeys.each { key ->
       if (project.hasProperty(key)) {
@@ -647,6 +648,7 @@ def genTasks = { target ->
             '--prefix', _prefix,
             '--os', _OS,
             '--target', _target_pkg,
+            '--docker-run-option', _docker_run_option,
     ]
     if ( project.hasProperty("nexus") ) {
       command.add('--nexus')
@@ -845,17 +847,19 @@ if (nativePackaging) {
 
 task "repo-ind" (
     description: "Invoking a native repository in Docker. Usage: \$ ./gradlew " +
-            "-POS=[centos-7|fedora-26|debian-9|ubuntu-16.04|opensuse-42.3] " +
-            "-Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] repo-ind",
+            "-POS=[centos-7|fedora-31|debian-9|ubuntu-16.04] " +
+            "-Pprefix=[trunk|1.4.0|1.3.0|1.2.1|...] repo-ind",
     group: PACKAGES_GROUP) doLast {
   def _prefix = project.hasProperty("prefix") ? prefix : "trunk"
   def _OS = project.hasProperty("OS") ? OS : "centos-7"
+  def _docker_run_option = project.hasProperty("docker-run-option") ? this.'docker-run-option' : ""
   def command = [
       'bash', '-x',
       './bigtop-ci/build.sh',
       '--prefix', _prefix,
       '--os', _OS,
-      '--target', 'repo'
+      '--target', 'repo',
+      '--docker-run-option', _docker_run_option
   ]
   exec {
     workingDir BASE_DIR


### PR DESCRIPTION
With this PR, we can pass some options from Jenkins to the `docker run` command for avoiding the problem reported as BIGTOP-3392.
I confirmed that the specified options were passed to the `docker run` command, as follows:

```
$ ./gradlew -Pprefix=trunk -POS=debian-9 -Pdocker-run-option="-v $HOME/.m2:/root/.m2" bigtop-utils-pkg-ind

(snip)

++ docker run -d -v /home/sekikn/.m2:/root/.m2 bigtop/slaves:trunk-debian-9 /sbin/init

(snip)

BUILD SUCCESSFUL in 6m 15s
1 actionable task: 1 executed
```

```
$ ./gradlew -Pprefix=trunk -POS=debian-9 -Pdocker-run-option="-v $HOME/.m2:/root/.m2" repo-ind

(snip)

++ docker run -d -v /home/sekikn/.m2:/root/.m2 bigtop/slaves:trunk-debian-9 /sbin/init

(snip)

BUILD SUCCESSFUL in 5m 14s
1 actionable task: 1 executed
```