### PR TITLE
BIGTOP-3399. Fix bigtop-groovy build failure.

### DIFF
--- a/bigtop-packages/src/common/bigtop-groovy/install_groovy.sh
+++ b/bigtop-packages/src/common/bigtop-groovy/install_groovy.sh
@@ -99,9 +99,7 @@ chmod 755 ${PREFIX}/${BIN_DIR}/*
 # lib
 install -d -m 0755 ${PREFIX}/${LIB_DIR}
 cp ${BUILD_DIR}/lib/groovy-${BIGTOP_GROOVY_VERSION}.jar ${PREFIX}/${LIB_DIR}
-cp ${BUILD_DIR}/embeddable/groovy-all-${BIGTOP_GROOVY_VERSION}.jar ${PREFIX}/${LIB_DIR}
-cp ${BUILD_DIR}/lib/commons-cli-1.2.jar ${PREFIX}/${LIB_DIR}
-cp ${BUILD_DIR}/lib/*antlr*.jar ${PREFIX}/${LIB_DIR}
+cp ${BUILD_DIR}/lib/groovy-json-${BIGTOP_GROOVY_VERSION}.jar ${PREFIX}/${LIB_DIR}
 
 #conf
 install -d -m 0755 ${PREFIX}/${CONF_DIR}


### PR DESCRIPTION
In my understanding, bigtop-packages/src/common/hadoop/init-hdfs.sh (and its callee init-hcfs.groovy) are the only users of bigtop-groovy for now. They requires groovy's core and json features, so I fixed install_groovy.sh to just install groovy.jar and groovy-json.jar instead of the former groovy-all.jar, which is no longer provided as a uber-jar.

With this PR, I made sure init-hdfs succeeded on my local ubuntu 18.04, as follows:

```
$ ./gradlew realclean hadoop-pkg repo -Dbuildwithdeps=true
$ cat /etc/puppet/hieradata/site.yaml

(snip)

hadoop_cluster_node::cluster_components:
  - hdfs
  - yarn
  - mapreduce
bigtop::bigtop_repo_uri: file:///home/sekikn/repos/bigtop/output/apt
bigtop::jdk_preinstalled: true
bigtop::bigtop_repo_gpg_check: false
$ sudo puppet apply --modulepath=bigtop-deploy/puppet/modules:/usr/share/puppet/modules bigtop-deploy/puppet/manifests --debug

(snip)

Debug: Exec[init hdfs](provider=posix): Executing 'bash -x /usr/lib/hadoop/libexec/init-hdfs.sh'
Debug: Executing: 'bash -x /usr/lib/hadoop/libexec/init-hdfs.sh'
Notice: /Stage[main]/Hadoop::Init_hdfs/Exec[init hdfs]/returns: executed successfully

(snip)

$ /usr/lib/bigtop-groovy/bin/groovy -v
Groovy Version: 2.5.4 JVM: 1.8.0_265 Vendor: AdoptOpenJDK OS: Linux
```