### PR TITLE
BIGTOP-3505. Update hadoop-kms puppet manifests based on hadoop-3.

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -122,7 +122,7 @@ hadoop::common_yarn::yarn_log_server_url: "%{hiera('bigtop::hadoop_history_serve
 hadoop::httpfs::hadoop_httpfs_port: "14000"
 
 hadoop::kms_host: "%{hiera('bigtop::hadoop_head_node')}"
-hadoop::kms_port: "16000"
+hadoop::kms_port: "9600"
 
 bigtop::hadoop_zookeeper_port: "2181"
 hadoop::zk: "%{hiera('bigtop::hadoop_head_node')}:%{hiera('bigtop::hadoop_zookeeper_port')}"

--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -543,13 +543,21 @@ class hadoop ($hadoop_security_authentication = "simple",
       require => Package["jdk"],
     }
 
-    file { "/etc/hadoop-kms/conf/kms-site.xml":
+    file { "/etc/hadoop/conf/kms-site.xml":
       content => template('hadoop/kms-site.xml'),
       require => [Package["hadoop-kms"]],
     }
 
-    file { "/etc/hadoop-kms/conf/kms-env.sh":
+    file { "/etc/hadoop/conf/kms-env.sh":
       content => template('hadoop/kms-env.sh'),
+      owner   => 'kms',
+      group   => 'kms',
+      mode    => '0400',
+      require => [Package["hadoop-kms"]],
+    }
+
+    file { "/etc/hadoop/conf/kms.keystore.password":
+      content => 'keystore-password',
       owner   => 'kms',
       group   => 'kms',
       mode    => '0400',
@@ -565,7 +573,7 @@ class hadoop ($hadoop_security_authentication = "simple",
       fail("KMS signature secret must be set")
     }
 
-    file { "/etc/hadoop-kms/conf/kms-signature.secret":
+    file { "/etc/hadoop/conf/kms-signature.secret":
       content => $kms_signature_secret,
       # it's a password file - do not filebucket
       backup => false,
@@ -575,7 +583,7 @@ class hadoop ($hadoop_security_authentication = "simple",
     service { "hadoop-kms":
       ensure => running,
       hasstatus => true,
-      subscribe => [Package["hadoop-kms"], File["/etc/hadoop-kms/conf/kms-site.xml"], File["/etc/hadoop-kms/conf/kms-env.sh"], File["/etc/hadoop-kms/conf/kms-signature.secret"],
+      subscribe => [Package["hadoop-kms"], File["/etc/hadoop/conf/kms-site.xml"], File["/etc/hadoop/conf/kms-env.sh"], File["/etc/hadoop/conf/kms-signature.secret"],
         File["/etc/hadoop/conf/core-site.xml"], File["/etc/hadoop/conf/hdfs-site.xml"]],
       require => [ Package["hadoop-kms"] ],
     }

--- a/bigtop-deploy/puppet/modules/hadoop/templates/kms-env.sh
+++ b/bigtop-deploy/puppet/modules/hadoop/templates/kms-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,74 +14,37 @@
 #
 
 # Set kms specific environment variables here.
-
-# Settings for the Embedded Tomcat that runs KMS
-# Java System properties for KMS should be specified in this variable
 #
-# export CATALINA_OPTS=
-
-# KMS logs directory
+# hadoop-env.sh is read prior to this file.
 #
-# export KMS_LOG=${KMS_HOME}/logs
+
+# KMS config directory
+#
+# export KMS_CONFIG=${HADOOP_CONF_DIR}
+
+# KMS log directory
+#
+# export KMS_LOG=${HADOOP_LOG_DIR}
 
 # KMS temporary directory
 #
-# export KMS_TEMP=${KMS_HOME}/temp
+# export KMS_TEMP=${HADOOP_HOME}/temp
 
 # The HTTP port used by KMS
 #
 export KMS_HTTP_PORT=<%= @kms_port %>
 
-# The Admin port used by KMS
-#
-# export KMS_ADMIN_PORT=`expr ${KMS_HTTP_PORT} + 1`
-
-# The Tomcat protocol to use for handling requests.
-# The default HTTP/1.1 handler is thread-per-request.
-# The NIO handler multiplexes multiple requests per thread.
-#
-# export KMS_PROTOCOL="HTTP/1.1"
-# export KMS_PROTOCOL="org.apache.coyote.http11.Http11NioProtocol"
-
-# The maximum number of Tomcat handler threads
+# The maximum number of HTTP handler threads
 #
 # export KMS_MAX_THREADS=1000
 
-# The maximum queue length for incoming connection requests when all possible
-# request processing threads are in use. Any requests received when the queue
-# is full will be refused.
-#
-# export KMS_ACCEPT_COUNT=500
-
-# The number of threads to be used to accept connections. Increase this value
-# on a multi CPU machine, although you would never really need more than 2.
-# Also, with a lot of non keep alive connections, you might want to increase
-# this value as well.
-#
-# Increasing this has no effect unless using the NIO protocol.
-#
-# export KMS_ACCEPTOR_THREAD_COUNT=1
-
-# The maximum size of Tomcat HTTP header
+# The maximum size of HTTP header
 #
 # export KMS_MAX_HTTP_HEADER_SIZE=65536
 
-# Set to 'true' if you want the SSL stack to require a valid certificate chain
-# from the client before accepting a connection. Set to 'want' if you want the
-# SSL stack to request a client Certificate, but not fail if one isn't
-# presented. A 'false' value (which is the default) will not require a
-# certificate chain unless the client requests a resource protected by a
-# security constraint that uses CLIENT-CERT authentication.
+# Whether SSL is enabled
 #
-# export KMS_SSL_CLIENT_AUTH=false
-
-# The comma separated list of SSL protocols to support
-#
-# export KMS_SSL_ENABLED_PROTOCOLS="TLSv1,TLSv1.1,TLSv1.2,SSLv2Hello"
-
-# The comma separated list of encryption ciphers for SSL
-#
-# export KMS_SSL_CIPHERS=
+# export KMS_SSL_ENABLED=false
 
 # The location of the SSL keystore if using SSL
 #
@@ -90,11 +53,3 @@ export KMS_HTTP_PORT=<%= @kms_port %>
 # The password of the SSL keystore if using SSL
 #
 # export KMS_SSL_KEYSTORE_PASS=password
-
-# The full path to any native libraries that need to be loaded
-# (For eg. location of natively compiled tomcat Apache portable
-# runtime (APR) libraries
-#
-# export JAVA_LIBRARY_PATH=${HOME}/lib/native
-
-export HADOOP_KEYSTORE_PASSWORD="<%= @secret %>"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3505

Current Puppet manifests of hadoop-kms assumes hadoop-2. It does not work for hadoop-3 without fix.
