### PR TITLE
BIGTOP-3478. Fix version mismatch of Guava between Hadoop and HBase.

### DIFF
--- a/bigtop-packages/src/common/hbase/do-component-build
+++ b/bigtop-packages/src/common/hbase/do-component-build
@@ -30,8 +30,6 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
   sed  -i "s|<version>1.5.0-alpha.6</version>|<version>1.5.0-alpha.11</version>|" pom.xml
 fi
 
-rm -f hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestBulkLoad.java
-
 if [ $HOSTTYPE = "aarch64" ] ; then
   sed -i '/asciidoctorj-pdf/!{p;d;};n;n;a'\
 '\          <dependency>\n'\
@@ -42,10 +40,11 @@ if [ $HOSTTYPE = "aarch64" ] ; then
 fi
 
 MVN_ARGS="-Phadoop-3.0 "
-MVN_ARGS="-DskipTests "
 MVN_ARGS+="-Dhadoop-three.version=${HADOOP_VERSION} "
+MVN_ARGS+="-Dhadoop.guava.version=27.0-jre "
 MVN_ARGS+="-Dslf4j.version=1.7.25 "
 MVN_ARGS+="-Dzookeeper.version=${ZOOKEEPER_VERSION} "
+MVN_ARGS+="-DskipTests "
 MVN_ARGS+="-Dcheckstyle.skip=true "
 
 # HBASE-21513: separate site and assembly:single to avoid assembly issues.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3478

There was unexpected guava-11.0.2.jar in the hbase classpath.
```
$ rpm -qlp output/hbase/x86_64/hbase-2.2.6-1.el8.x86_64.rpm | grep guava
/usr/lib/hbase/lib/guava-11.0.2.jar
/usr/lib/hbase/lib/jersey-guava-2.25.1.jar
```

The cause was
* missing `-Dhadoop.guava.version=27.0-jre` on hbase build.
* missing `-Phadoop-3.0` due to bug in do-component-build.
