### PR TITLE
BIGTOP-3407. Ensure the procps package is installed in Debian 10.

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -44,7 +44,7 @@ case ${ID}-${VERSION_ID} in
         ;;
     debian-10*)
         apt-get update
-        apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv gnupg
+        apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv gnupg procps
         ;;
     centos-7*)
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm


### PR DESCRIPTION
I confirmed that newly built bigtop/puppet image with this PR has the ps command, as follows:

```
$ docker run -it debian:10 ps  # The original Debian 10 image doesn't have the ps command
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"ps\": executable file not found in $PATH": unknown.
ERRO[0000] error waiting for container: context canceled 
$ cd docker/bigtop-puppet
$ ./build.sh trunk-debian-10

(snip)

Successfully built ad86d3a95f32
Successfully tagged bigtop/puppet:trunk-debian-10
++ rm -f Dockerfile puppetize.sh
$ docker run -it bigtop/puppet:trunk-debian-10 ps  # Confirm successful installation
  PID TTY          TIME CMD
    1 pts/0    00:00:00 ps
```