### PR TITLE
BIGTOP-3395. Building Kafka is failing on Fedora 31 for ARM64.

### DIFF
--- a/bigtop-tests/smoke-tests/build.gradle
+++ b/bigtop-tests/smoke-tests/build.gradle
@@ -27,7 +27,7 @@ subprojects {
     }
   }
 
-  ext.groovyVersion = '2.4.10'
+  ext.groovyVersion = '2.5.4'
   ext.hadoopVersion = '2.7.4'
   ext.hbaseVersion = '1.1.9'
   ext.solrVersion = '4.6.0'

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -314,7 +314,7 @@ bigtop {
     }
     'bigtop-groovy' {
       name    = 'bigtop-groovy'
-      version { base = '2.4.10'; pkg = '2.4.10'; release = 1}
+      version { base = '2.5.4'; pkg = '2.5.4'; release = 1}
       relNotes = "Groovy: a dynamic language for the Java platform"
       tarball { destination = "$name-${version.base}.tar.gz";
                 source      = "apache-groovy-binary-${version.base}.zip"}

--- a/bigtop_toolchain/manifests/gradle.pp
+++ b/bigtop_toolchain/manifests/gradle.pp
@@ -15,7 +15,7 @@
 
 class bigtop_toolchain::gradle {
 
-  $gradle_version = '4.10.3'
+  $gradle_version = '5.6.4'
   $gradle = "gradle-${gradle_version}"
 
   exec {"/usr/bin/wget https://services.gradle.org/distributions/${gradle}-bin.zip":

--- a/bigtop_toolchain/manifests/groovy.pp
+++ b/bigtop_toolchain/manifests/groovy.pp
@@ -15,7 +15,7 @@
 
 class bigtop_toolchain::groovy {
 
-  $groovy_version = '2.4.10'
+  $groovy_version = '2.5.4'
   $groovy = "apache-groovy-binary-${groovy_version}"
 
   exec {"/usr/bin/wget https://dl.bintray.com/groovy/maven/${groovy}.zip":

--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ project(':itest-common') {
   description = """iTest: system and integration testing in the cloud"""
 
   dependencies {
-    compile group: 'org.codehaus.groovy', name: 'groovy-all', version:'2.4.10'
+    compile group: 'org.codehaus.groovy', name: 'groovy-all', version:'2.5.4'
     compile group: 'junit', name: 'junit', version:'4.11'
     compile group: 'commons-logging', name: 'commons-logging', version:'1.1'
     compile group: 'org.apache.ant', name: 'ant', version:'1.8.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -17,4 +17,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/packages.gradle
+++ b/packages.gradle
@@ -401,9 +401,12 @@ def genTasks = { target ->
       workingDir DEB_BLD_DIR
       commandLine "tar --strip-components 1 -xf $DEB_BLD_DIR/../${PKG_NAME}_${PKG_VERSION}.orig.tar.gz".split(' ')
     }
-    fileTree ("${BASE_DIR}/bigtop-packages/src/deb/$NAME") {
-      include '**/*'
-    }.copy { into "$DEB_BLD_DIR/debian" }
+    copy {
+      from fileTree("${BASE_DIR}/bigtop-packages/src/deb/$NAME") {
+        include '**/*'
+      }
+      into "$DEB_BLD_DIR/debian"
+    }
     copy {
       from "${BASE_DIR}/bigtop-packages/src/templates/init.d.tmpl"
       into "$DEB_BLD_DIR/debian"
@@ -416,9 +419,12 @@ def genTasks = { target ->
       from "${BASE_DIR}/bigtop-packages/src/extensions"
       into "$DEB_BLD_DIR/debian"
     }
-    fileTree ("$BASE_DIR/bigtop-packages/src/common/$NAME") {
-      include '**/*'
-    }.copy { into "$DEB_BLD_DIR/debian" }
+    copy {
+      from fileTree("$BASE_DIR/bigtop-packages/src/common/$NAME") {
+        include '**/*'
+      }
+      into "$DEB_BLD_DIR/debian"
+    }
     // Prepeare bom file with all the versions
     def bomWriter = new File("$DEB_BLD_DIR/debian/bigtop.bom").newWriter()
     bomVersions.each { bomWriter << "$it\n"}
@@ -442,14 +448,15 @@ def genTasks = { target ->
       seriesWriter.close()
     }
     // Deleting obsolete files
-    delete fileTree (dir: "$DEB_BLD_DIR/debian", includes: ['*.ex', '*.EX', '*.~'])
+    delete fileTree(dir: "$DEB_BLD_DIR/debian", includes: ['*.ex', '*.EX', '*.~'])
     // Creating source package
     exec {
       workingDir DEB_BLD_DIR
       commandLine "dpkg-buildpackage -uc -us -sa -S".split(' ')
     }
     mkdir(PKG_OUTPUT_DIR)
-    fileTree (dir: "$DEB_PKG_DIR/..", includes: ['*.dsc', '*.diff.gz', '*.debian.tar.gz', '*.debian.tar.xz', "*_source.changes", "*.orig.tar.gz" ]).copy {
+    copy {
+      from fileTree(dir: "$DEB_PKG_DIR/..", includes: ['*.dsc', '*.diff.gz', '*.debian.tar.gz', '*.debian.tar.xz', "*_source.changes", "*.orig.tar.gz" ])
       into PKG_OUTPUT_DIR
     }
     safeDelete(DEB_BLD_DIR)
@@ -502,9 +509,12 @@ def genTasks = { target ->
       executable 'rpmbuild'
       args command
     }
-    fileTree ("$PKG_BUILD_DIR/rpm/RPMS") {
-      include '**/*'
-    }.copy { into PKG_OUTPUT_DIR }
+    copy {
+      from fileTree("$PKG_BUILD_DIR/rpm/RPMS") {
+        include '**/*'
+      }
+      into PKG_OUTPUT_DIR
+    }
     touchTargetFile(config.bigtop.components[target].targetrpm)
   }
   // Guarantee that tasks are ran in the order set by BOM file dependencies section
@@ -537,9 +547,12 @@ def genTasks = { target ->
     ['INSTALL','SOURCES','BUILD','SRPMS','RPMS'].each { rpmdir ->
       mkdir("$PKG_BUILD_DIR/rpm/$rpmdir")
     }
-    fileTree ("${BASE_DIR}/bigtop-packages/src/rpm/$NAME") {
-      include '**/*'
-    }.copy { into "$PKG_BUILD_DIR/rpm" }
+    copy {
+      from fileTree("${BASE_DIR}/bigtop-packages/src/rpm/$NAME") {
+        include '**/*'
+      }
+      into "$PKG_BUILD_DIR/rpm"
+    }
     copy {
       from SEED_TAR
       into "$PKG_BUILD_DIR/rpm/SOURCES"
@@ -558,9 +571,12 @@ def genTasks = { target ->
       into "$PKG_BUILD_DIR/rpm/SOURCES"
       include "*"
     }
-    fileTree ("$BASE_DIR/bigtop-packages/src/common/$NAME") {
-      include '**/*'
-    }.copy { into "$PKG_BUILD_DIR/rpm/SOURCES" }
+    copy {
+      from fileTree("$BASE_DIR/bigtop-packages/src/common/$NAME") {
+        include '**/*'
+      }
+      into "$PKG_BUILD_DIR/rpm/SOURCES"
+    }
     // Writing bigtop.bom files with all the versions
     def bomWriter = new File("$PKG_BUILD_DIR/rpm/SOURCES/bigtop.bom").newWriter()
     bomVersions.each { bomWriter << "$it\n"}

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <itest-common.version>${project.version}</itest-common.version>
 
-    <groovy.version>2.4.10</groovy.version>
+    <groovy.version>2.5.4</groovy.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>2.12</maven-failsafe-plugin.version>
     <groovy-eclipse-compiler.version>2.9.2-01</groovy-eclipse-compiler.version>


### PR DESCRIPTION
This PR upgrades Groovy and Gradle to v2.5.4 and v5.6.4 respectively so that building Kafka on fedora-31-aarch64 succeeds.
I confirmed `./gradlew kafka-pkg` after `./gradlew toolchain` succeeded inside the fedora-31-aarch64 container with this PR.