### PR TITLE
BIGTOP-3411: Disable unnecessary scm check in Buildnumber-maven-plugin for Mpack

### DIFF
--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/pom.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/pom.xml
@@ -102,13 +102,19 @@
       <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>${buildnumber-maven-plugin-version}</version>
+	  <version>${buildnumber-maven-plugin-version}</version>
+          <configuration>
+              <revisionOnScmFailure>no.scm.config.in.pom</revisionOnScmFailure>
+          </configuration>
           <executions>
               <execution>
                   <phase>validate</phase>
                   <goals>
-                      <goal>create</goal>
+                      <goal>create-timestamp</goal>
                   </goals>
+                  <configuration>
+                      <timestampFormat>yyyy-MM-dd HH:mm:ss.S</timestampFormat>
+                  </configuration>
               </execution>
           </executions>
       </plugin>

--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ rat {
        "bigtop-packages/src/**/*.diff",
        "bigtop-packages/src/common/*/*.json",
        "bigtop-packages/src/common/**/*.default",
+       "bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/**",
        "bigtop-repos/apt/distributions",
        /* Juju charm files with rigid structure */
        "bigtop-packages/src/charm/**/wheelhouse.txt",


### PR DESCRIPTION
Make it possible to use Buildnumber-maven-plugin to generate build number
without unnecessary scm check. And fix 'rat' issues.

Confirmed that build:  `./gradlew bigtop-ambari-mpack-pkg ` was passed on:
Ubuntu18.04/16.04, Centos-7/8, Debian-10 and Fedora-31 (x86/Arm64).
