### PR TITLE
BIGTOP-3515 - Backport HIVE-19231

### DIFF
--- a/bigtop-packages/src/common/hive/patch6-HIVE-19231.diff
+++ b/bigtop-packages/src/common/hive/patch6-HIVE-19231.diff
@@ -1,0 +1,14 @@
+diff --git a/bin/hive b/bin/hive
+index a7671c3950..508e73da75 100755
+--- a/bin/hive
++++ b/bin/hive
+@@ -351,7 +351,7 @@ fi
+ 
+ if [[ "$SERVICE" =~ ^(hiveserver2|beeline|cli)$ ]] ; then
+   # If process is backgrounded, don't change terminal settings
+-  if [[ ( ! $(ps -o stat= -p $$) =~ "+" ) && ! ( -p /dev/stdin ) ]]; then
++  if [[ ( ! $(ps -o stat= -p $$) =~ "+" ) && ! ( -p /dev/stdin ) && ( ! $(ps -o tty= -p $$) =~ "?" ) ]]; then
+     export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Djline.terminal=jline.UnsupportedTerminal"
+   fi
+ fi
+

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -180,7 +180,7 @@ bigtop {
     'hive' {
       name    = 'hive'
       relNotes = 'Apache Hive'
-      version { base = '2.3.6'; pkg = base; release = 1 }
+      version { base = '2.3.6'; pkg = base; release = 2 }
       tarball { destination = "apache-${name}-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}/"


### PR DESCRIPTION
This patch is contained in Hive 3.x, but not in the Hive 2.x branch. It
leads to subtle errors when executing Hive via Python or systemd, and
having it fixed in the 1.5 branch would allow people to rebuild their
packages if needed (we could update the docs about it).