### PR TITLE
BIGTOP-3416. Fix YCSB to work with CentOS 8 and Fedora 31.

### DIFF
--- a/bigtop-packages/src/common/ycsb/patch0-python-executable-version.diff
+++ b/bigtop-packages/src/common/ycsb/patch0-python-executable-version.diff
@@ -1,0 +1,10 @@
+diff --git a/bin/ycsb b/bin/ycsb
+index 72e218a5..7421e981 100755
+--- a/bin/ycsb
++++ b/bin/ycsb
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright (c) 2012 - 2015 YCSB contributors. All rights reserved.
+ #

--- a/bigtop-packages/src/rpm/ycsb/SPECS/ycsb.spec
+++ b/bigtop-packages/src/rpm/ycsb/SPECS/ycsb.spec
@@ -33,6 +33,7 @@ Source0: %{ycsb_name}-%{ycsb_base_version}.tar.gz
 Source1: do-component-build 
 Source2: install_%{ycsb_name}.sh
 Source3: bigtop.bom
+#BIGTOP_PATCH_FILES
 ## This package _explicitly_ turns off the auto-discovery of required dependencies
 ## to work around OSGI corner case, added to RPM lately. See BIGTOP-2421 for more info.
 Requires: coreutils, bigtop-utils >= 0.7, python2
@@ -46,6 +47,8 @@ performance of NoSQL database management systems.
 
 %prep
 %setup -n YCSB-%{ycsb_base_version}
+
+#BIGTOP_PATCH_COMMANDS
 
 %build
 bash $RPM_SOURCE_DIR/do-component-build

--- a/bigtop-packages/src/rpm/ycsb/SPECS/ycsb.spec
+++ b/bigtop-packages/src/rpm/ycsb/SPECS/ycsb.spec
@@ -35,7 +35,7 @@ Source2: install_%{ycsb_name}.sh
 Source3: bigtop.bom
 ## This package _explicitly_ turns off the auto-discovery of required dependencies
 ## to work around OSGI corner case, added to RPM lately. See BIGTOP-2421 for more info.
-Requires: coreutils, bigtop-utils >= 0.7, python
+Requires: coreutils, bigtop-utils >= 0.7, python2
 AutoReq: no
 
 %description 


### PR DESCRIPTION
Tested on CentOS 7/8 and Fedora 31.