### PR TITLE
BIGTOP-3394: Building Logstash is failing on CentOS 8, Debian 10 and Ubuntu 18.04

### DIFF
--- a/bigtop-packages/src/common/logstash/do-component-build
+++ b/bigtop-packages/src/common/logstash/do-component-build
@@ -43,6 +43,12 @@ then
 else
   [ -s $HOME/.rvm/scripts/rvm ] && source $HOME/.rvm/scripts/rvm
 fi
+
+# BIGTOP-3394
+# Disable unnecessary autolibs installation
+# for rvm fail to "try_sudo" to install autolibs
+# dependencies under user:'jenkins'
+rvm autolibs disable
 rvm install ruby-2.4.0 && rvm use 2.4.0
 
 # Specify childprocess to 3.0.0. The latest release 4.0.0 is not compatible with 5.4.1.


### PR DESCRIPTION
when rvm install ruby-2.4.0 under user: jenkins,
it fails to "try_sudo" to install autolibs dependencies.
Disable unnecessary autolibs installation.