### PR TITLE
BIGTOP-3494. Add MapReduce settings to yarn.nodemanager.env-whitelist in yarn-site.xml.

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop/templates/yarn-site.xml
+++ b/bigtop-deploy/puppet/modules/hadoop/templates/yarn-site.xml
@@ -156,6 +156,11 @@
   </property>
 
   <property>
+    <name>yarn.nodemanager.env-whitelist</name>
+    <value>JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,CLASSPATH_PREPEND_DISTCACHE,HADOOP_YARN_HOME,HADOOP_MAPRED_HOME</value>
+  </property>
+
+  <property>
     <name>yarn.log-aggregation-enable</name>
     <value>true</value>
   </property>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3494

MapReduce job does not work without adding HADOOP_MAPRED_HOME to the value of yarn.nodemanager.env-whitelist. testDistcpIntra and testDistcpIntra_MultipleSources reproducibly fails after upgrading hadoop to 3.2 due to this.