### PR TITLE
BIGTOP-3527: replace ${PWD} with ${CURDIR} in debian rules files

### DIFF
--- a/bigtop-packages/src/deb/gpdb/rules
+++ b/bigtop-packages/src/deb/gpdb/rules
@@ -37,7 +37,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -d -p -m 755 debian/gpdb
-	bash -x debian/install_gpdb.sh ${PWD}/debian/gpdb
+	bash -x debian/install_gpdb.sh ${CURDIR}/debian/gpdb
 
 override_dh_auto_test:
 	@echo Tests are disabled

--- a/bigtop-packages/src/deb/hadoop/rules
+++ b/bigtop-packages/src/deb/hadoop/rules
@@ -56,7 +56,7 @@ override_dh_auto_install:
 	bash debian/install_hadoop.sh \
 	  --prefix=debian/tmp/ \
 	  --distro-dir=debian \
-	  --build-dir=${PWD}/build \
+	  --build-dir=${CURDIR}/build \
 	  --system-lib-dir=debian/tmp/usr/lib/ \
 	  --system-libexec-dir=debian/tmp/usr/lib/hadoop/libexec/ \
 	  --system-include-dir=debian/tmp/usr/include \
@@ -81,7 +81,7 @@ override_dh_auto_install:
 override_dh_install: $(hadoop_svcs)
 	dh_install
 	# Drop misc fuse_dfs directories
-	rm -Rf debian/hadoop/usr/lib/hadoop/bin/fuse_dfs 
+	rm -Rf debian/hadoop/usr/lib/hadoop/bin/fuse_dfs
 	rm -Rf debian/hadoop/usr/lib/hadoop/contrib/fuse-dfs
 	rm -Rf debian/hadoop/usr/lib/hadoop/hdfs/contrib/fuse-dfs
 

--- a/bigtop-packages/src/deb/phoenix/rules
+++ b/bigtop-packages/src/deb/phoenix/rules
@@ -41,5 +41,5 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	bash -x debian/install_phoenix.sh \
-	  --build-dir=$${PWD}/build     \
+	  --build-dir=${CURDIR}/build     \
 	  --prefix=debian/tmp


### PR DESCRIPTION
According to
https://lintian.debian.org/tags/debian-rules-calls-pwd.html,
CURDIR is the preferred way in a makefile (like rules) to refer to the
current directory. For some reason I got building failures when running
a Debian 10 bigtop docker imagei and trying to build the hadoop pkg,
that got solved only applying this fix.

Applied the same fix to all the debian rules files with ${PWD}.