### PR TITLE
BIGTOP-3516. Remove dead HBase jar link for Hive.

### DIFF
--- a/bigtop-packages/src/deb/hive/rules
+++ b/bigtop-packages/src/deb/hive/rules
@@ -51,7 +51,7 @@ override_dh_auto_install: server2 metastore hcatalog-server webhcat-server
 	# We need to get rid of jars that happen to be shipped in other CDH packages
 	rm -f debian/tmp/usr/lib/hive/lib/hbase-*.jar debian/tmp/usr/lib/hive/lib/zookeeper-*.jar
 	ln -s /usr/lib/hbase/hbase-common.jar /usr/lib/hbase/hbase-client.jar /usr/lib/hbase/hbase-hadoop-compat.jar /usr/lib/hbase/hbase-hadoop2-compat.jar debian/tmp/usr/lib/hive/lib
-	ln -s /usr/lib/hbase/hbase-prefix-tree.jar /usr/lib/hbase/hbase-procedure.jar /usr/lib/hbase/hbase-protocol.jar /usr/lib/hbase/hbase-server.jar debian/tmp/usr/lib/hive/lib/
+	ln -s /usr/lib/hbase/hbase-procedure.jar /usr/lib/hbase/hbase-protocol.jar /usr/lib/hbase/hbase-server.jar debian/tmp/usr/lib/hive/lib/
 	ln -s /usr/lib/zookeeper/zookeeper.jar debian/tmp/usr/lib/hive/lib
 	# Workaround for BIGTOP-583
 	rm -f debian/tmp/usr/lib/hive/lib/slf4j-log4j12-*.jar

--- a/bigtop-packages/src/rpm/hive/SPECS/hive.spec
+++ b/bigtop-packages/src/rpm/hive/SPECS/hive.spec
@@ -269,7 +269,7 @@ cp $RPM_SOURCE_DIR/hive-site.xml .
 %__rm -f $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/hbase-*.jar $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/zookeeper-*.jar
 %__ln_s  /usr/lib/zookeeper/zookeeper.jar  $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/
 %__ln_s  /usr/lib/hbase/hbase-common.jar /usr/lib/hbase/hbase-client.jar /usr/lib/hbase/hbase-hadoop-compat.jar /usr/lib/hbase/hbase-hadoop2-compat.jar $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/
-%__ln_s  /usr/lib/hbase/hbase-prefix-tree.jar /usr/lib/hbase/hbase-procedure.jar /usr/lib/hbase/hbase-protocol.jar /usr/lib/hbase/hbase-server.jar $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/
+%__ln_s  /usr/lib/hbase/hbase-procedure.jar /usr/lib/hbase/hbase-protocol.jar /usr/lib/hbase/hbase-server.jar $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/
 
 # Workaround for BIGTOP-583
 %__rm -f $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/slf4j-log4j12-*.jar


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3516