### PR TITLE
BIGTOP-3397. Building Spark is failing on CentOS 7 for ARM64 and PPC64.

### DIFF
--- a/bigtop-packages/src/common/spark/patch2-snappy-java-1.1.8.diff
+++ b/bigtop-packages/src/common/spark/patch2-snappy-java-1.1.8.diff
@@ -1,0 +1,52 @@
+diff --git a/dev/deps/spark-deps-hadoop-2.6 b/dev/deps/spark-deps-hadoop-2.6
+index 730201d..d268559 100644
+--- a/dev/deps/spark-deps-hadoop-2.6
++++ b/dev/deps/spark-deps-hadoop-2.6
+@@ -179,7 +179,7 @@ shims/0.7.45//shims-0.7.45.jar
+ slf4j-api/1.7.16//slf4j-api-1.7.16.jar
+ slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
+ snakeyaml/1.15//snakeyaml-1.15.jar
+-snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
++snappy-java/1.1.8//snappy-java-1.1.8.jar
+ snappy/0.2//snappy-0.2.jar
+ spire-macros_2.11/0.13.0//spire-macros_2.11-0.13.0.jar
+ spire_2.11/0.13.0//spire_2.11-0.13.0.jar
+diff --git a/dev/deps/spark-deps-hadoop-2.7 b/dev/deps/spark-deps-hadoop-2.7
+index 262f1f0..ba5790c 100644
+--- a/dev/deps/spark-deps-hadoop-2.7
++++ b/dev/deps/spark-deps-hadoop-2.7
+@@ -180,7 +180,7 @@ shims/0.7.45//shims-0.7.45.jar
+ slf4j-api/1.7.16//slf4j-api-1.7.16.jar
+ slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
+ snakeyaml/1.15//snakeyaml-1.15.jar
+-snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
++snappy-java/1.1.8//snappy-java-1.1.8.jar
+ snappy/0.2//snappy-0.2.jar
+ spire-macros_2.11/0.13.0//spire-macros_2.11-0.13.0.jar
+ spire_2.11/0.13.0//spire_2.11-0.13.0.jar
+diff --git a/dev/deps/spark-deps-hadoop-3.1 b/dev/deps/spark-deps-hadoop-3.1
+index dc82809..86314b0 100644
+--- a/dev/deps/spark-deps-hadoop-3.1
++++ b/dev/deps/spark-deps-hadoop-3.1
+@@ -200,7 +200,7 @@ shims/0.7.45//shims-0.7.45.jar
+ slf4j-api/1.7.16//slf4j-api-1.7.16.jar
+ slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
+ snakeyaml/1.15//snakeyaml-1.15.jar
+-snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
++snappy-java/1.1.8//snappy-java-1.1.8.jar
+ snappy/0.2//snappy-0.2.jar
+ spire-macros_2.11/0.13.0//spire-macros_2.11-0.13.0.jar
+ spire_2.11/0.13.0//spire_2.11-0.13.0.jar
+diff --git a/pom.xml b/pom.xml
+index 54930c2..ae5f8ae 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -161,7 +161,7 @@
+     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
+     <fasterxml.jackson-module-scala.version>2.6.7.1</fasterxml.jackson-module-scala.version>
+     <fasterxml.jackson.databind.version>2.6.7.3</fasterxml.jackson.databind.version>
+-    <snappy.version>1.1.7.3</snappy.version>
++    <snappy.version>1.1.8</snappy.version>
+     <netlib.java.version>1.1.2</netlib.java.version>
+     <calcite.version>1.2.0-incubating</calcite.version>
+     <commons-codec.version>1.10</commons-codec.version>


### PR DESCRIPTION
snappy-java must be upgraded to 1.1.8 to fix build issue on aarm64 and ppc64le.
https://issues.apache.org/jira/browse/BIGTOP-3397