### PR TITLE
BIGTOP-3408. hadoop-docker.sh generates broken site.yaml from config.yaml containing multiple components.

### DIFF
--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -93,7 +93,7 @@ create() {
         repo=$(get-yaml-config repo)
     fi
     if [ -z ${components+x} ]; then
-        components="[`echo "$(get-yaml-config components)" | sed 's/ /, /g'`]"
+        components="[`echo $(get-yaml-config components) | sed 's/ /, /g'`]"
     fi
     if [ -z ${distro+x} ]; then
         distro=$(get-yaml-config distro)

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -191,7 +191,7 @@ provision() {
 smoke-tests() {
     hadoop_head_node=${NODES:0:12}
     if [ -z ${smoke_test_components+x} ]; then
-        smoke_test_components="`echo "$(get-yaml-config smoke_test_components)" | sed 's/ /,/g'`"
+        smoke_test_components="`echo $(get-yaml-config smoke_test_components) | sed 's/ /,/g'`"
     fi
     docker exec $hadoop_head_node bash -c "bash -x /bigtop-home/provisioner/utils/smoke-tests.sh $smoke_test_components"
 }


### PR DESCRIPTION
[Link to BIGTOP-3408](https://issues.apache.org/jira/browse/BIGTOP-3408)