### PR TITLE
BIGTOP-3391: Support GPDB on Perl 5.30+ environment

### DIFF
--- a/bigtop-packages/src/common/gpdb/patch2-fix-deprecated-first-element-index-in-perl.diff
+++ b/bigtop-packages/src/common/gpdb/patch2-fix-deprecated-first-element-index-in-perl.diff
@@ -1,0 +1,106 @@
+diff --git a/src/interfaces/ecpg/preproc/parse.pl b/src/interfaces/ecpg/preproc/parse.pl
+index f694484bea..61d289eed1 100644
+--- a/src/interfaces/ecpg/preproc/parse.pl
++++ b/src/interfaces/ecpg/preproc/parse.pl
+@@ -18,7 +18,7 @@ if (@ARGV) {
+ 
+ if ($path eq '') { $path = "."; }
+ 
+-$[ = 1;			# set array base to 1
++#$[ = 1;			# set array base to 1
+ $, = ' ';		# set output field separator
+ $\ = "\n";		# set output record separator
+ 
+@@ -113,12 +113,12 @@ line: while (<>) {
+     # Now split the line into individual fields
+     $n = (@arr = split(' ', $S));
+ 
+-    if ($arr[1] eq '%token' && $tokenmode == 0) {
++    if ($arr[0] eq '%token' && $tokenmode == 0) {
+ 	$tokenmode = 1;
+ 	&include_stuff('tokens', 'ecpg.tokens', '', 1, 0);
+ 	#$type = 1;
+     }
+-    elsif ($arr[1] eq '%type' && $header_included == 0) {
++    elsif ($arr[0] eq '%type' && $header_included == 0) {
+ 	&include_stuff('header', 'ecpg.header', '', 1, 0);
+ 	&include_stuff('ecpgtype', 'ecpg.type', '', 1, 0);
+ 	$header_included = 1;
+@@ -126,7 +126,7 @@ line: while (<>) {
+ 
+     if ($tokenmode == 1) {
+ 	$str = '';
+-	for ($a = 1; $a <= $n; $a++) {
++	for ($a = 0; $a < $n; $a++) {
+ 	    if ($arr[$a] eq '/*') {
+ 		$comment++;
+ 		next;
+@@ -138,7 +138,7 @@ line: while (<>) {
+ 	    if ($comment) {
+ 		next;
+ 	    }
+-	    if (substr($arr[$a], 1, 1) eq '<') {
++	    if (substr($arr[$a], 0, 1) eq '<') {
+ 		next;
+ 		# its a type
+ 	    }
+@@ -160,7 +160,7 @@ line: while (<>) {
+     }
+ 
+     # Go through each field in turn
+-    for ($fieldIndexer = 1; $fieldIndexer <= $n; $fieldIndexer++) {
++    for ($fieldIndexer = 0; $fieldIndexer < $n; $fieldIndexer++) {
+ 	if ($arr[$fieldIndexer] eq '*/' && $comment) {
+ 	    $comment = 0;
+ 	    next;
+@@ -316,11 +316,11 @@ sub include_stuff {
+     $inblock = 0;
+     $filename = $path . "/" . $includefilename;
+     while (($_ = &Getline2($filename),$getline_ok)) {
+-	if ($includeblock ne '' && $Fld[1] eq 'ECPG:' && $inblock == 0) {
+-	    if ($Fld[2] eq $includeblock) {
++	if ($includeblock ne '' && $Fld[0] eq 'ECPG:' && $inblock == 0) {
++	    if ($Fld[1] eq $includeblock) {
+ 		$copy = 1;
+ 		$inblock = 1;
+-		$includetype = $Fld[3];
++		$includetype = $Fld[2];
+ 		if ($includetype eq 'rule') {
+ 		    &dump_fields($stmt_mode, *fields, $field_count, ' { ');
+ 		}
+@@ -333,7 +333,7 @@ sub include_stuff {
+ 	    }
+ 	}
+ 	else {
+-	    if ($copy == 1 && $Fld[1] ne 'ECPG:') {
++	    if ($copy == 1 && $Fld[0] ne 'ECPG:') {
+ 		&add_to_buffer($includestream, $_);
+ 		$copied = 1;
+ 		$inblock = 0;
+@@ -387,7 +387,7 @@ sub dump_fields {
+ 	    # Go through each field and try to 'aggregate' the tokens into a single 'make_str' where possible
+ 	    $cnt = 0;
+ 	    for ($z = 0; $z < $len; $z++) {
+-		if (substr($flds{$z}, 1, 1) eq "\$") {
++		if (substr($flds{$z}, 0, 1) eq "\$") {
+ 		    $flds_new{$cnt++} = $flds{$z};
+ 		    next;
+ 		}
+@@ -395,7 +395,7 @@ sub dump_fields {
+ 		$str = $flds{$z};
+ 
+ 		while (1) {
+-		    if ($z >= $len - 1 || substr($flds{$z + 1}, 1, 1) eq "\$") {
++		    if ($z >= $len - 1 || substr($flds{$z + 1}, 0, 1) eq "\$") {
+ 			# We're at the end...
+ 			$flds_new{$cnt++} = "make_str(\"" . $str . "\")";
+ 			last;
+@@ -454,7 +454,7 @@ sub dump_line {
+ 	return 0;
+     }
+     elsif ($replace_line{$block}) {
+-	if (index($line, '|') != 0) {
++	if (index($line, '|') != -1) {
+ 	    $line = '| ' . $replace_line{$block};
+ 	}
+ 	else {


### PR DESCRIPTION
GPDB is using a special variable $[ in its Perl script,
but it was deprecated from v5.30. So it can't be built
on some distros, e.g., Fedora 31 and Ubuntu 20.04.

This patch fixes indexs used in array and substr functions.

Change-Id: I92c793243c37ce57ffe146b71a5f732488f5e4a9
Signed-off-by: Jun He <jun.he@arm.com>