### PR TITLE
BIGTOP-3475. Bump ZooKeeper to 3.4.14.

### DIFF
--- a/bigtop-packages/src/common/zookeeper/do-component-build
+++ b/bigtop-packages/src/common/zookeeper/do-component-build
@@ -18,13 +18,9 @@ set -ex
 
 . `dirname ${0}`/bigtop.bom
 
-# ZOOKEEPER-2654, BIGTOP-2642
-sed -i -e 's@AM_PATH_CPPUNIT(1.10.2)@PKG_CHECK_MODULES([CPPUNIT], [cppunit])@' src/c/configure.ac
-
 ANT_OPTS="-Dversion=$ZOOKEEPER_VERSION -f build.xml $@"
 sed -i.orig -e 's#test-jar,api-report#test-jar#g' build.xml
 ant compile ${ANT_OPTS}
-(cd src/contrib/rest && ant jar ${ANT_OPTS})
 ant package package-native tar ${ANT_OPTS}
 
 mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.zookeeper -DartifactId=zookeeper -Dversion=$ZOOKEEPER_VERSION -Dpackaging=jar -Dfile=build/zookeeper-$ZOOKEEPER_VERSION.jar -DpomFile=build/zookeeper-$ZOOKEEPER_VERSION/dist-maven/zookeeper-$ZOOKEEPER_VERSION.pom

--- a/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
+++ b/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
@@ -109,10 +109,11 @@ SYSTEM_LIB_DIR=${SYSTEM_LIB_DIR:-/usr/lib}
 install -d -m 0755 $PREFIX/$LIB_DIR/
 rm -f $BUILD_DIR/zookeeper-*-javadoc.jar $BUILD_DIR/zookeeper-*-bin.jar $BUILD_DIR/zookeeper-*-sources.jar $BUILD_DIR/zookeeper-*-test.jar
 cp $BUILD_DIR/zookeeper*.jar $PREFIX/$LIB_DIR/
-install -d -m 0755 ${PREFIX}/${LIB_DIR}/contrib
-for module in rest; do
-    cp -r ${BUILD_DIR}/contrib/${module} ${PREFIX}/${LIB_DIR}/contrib/
-done
+install -d -m 0755 ${PREFIX}/${LIB_DIR}/contrib/rest
+install -d -m 0755 ${PREFIX}/${CONF_DIST_DIR}/rest
+cp ${BUILD_DIR}/zookeeper-contrib/zookeeper-contrib-rest/zookeeper-*-rest.jar ${PREFIX}/${LIB_DIR}/contrib/rest/
+cp -r ${BUILD_DIR}/zookeeper-contrib/zookeeper-contrib-rest/lib ${PREFIX}/${LIB_DIR}/contrib/rest/
+cp -r ${BUILD_DIR}/zookeeper-contrib/zookeeper-contrib-rest/conf/* ${PREFIX}/${CONF_DIST_DIR}/rest/
 
 # Make a symlink of zookeeper.jar to zookeeper-version.jar
 for x in $PREFIX/$LIB_DIR/zookeeper*jar ; do
@@ -127,12 +128,6 @@ cp $BUILD_DIR/lib/*.jar $PREFIX/$LIB_DIR/lib
 install -d -m 0755 $PREFIX/$CONF_DIST_DIR
 cp zoo.cfg $BUILD_DIR/conf/* $PREFIX/$CONF_DIST_DIR/
 ln -s $CONF_DIR $PREFIX/$LIB_DIR/conf
-
-install -d -m 0755 ${PREFIX}/${LIB_DIR}/contrib
-for module in rest; do
-    cp -r ${BUILD_DIR}/contrib/${module} ${PREFIX}/${LIB_DIR}/contrib/
-    mv ${PREFIX}/${LIB_DIR}/contrib/${module}/conf ${PREFIX}/${CONF_DIST_DIR}/${module}
-done
 
 # Copy in the /usr/bin/zookeeper-server wrapper
 install -d -m 0755 $PREFIX/$LIB_DIR/bin

--- a/bigtop-packages/src/common/zookeeper/patch0-ZOOKEEPER-3079.diff
+++ b/bigtop-packages/src/common/zookeeper/patch0-ZOOKEEPER-3079.diff
@@ -1,7 +1,7 @@
-diff --git a/src/c/src/zookeeper.c b/src/c/src/zookeeper.c
-index c0878648..bb454ddc 100644
---- a/src/c/src/zookeeper.c
-+++ b/src/c/src/zookeeper.c
+diff --git a/zookeeper-client/zookeeper-client-c/src/zookeeper.c b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+index c08786484..bb454ddc4 100644
+--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
++++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
 @@ -3478,7 +3478,7 @@ int zoo_add_auth(zhandle_t *zh,const char* scheme,const char* cert,
  static const char* format_endpoint_info(const struct sockaddr_storage* ep)
  {

--- a/bigtop-packages/src/common/zookeeper/patch1-ZOOKEEPER-3302.diff
+++ b/bigtop-packages/src/common/zookeeper/patch1-ZOOKEEPER-3302.diff
@@ -5,13 +5,13 @@ Subject: [PATCH 1/4] ZOOKEEPER-3302 ZooKeeper C client does not compile on
  Fedora 29
 
 ---
- src/c/src/cli.c | 6 +++---
+ zookeeper-client/zookeeper-client-c/src/cli.c | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/src/c/src/cli.c b/src/c/src/cli.c
+diff --git a/zookeeper-client/zookeeper-client-c/src/cli.c b/zookeeper-client/zookeeper-client-c/src/cli.c
 index 6ca4a415f9..c3c0ff8ea4 100644
---- a/src/c/src/cli.c
-+++ b/src/c/src/cli.c
+--- a/zookeeper-client/zookeeper-client-c/src/cli.c
++++ b/zookeeper-client/zookeeper-client-c/src/cli.c
 @@ -678,15 +678,15 @@ int main(int argc, char **argv) {
      }
      if (argc > 2) {
@@ -39,13 +39,13 @@ Subject: [PATCH 2/4] ZOOKEEPER-3302 ZooKeeper C client does not compile on
  Fedora 29
 
 ---
- src/c/src/cli.c | 46 +++++++++++++++----
+ zookeeper-client/zookeeper-client-c/src/cli.c | 46 +++++++++++++++----
  1 file changed, 36 insertions(+), 10 deletions(-)
 
-diff --git a/src/c/src/cli.c b/src/c/src/cli.c
+diff --git a/zookeeper-client/zookeeper-client-c/src/cli.c b/zookeeper-client/zookeeper-client-c/src/cli.c
 index c3c0ff8ea4..96836dfeab 100644
---- a/src/c/src/cli.c
-+++ b/src/c/src/cli.c
+--- a/zookeeper-client/zookeeper-client-c/src/cli.c
++++ b/zookeeper-client/zookeeper-client-c/src/cli.c
 @@ -649,6 +649,38 @@ void processline(char *line) {
        zoo_add_auth(zh, line, ptr, ptr ? strlen(ptr) : 0, NULL, NULL);
      }
@@ -56,9 +56,9 @@ index c3c0ff8ea4..96836dfeab 100644
 + * Returns 0 if the argument does not start with the prefix.
 + * Returns -1 in case of error (command too long).
 + * Returns 1 in case of success.
-+ *
++ * 
 + */
-+int handleBatchMode(char* arg, char* buf, size_t maxlen) {
++int handleBatchMode(char* arg, char* buf, size_t maxlen) {    
 +    size_t cmdlen = strlen(arg);
 +    if (cmdlen < 4) {
 +        // too short
@@ -66,7 +66,7 @@ index c3c0ff8ea4..96836dfeab 100644
 +    }
 +    cmdlen -= 4;
 +    if(strncmp("cmd:", arg, 4) != 0){
-+        return 0;
++        return 0;        
 +    }
 +    if (cmdlen >= maxlen) {
 +          fprintf(stderr,
@@ -82,7 +82,7 @@ index c3c0ff8ea4..96836dfeab 100644
 +    memcpy(cmd, arg + 4, cmdlen);
 +    return 1;
 +}
-
+ 
  int main(int argc, char **argv) {
  #ifndef THREADED
 @@ -677,18 +709,12 @@ int main(int argc, char **argv) {
@@ -101,7 +101,7 @@ index c3c0ff8ea4..96836dfeab 100644
            return 2;
 -        }
 -        memcpy(cmd, argv[2]+4, cmdlen);
-+      } else if(batchModeRes == 1){
++      } else if(batchModeRes == 1){                
          batchMode=1;
 -        fprintf(stderr,"Batch mode: %s\n",cmd);
 +        fprintf(stderr,"Batch mode: '%s'\n",cmd);
@@ -115,13 +115,13 @@ Date: Sun, 31 Mar 2019 15:20:44 +0200
 Subject: [PATCH 3/4] Drop debug
 
 ---
- src/c/src/cli.c | 4 ----
+ zookeeper-client/zookeeper-client-c/src/cli.c | 4 ----
  1 file changed, 4 deletions(-)
 
-diff --git a/src/c/src/cli.c b/src/c/src/cli.c
+diff --git a/zookeeper-client/zookeeper-client-c/src/cli.c b/zookeeper-client/zookeeper-client-c/src/cli.c
 index 96836dfeab..bf8fcfa216 100644
---- a/src/c/src/cli.c
-+++ b/src/c/src/cli.c
+--- a/zookeeper-client/zookeeper-client-c/src/cli.c
++++ b/zookeeper-client/zookeeper-client-c/src/cli.c
 @@ -674,10 +674,6 @@ int handleBatchMode(char* arg, char* buf, size_t maxlen) {
                    maxlen);
            return -1;
@@ -140,16 +140,16 @@ Date: Sun, 31 Mar 2019 15:35:33 +0200
 Subject: [PATCH 4/4] add comment
 
 ---
- src/c/src/cli.c | 1 +
+ zookeeper-client/zookeeper-client-c/src/cli.c | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/src/c/src/cli.c b/src/c/src/cli.c
+diff --git a/zookeeper-client/zookeeper-client-c/src/cli.c b/zookeeper-client/zookeeper-client-c/src/cli.c
 index bf8fcfa216..6f443cd50e 100644
---- a/src/c/src/cli.c
-+++ b/src/c/src/cli.c
+--- a/zookeeper-client/zookeeper-client-c/src/cli.c
++++ b/zookeeper-client/zookeeper-client-c/src/cli.c
 @@ -667,6 +667,7 @@ int handleBatchMode(char* arg, char* buf, size_t maxlen) {
      if(strncmp("cmd:", arg, 4) != 0){
-         return 0;
+         return 0;        
      }
 +    // we must leave space for the NULL terminator
      if (cmdlen >= maxlen) {

--- a/bigtop-packages/src/common/zookeeper/patch2-ZOOKEEPER-2654.diff
+++ b/bigtop-packages/src/common/zookeeper/patch2-ZOOKEEPER-2654.diff
@@ -1,0 +1,13 @@
+diff --git a/zookeeper-client/zookeeper-client-c/configure.ac b/zookeeper-client/zookeeper-client-c/configure.ac
+index 2b18c9c0b..c4f5831bd 100644
+--- a/zookeeper-client/zookeeper-client-c/configure.ac
++++ b/zookeeper-client/zookeeper-client-c/configure.ac
+@@ -34,7 +34,7 @@ if test "$with_cppunit" = "no" ; then
+    CPPUNIT_INCLUDE=
+    CPPUNIT_LIBS=
+ else
+-   AM_PATH_CPPUNIT(1.10.2)
++   PKG_CHECK_MODULES([CPPUNIT], [cppunit])
+ fi
+ 
+ if test "$CALLER" = "ANT" ; then

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -131,7 +131,7 @@ bigtop {
       name    = 'zookeeper'
       pkg     = name
       version {
-        base  = '3.4.13'
+        base  = '3.4.14'
         pkg   = base
         release = 1
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3475

* addressed changes made by [ZOOKEEPER-3021](https://issues.apache.org/jira/browse/ZOOKEEPER-3021).
