### PR TITLE
BIGTOP-3429. QFS smoke test fails on Ubuntu 16.04.

### DIFF
--- a/bigtop-deploy/puppet/modules/qfs/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/qfs/manifests/init.pp
@@ -169,8 +169,8 @@ class qfs {
     exec { "add_qfs_native_lib":
       path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
       command => 'find /usr/lib/qfs/ -name "lib*" -exec ln -s {} /usr/lib/hadoop/lib/native \;',
-      require => Package["qfs-client"],
-      notify => [ Service["hadoop-yarn-nodemanager"] ],
+      require => [ Package["hadoop-yarn-nodemanager"], Package["qfs-client"] ],
+      notify  => [ Service["hadoop-yarn-nodemanager"] ],
     }
   }
 }


### PR DESCRIPTION
This PR ensures that symlinks to qfs shared libraries are created after target directory creation. Tested with Ubuntu 16.04 and 18.04 on x86_64.