### PR TITLE
BIGTOP-3439. Oozie's smoke test fails on CentOS and Fedora.

### DIFF
--- a/bigtop-packages/src/common/oozie/install_oozie.sh
+++ b/bigtop-packages/src/common/oozie/install_oozie.sh
@@ -234,6 +234,8 @@ ln -s ${DATA_DIR#${SERVER_PREFIX}} ${SERVER_LIB_DIR}/libext
 
 # Remove jars provided by 'oozie-client' from 'oozie' to avoid run-time issues
 # while installing the package.
-for oozie_client_jar_file in $(ls $CLIENT_LIB_DIR/lib); do
-  rm -f $SERVER_LIB_DIR/lib/$oozie_client_jar_file
-done
+if [ "${SERVER_PREFIX}" != "${CLIENT_PREFIX}" ]; then
+  for oozie_client_jar_file in $(ls $CLIENT_LIB_DIR/lib); do
+    rm -f $SERVER_LIB_DIR/lib/$oozie_client_jar_file
+  done
+fi


### PR DESCRIPTION
jars are removed by install_oozie.sh on building RPM due to the fix of [BIGTOP-3330](https://issues.apache.org/jira/browse/BIGTOP-3330). The cause is that bigtop-packages/src/common/oozie/install_oozie.sh is written in deb centric way. I prefer quick-fix rather than overhaul here.