### PR TITLE
BIGTOP-3427. Deploying GPDB fails due to the paramiko installation on some distros (addendum).

### DIFF
--- a/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
@@ -163,6 +163,9 @@ class gpdb {
           package { ["libffi-dev"]:
             ensure => latest,
           }
+          package { ["libssl-dev"]:
+            ensure => latest,
+          }
           package { ["python-lockfile"]:
             ensure => latest,
           }
@@ -180,6 +183,7 @@ class gpdb {
             ensure  => latest,
             require => [
               Package["libffi-dev"],
+              Package["libssl-dev"],
               Package["python-lockfile"],
             ],
           }


### PR DESCRIPTION
Tested with Debian 9, Ubuntu 16.04 and 18.04 on AWS m6g (ARM64) instances.