### PR TITLE
BIGTOP-3401: Failed to build Centos-8 docker images for Arm64

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -56,10 +56,11 @@ case ${ID}-${VERSION_ID} in
         puppet module install puppetlabs-stdlib --version 4.12.0
         ;;
     centos-8*)
-        rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm
+        rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         dnf -y check-update
-        dnf -y install hostname curl sudo unzip wget puppet-agent 'dnf-command(config-manager)'
-        puppet module install puppetlabs-stdlib
+        dnf -y install hostname curl sudo unzip wget puppet 'dnf-command(config-manager)'
+        # Install the module in the same way as Fedora 31 and CentOS 7 for compatibility issues.
+        puppet module install puppetlabs-stdlib --version 4.12.0
         # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.
         # As a workaround for that, enable the former here in advance of running the Puppet manifests.
         dnf config-manager --set-enabled PowerTools

--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,7 @@ task toolchain(type:Exec,
   if ('3.7' <= version && version < '4') {
     command.addAll(['--parser', 'future'])
   }
-  command.addAll(["--modulepath=${projectDir.absolutePath}:/etc/puppet/modules:/usr/share/puppet/modules:/etc/puppetlabs/code/environments/production/modules",
+  command.addAll(["--modulepath=${projectDir.absolutePath}:/etc/puppet/modules:/usr/share/puppet/modules:/etc/puppetlabs/code/modules",
     '-e', 'include bigtop_toolchain::installer'])
   workingDir '.'
   commandLine command


### PR DESCRIPTION
1. Enable Centos-8 docker image on Arm64.
2. Modify Puppet modulepath for puppetlabs-4.12 to fix issue :`'Unknown function: 'any2array'`
3. Fix docker provisioner on Arm64 Centos-8.
4. Fix `shellcheck `warning in `bash `scripts.