### PR TITLE
BIGTOP-3440: disable flume solr sink to avoid build failures

### DIFF
--- a/bigtop-packages/src/common/flume/patch5-BIGTOP-3440.diff
+++ b/bigtop-packages/src/common/flume/patch5-BIGTOP-3440.diff
@@ -1,0 +1,14 @@
+diff --git a/flume-ng-sinks/pom.xml b/flume-ng-sinks/pom.xml
+index 43e7da97..d0e50df4 100644
+--- a/flume-ng-sinks/pom.xml
++++ b/flume-ng-sinks/pom.xml
+@@ -37,7 +37,9 @@ limitations under the License.
+     <module>flume-ng-hbase-sink</module>
+     <module>flume-ng-hbase2-sink</module>
+     <module>flume-ng-elasticsearch-sink</module>
++    <!-- Disabled, see BIGTOP-3440
+     <module>flume-ng-morphline-solr-sink</module>
++    -->
+     <module>flume-ng-kafka-sink</module>
+     <module>flume-http-sink</module>
+     <module>flume-dataset-sink</module>


### PR DESCRIPTION
The solr sink currently depends on kite, that it is a library not
developed anymore. There are currently build failures due to
the ua_parser library, that was available in a Twitter maven repository
not maintained anymore (since it throws HTTP 503s consistently).
Flume upstream moved the dependency to another repository,
https://github.com/apache/flume/commit/9e0bc5bf4865673e6989ba887d27f468991c1e27
that fixes the Twitter problem but that brings in another build failure
for the 'rome' dependency.

This commit removes the solr sink from the build list, resolving the
overall build problem for Flume.