### PR TITLE
BIGTOP-3508: drop /usr/share/java from sqoop's bin classpath

### DIFF
--- a/bigtop-packages/src/common/sqoop/install_sqoop.sh
+++ b/bigtop-packages/src/common/sqoop/install_sqoop.sh
@@ -149,7 +149,7 @@ for i in sqoop sqoop-codegen sqoop-export sqoop-import-all-tables sqoop-version 
 # Autodetect JAVA_HOME if not defined
 . /usr/lib/bigtop-utils/bigtop-detect-javahome
 
-SQOOP_JARS=\`ls /var/lib/sqoop/*.jar /usr/share/java/*.jar 2>/dev/null\`
+SQOOP_JARS=\`ls /var/lib/sqoop/*.jar 2>/dev/null\`
 if [ -n "\${SQOOP_JARS}" ]; then
     export HADOOP_CLASSPATH=\$(JARS=(\${SQOOP_JARS}); IFS=:; echo "\${HADOOP_CLASSPATH}:\${JARS[*]}")
 fi


### PR DESCRIPTION
On Debian 10 the package libslf4j-java deploys various jars to the
system, including log4j-over-slf4j.jar or slf4j-log4j12.jar that cannot
be added to the classpath together (see http://www.slf4j.org/codes.html#log4jDelegationLoop).
From my tests it seems that dropping /usr/share/java from the sqoop's
classpath is safe, I didn't notice any regression.

Co-authored-by: Kengo Seki <sekikn@apache.org>