### PR TITLE
BIGTOP-3447: Fix Unknown variable: 'rpkgs' in docker bigtop/slaves for Fedora/Centos/SLES

### DIFF
--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -17,6 +17,8 @@ class bigtop_toolchain::renv {
 
   require bigtop_toolchain::packages
 
+  $rpkgs = "install_r_packages"
+
   case $operatingsystem{
     /(?i:(centos|fedora|redhat|Amazon))/: {
       $pkgs = [
@@ -48,7 +50,6 @@ class bigtop_toolchain::renv {
           "r-base-dev",
           "pandoc",
         ]
-        $rpkgs = "install_r_packages"
       }
     }
   }


### PR DESCRIPTION


'$rpkgs' should be defined outside of  'Distros detection'.

