### PR TITLE
BIGTOP-3492. Add Ubuntu 20.04 support to the Docker provisioner.

### DIFF
--- a/provisioner/docker/config_ubuntu-20.04.yaml
+++ b/provisioner/docker/config_ubuntu-20.04.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker:
+        memory_limit: "4g"
+        image:  "bigtop/puppet:trunk-ubuntu-20.04"
+
+repo: "http://repos.bigtop.apache.org/releases/3.0.0/ubuntu/20.04/$(ARCH)"
+distro: debian
+components: [hdfs, yarn, mapreduce]
+enable_local_repo: false
+smoke_test_components: [hdfs, yarn, mapreduce]


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3492

I added a config yaml for Ubuntu 20.04 for testing purpose.
The repo URL in that file is not valid until v3.0.0 is released and its repo is published on S3, so users have to override it with some existent (dummy) URL for now. For example, if you want to test locally built packages, try the following command:

```
$ ./docker-hadoop.sh -d -k zookeeper -s zookeeper -r 'http://repos.bigtop.apache.org/releases/1.5.0/ubuntu/18.04/$(ARCH)' -L -C config_ubuntu-20.04.yaml -c 1
```