### PR TITLE
BIGTOP-3531. Fix packaging of Oozie 5.2.1.

### DIFF
--- a/bigtop-packages/src/common/hive/do-component-build
+++ b/bigtop-packages/src/common/hive/do-component-build
@@ -25,7 +25,8 @@ HIVE_MAVEN_OPTS=" -Dhbase.version=$HBASE_VERSION \
 -Dtez.version=${TEZ_VERSION} \
 -Dspark.version=${SPARK_VERSION} \
 -Dscala.binary.version=${SCALA_VERSION%.*} \
--Dscala.version=${SCALA_VERSION}
+-Dscala.version=${SCALA_VERSION} \
+-Dguava.version=27.0-jre
 "
 
 # Include common Maven Deployment logic

--- a/bigtop-packages/src/common/oozie/install_oozie.sh
+++ b/bigtop-packages/src/common/oozie/install_oozie.sh
@@ -103,6 +103,7 @@ BIN_DIR=${CLIENT_PREFIX}/usr/bin
 
 install -d -m 0755 ${CLIENT_LIB_DIR}
 tar --strip-components=1 -zxf ${BUILD_DIR}/oozie-client-*.tar.gz -C ${CLIENT_LIB_DIR}/
+mv ${CLIENT_LIB_DIR}/lib ${CLIENT_LIB_DIR}/lib-client
 cp ${BUILD_DIR}/oozie-examples.tar.gz ${CLIENT_LIB_DIR}/
 install -d -m 0755 ${DOC_DIR}
 mv ${CLIENT_LIB_DIR}/*.txt ${DOC_DIR}/
@@ -179,6 +180,7 @@ DATA_DIR=${SERVER_PREFIX}/var/lib/oozie
 install -d -m 0755 ${SERVER_LIB_DIR}
 install -d -m 0755 ${SERVER_LIB_DIR}/bin
 install -d -m 0755 ${SERVER_LIB_DIR}/lib
+install -d -m 0755 ${CLIENT_LIB_DIR}/lib
 install -d -m 0755 ${DATA_DIR}
 for file in ooziedb.sh oozied.sh oozie-jetty-server.sh oozie-sys.sh oozie-setup.sh ; do
   cp ${BUILD_DIR}/bin/$file ${SERVER_LIB_DIR}/bin
@@ -212,10 +214,14 @@ for f in $(find ${SERVER_LIB_DIR}/embedded-oozie-server/webapp/WEB-INF/lib -name
   ln -s -f /usr/lib/oozie/embedded-oozie-server/webapp/WEB-INF/lib/$f ${SERVER_LIB_DIR}/lib/
 done
 
+for f in $(find ${CLIENT_LIB_DIR}/lib-client -name '*.jar' -printf '%f\n') ; do
+  ln -s -f /usr/lib/oozie/lib-client/$f ${CLIENT_LIB_DIR}/lib/
+done
+
 # Remove jars provided by 'oozie-client' from 'oozie' to avoid run-time issues
 # while installing the package.
 if [ "${SERVER_PREFIX}" != "${CLIENT_PREFIX}" ]; then
-  for oozie_client_jar_file in $(ls $CLIENT_LIB_DIR/lib); do
+  for oozie_client_jar_file in $(ls $CLIENT_LIB_DIR/lib-client); do
     rm -f $SERVER_LIB_DIR/lib/$oozie_client_jar_file
   done
 fi

--- a/bigtop-packages/src/common/oozie/install_oozie.sh
+++ b/bigtop-packages/src/common/oozie/install_oozie.sh
@@ -178,6 +178,7 @@ DATA_DIR=${SERVER_PREFIX}/var/lib/oozie
 
 install -d -m 0755 ${SERVER_LIB_DIR}
 install -d -m 0755 ${SERVER_LIB_DIR}/bin
+install -d -m 0755 ${SERVER_LIB_DIR}/lib
 install -d -m 0755 ${DATA_DIR}
 for file in ooziedb.sh oozied.sh oozie-jetty-server.sh oozie-sys.sh oozie-setup.sh ; do
   cp ${BUILD_DIR}/bin/$file ${SERVER_LIB_DIR}/bin
@@ -206,6 +207,10 @@ cp -R ${BUILD_DIR}/libtools ${SERVER_LIB_DIR}/
 
 # Provide a convenience symlink to be more consistent with tarball deployment
 ln -s ${DATA_DIR#${SERVER_PREFIX}} ${SERVER_LIB_DIR}/libext
+
+for f in $(find ${SERVER_LIB_DIR}/embedded-oozie-server/webapp/WEB-INF/lib -name '*.jar' -printf '%f\n') ; do
+  ln -s -f /usr/lib/oozie/embedded-oozie-server/webapp/WEB-INF/lib/$f ${SERVER_LIB_DIR}/lib/
+done
 
 # Remove jars provided by 'oozie-client' from 'oozie' to avoid run-time issues
 # while installing the package.

--- a/bigtop-packages/src/common/oozie/install_oozie.sh
+++ b/bigtop-packages/src/common/oozie/install_oozie.sh
@@ -178,9 +178,8 @@ DATA_DIR=${SERVER_PREFIX}/var/lib/oozie
 
 install -d -m 0755 ${SERVER_LIB_DIR}
 install -d -m 0755 ${SERVER_LIB_DIR}/bin
-install -d -m 0755 ${SERVER_LIB_DIR}/lib
 install -d -m 0755 ${DATA_DIR}
-for file in ooziedb.sh oozied.sh oozie-sys.sh oozie-setup.sh ; do
+for file in ooziedb.sh oozied.sh oozie-jetty-server.sh oozie-sys.sh oozie-setup.sh ; do
   cp ${BUILD_DIR}/bin/$file ${SERVER_LIB_DIR}/bin
 done
 
@@ -201,11 +200,9 @@ fi
 cp -R ${BUILD_DIR}/oozie-sharelib*.tar.gz ${SERVER_LIB_DIR}/oozie-sharelib.tar.gz
 ln -s -f /etc/oozie/conf/oozie-env.sh ${SERVER_LIB_DIR}/bin
 
-cp -R ${BUILD_DIR}/embedded-oozie-server/webapp ${SERVER_LIB_DIR}/webapp
-cp ${BUILD_DIR}/embedded-oozie-server/dependency/* ${SERVER_LIB_DIR}/lib/
+cp -R ${BUILD_DIR}/embedded-oozie-server ${SERVER_LIB_DIR}/
 
 cp -R ${BUILD_DIR}/libtools ${SERVER_LIB_DIR}/
-cp ${BUILD_DIR}/oozie-core/* ${SERVER_LIB_DIR}/lib/
 
 # Provide a convenience symlink to be more consistent with tarball deployment
 ln -s ${DATA_DIR#${SERVER_PREFIX}} ${SERVER_LIB_DIR}/libext

--- a/bigtop-packages/src/common/oozie/oozie-env.sh
+++ b/bigtop-packages/src/common/oozie/oozie-env.sh
@@ -75,3 +75,5 @@ export OOZIE_LOG=/var/log/oozie
 # The Oozie Instance ID
 #
 # export OOZIE_INSTANCE_ID="${OOZIE_HTTP_HOSTNAME}"
+
+export JETTY_PID_FILE=/var/run/oozie/oozie.pid

--- a/bigtop-packages/src/common/oozie/oozie.init
+++ b/bigtop-packages/src/common/oozie/oozie.init
@@ -39,7 +39,7 @@ is_oozie_alive() {
   if [ ! -f "$OOZIE_PID" ]; then
     #not running
     STATUS=3
-  elif read pid < "$OOZIE_PID" && ps -p "$pid" > /dev/null 2>&1; then
+  elif ps -p "$(<${OOZIE_PID})" >/dev/null 2>&1; then
     #running
     STATUS=0
   else
@@ -49,7 +49,6 @@ is_oozie_alive() {
 }
 
 start_oozie() {
-  . /usr/lib/oozie/tomcat-deployment.sh
   install -d -o oozie -g oozie /var/run/oozie
   install -d -o oozie -g oozie /var/log/oozie
   install -d -o oozie -g oozie /var/tmp/oozie
@@ -65,8 +64,7 @@ stop_oozie() {
       if [ "${STATUS}" = "1" ]; then
         rm ${OOZIE_PID}
       elif [ "${STATUS}" = "0" ]; then
-        read pid < "$OOZIE_PID" && ps -p "$pid" > /dev/null 2>&1
-        kill -9 ${pid}
+        kill -9 "$(<${OOZIE_PID})"
         rm ${OOZIE_PID}
       fi
     fi
@@ -77,7 +75,7 @@ stop_oozie() {
 
 . /usr/lib/oozie/bin/oozie-env.sh
 
-OOZIE_PID=${CATALINA_PID}
+OOZIE_PID=${JETTY_PID_FILE}
 
 case "$1" in
   start)
@@ -135,7 +133,7 @@ case "$1" in
           echo "Error: Oozie is running. Stop it first."
           exit 1
         else
-          (cd /tmp ; su --shell=/bin/bash -l oozie -c "env JAVA_HOME=$JAVA_HOME /usr/lib/oozie/bin/ooziedb.sh create -run")
+          (cd /tmp ; runuser --shell=/bin/bash -l oozie -c "env JAVA_HOME=$JAVA_HOME /usr/lib/oozie/bin/ooziedb.sh create -run")
         fi
         exit 0
         ;;

--- a/bigtop-packages/src/common/oozie/patch0-hadoop322-hive312.diff
+++ b/bigtop-packages/src/common/oozie/patch0-hadoop322-hive312.diff
@@ -1,20 +1,3 @@
-diff --git a/core/pom.xml b/core/pom.xml
-index a60d5b909..83f19b138 100644
---- a/core/pom.xml
-+++ b/core/pom.xml
-@@ -255,6 +255,12 @@
-             <scope>compile</scope>
-         </dependency>
- 
-+        <dependency>
-+          <groupId>org.apache.logging.log4j</groupId>
-+          <artifactId>log4j-1.2-api</artifactId>
-+          <version>2.10.0</version>
-+        </dependency>
-+
-         <dependency>
-             <groupId>log4j</groupId>
-             <artifactId>apache-log4j-extras</artifactId>
 diff --git a/core/src/main/java/org/apache/oozie/dependency/HCatURIHandler.java b/core/src/main/java/org/apache/oozie/dependency/HCatURIHandler.java
 index c60c811ac..3ce6a3629 100644
 --- a/core/src/main/java/org/apache/oozie/dependency/HCatURIHandler.java
@@ -109,8 +92,208 @@ index 6d663c375..3be398fbe 100644
  import org.apache.hadoop.hive.shims.HadoopShims.MiniDFSShim;
  import org.apache.hadoop.hive.shims.HadoopShims.MiniMrShim;
  import org.apache.hadoop.hive.shims.ShimLoader;
+diff --git a/pom.xml b/pom.xml
+index 59f871266..110daeb21 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -128,6 +128,7 @@
+          <spotbugs-maven-plugin.version>3.1.11</spotbugs-maven-plugin.version>
+          <spotbugs.version>3.1.11</spotbugs.version>
+          <powermock.version>2.0.2</powermock.version>
++         <guava.version>27.0-jre</guava.version>
+     </properties>
+ 
+     <modules>
+@@ -254,6 +255,22 @@
+                             <groupId>joda-time</groupId>
+                             <artifactId>joda-time</artifactId>
+                     </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-1.2-api</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-web</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-slf4j-impl</artifactId>
++                    </exclusion>
+                 </exclusions>
+             </dependency>
+             <dependency>
+@@ -551,6 +568,22 @@
+                         <groupId>joda-time</groupId>
+                         <artifactId>joda-time</artifactId>
+                     </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-1.2-api</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-web</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-slf4j-impl</artifactId>
++                    </exclusion>
+                 </exclusions>
+             </dependency>
+ 
+@@ -1224,6 +1257,14 @@
+                         <artifactId>zookeeper</artifactId>
+                         <groupId>org.apache.zookeeper</groupId>
+                     </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-1.2-api</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-slf4j-impl</artifactId>
++                    </exclusion>
+                 </exclusions>
+             </dependency>
+ 
+@@ -1417,7 +1458,7 @@
+             <dependency>
+                 <groupId>com.google.guava</groupId>
+                 <artifactId>guava</artifactId>
+-                <version>11.0.2</version>
++                <version>${guava.version}</version>
+             </dependency>
+ 
+             <dependency>
+@@ -1506,6 +1547,24 @@
+                 <artifactId>hive-exec</artifactId>
+                 <version>${hive.version}</version>
+                 <classifier>${hive.classifier}</classifier>
++                <exclusions>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-1.2-api</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-web</artifactId>
++                    </exclusion>
++                    <exclusion>
++                        <groupId>org.apache.logging.log4j</groupId>
++                        <artifactId>log4j-slf4j-impl</artifactId>
++                    </exclusion>
++                </exclusions>
+             </dependency>
+ 
+             <!-- examples -->
+diff --git a/sharelib/hive/pom.xml b/sharelib/hive/pom.xml
+index d50984566..408fb565d 100644
+--- a/sharelib/hive/pom.xml
++++ b/sharelib/hive/pom.xml
+@@ -129,6 +129,18 @@
+                     <groupId>javax.mail</groupId>
+                     <artifactId>mail</artifactId>
+                 </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-1.2-api</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-web</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-slf4j-impl</artifactId>
++                </exclusion>
+             </exclusions>
+         </dependency>
+ 
+@@ -142,6 +154,14 @@
+                     <groupId>org.pentaho</groupId>
+                     <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                 </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-1.2-api</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-slf4j-impl</artifactId>
++                </exclusion>
+             </exclusions>
+         </dependency>
+ 
+diff --git a/sharelib/hive2/pom.xml b/sharelib/hive2/pom.xml
+index 619768837..088ed8556 100644
+--- a/sharelib/hive2/pom.xml
++++ b/sharelib/hive2/pom.xml
+@@ -7,7 +7,7 @@
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+-
++e
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+@@ -133,6 +133,18 @@
+                     <groupId>javax.mail</groupId>
+                     <artifactId>mail</artifactId>
+                 </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-1.2-api</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-web</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-slf4j-impl</artifactId>
++                </exclusion>
+             </exclusions>
+         </dependency>
+ 
+diff --git a/sharelib/pig/pom.xml b/sharelib/pig/pom.xml
+index d9fb408fe..01f0ff0a1 100644
+--- a/sharelib/pig/pom.xml
++++ b/sharelib/pig/pom.xml
+@@ -143,6 +143,18 @@
+                     <groupId>javax.mail</groupId>
+                     <artifactId>mail</artifactId>
+                 </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-1.2-api</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-web</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>org.apache.logging.log4j</groupId>
++                    <artifactId>log4j-slf4j-impl</artifactId>
++                </exclusion>
+             </exclusions>
+         </dependency>
+         <dependency>
 diff --git a/sharelib/spark/pom.xml b/sharelib/spark/pom.xml
-index e506c8305..a71f08646 100644
+index 17a538a5e..9735e5365 100644
 --- a/sharelib/spark/pom.xml
 +++ b/sharelib/spark/pom.xml
 @@ -209,30 +209,6 @@

--- a/bigtop-packages/src/deb/oozie/rules
+++ b/bigtop-packages/src/deb/oozie/rules
@@ -39,8 +39,5 @@ override_dh_auto_install:
 	sh -x debian/install_oozie.sh --extra-dir=debian/ --build-dir=$(PWD) --server-dir=./debian/oozie --client-dir=./debian/oozie-client --docs-dir=./debian/oozie-client/usr/share/doc/oozie --initd-dir=./debian/oozie/etc/init.d --conf-dir=./debian/oozie/etc/oozie/conf.dist
 	rm -rf                        debian/oozie/usr/lib/oozie/embedded-oozie-server/webapp/docs
 	ln -s -f /usr/share/doc/oozie debian/oozie/usr/lib/oozie/embedded-oozie-server/webapp/docs
-	rm -rf debian/oozie/usr/lib/oozie/lib
-	ln -s -f /usr/lib/oozie/embedded-oozie-server/webapp/WEB-INF/lib debian/oozie/usr/lib/oozie/
 
- verride_dh_strip_nondeterminism:
-	echo ""
+override_dh_strip_nondeterminism:

--- a/bigtop-packages/src/deb/oozie/rules
+++ b/bigtop-packages/src/deb/oozie/rules
@@ -37,24 +37,10 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	sh -x debian/install_oozie.sh --extra-dir=debian/ --build-dir=$(PWD) --server-dir=./debian/oozie --client-dir=./debian/oozie-client --docs-dir=./debian/oozie-client/usr/share/doc/oozie --initd-dir=./debian/oozie/etc/init.d --conf-dir=./debian/oozie/etc/oozie/conf.dist
-	rm -rf                        debian/oozie/usr/lib/oozie/webapp/docs
-	ln -s -f /usr/share/doc/oozie debian/oozie/usr/lib/oozie/webapp/docs
+	rm -rf                        debian/oozie/usr/lib/oozie/embedded-oozie-server/webapp/docs
+	ln -s -f /usr/share/doc/oozie debian/oozie/usr/lib/oozie/embedded-oozie-server/webapp/docs
+	rm -rf debian/oozie/usr/lib/oozie/lib
+	ln -s -f /usr/lib/oozie/embedded-oozie-server/webapp/WEB-INF/lib debian/oozie/usr/lib/oozie/
 
-	# Oozie server
-	rm -rf  debian/oozie/usr/lib/oozie/lib/hadoop-*.jar
-	ln -sf /usr/lib/hadoop/client/hadoop-annotations.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-auth.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-common.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-hdfs-client.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-mapreduce-client-app.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-mapreduce-client-common.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-mapreduce-client-core.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-mapreduce-client-jobclient.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-mapreduce-client-shuffle.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-yarn-api.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-yarn-client.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-yarn-common.jar debian/oozie/usr/lib/oozie/lib/
-	ln -sf /usr/lib/hadoop/client/hadoop-yarn-server-common.jar debian/oozie/usr/lib/oozie/lib/
-
-override_dh_strip_nondeterminism:
+ verride_dh_strip_nondeterminism:
 	echo ""

--- a/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
+++ b/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
@@ -146,9 +146,6 @@ Requires: bigtop-utils >= 0.7
 %__rm  -rf $RPM_BUILD_ROOT/%{lib_oozie}/embedded-oozie-server/webapp/docs
 %__ln_s -f %{doc_oozie} $RPM_BUILD_ROOT/%{lib_oozie}/embedded-oozie-server/webapp/docs
 
-%__rm  -rf $RPM_BUILD_ROOT/%{lib_oozie}/lib
-%__ln_s -f %{lib_oozie}/embedded-oozie-server/webapp/WEB-INF/lib $RPM_BUILD_ROOT/%{lib_oozie}/
-
 # Oozie server
 
 %__install -d -m 0755 $RPM_BUILD_ROOT/usr/bin

--- a/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
+++ b/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
@@ -143,24 +143,13 @@ Requires: bigtop-utils >= 0.7
 %__rm -rf $RPM_BUILD_ROOT
     sh %{SOURCE2} --extra-dir=$RPM_SOURCE_DIR --build-dir=$PWD --server-dir=$RPM_BUILD_ROOT --client-dir=$RPM_BUILD_ROOT --docs-dir=$RPM_BUILD_ROOT%{doc_oozie} --initd-dir=$RPM_BUILD_ROOT%{initd_dir} --conf-dir=$RPM_BUILD_ROOT%{conf_oozie_dist}
 
-%__rm  -rf              $RPM_BUILD_ROOT/%{lib_oozie}/webapp/docs
-%__ln_s -f %{doc_oozie} $RPM_BUILD_ROOT/%{lib_oozie}/webapp/docs
+%__rm  -rf $RPM_BUILD_ROOT/%{lib_oozie}/embedded-oozie-server/webapp/docs
+%__ln_s -f %{doc_oozie} $RPM_BUILD_ROOT/%{lib_oozie}/embedded-oozie-server/webapp/docs
+
+%__rm  -rf $RPM_BUILD_ROOT/%{lib_oozie}/lib
+%__ln_s -f %{lib_oozie}/embedded-oozie-server/webapp/WEB-INF/lib $RPM_BUILD_ROOT/%{lib_oozie}/
 
 # Oozie server
-%__rm  -rf $RPM_BUILD_ROOT/%{lib_oozie}/lib/hadoop-*.jar
-%__ln_s -f %{lib_hadoop}/client/hadoop-annotations.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-auth.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-common.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-hdfs-client.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-mapreduce-client-app.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-mapreduce-client-common.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-mapreduce-client-core.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-mapreduce-client-jobclient.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-mapreduce-client-shuffle.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-yarn-api.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-yarn-client.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-yarn-common.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
-%__ln_s -f %{lib_hadoop}/client/hadoop-yarn-server-common.jar $RPM_BUILD_ROOT/%{lib_oozie}/lib/
 
 %__install -d -m 0755 $RPM_BUILD_ROOT/usr/bin
 
@@ -192,15 +181,16 @@ fi
 %defattr(-,root,root)
 %config(noreplace) %{conf_oozie_dist}
 %{usr_bin}/oozie-setup
-%{lib_oozie}/bin/oozie-sys.sh
 %{lib_oozie}/bin/oozie-env.sh
+%{lib_oozie}/bin/oozie-jetty-server.sh
+%{lib_oozie}/bin/oozie-setup.sh
+%{lib_oozie}/bin/oozie-sys.sh
 %{lib_oozie}/bin/oozied.sh
 %{lib_oozie}/bin/ooziedb.sh
-%{lib_oozie}/bin/oozie-setup.sh
-%{lib_oozie}/webapp
+%{lib_oozie}/embedded-oozie-server
 %{lib_oozie}/libtools
 %{lib_oozie}/lib
-%{lib_oozie}/oozie-sharelib.tar.gz
+%{lib_oozie}/oozie-sharelib*.tar.gz
 %{lib_oozie}/libext
 %{initd_dir}/oozie
 %defattr(-, oozie, oozie)

--- a/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
+++ b/bigtop-packages/src/rpm/oozie/SPECS/oozie.spec
@@ -203,6 +203,7 @@ fi
 %{lib_oozie}/bin/oozie
 %{lib_oozie}/conf/oozie-client-env.sh
 %{lib_oozie}/lib
+%{lib_oozie}/lib-client
 %{lib_oozie}/oozie-examples.tar.gz
 %doc %{doc_oozie}
 %{man_dir}/man1/oozie.1.*


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3531

I needed lots of fix than I expected just make oozie-server run.

* fixed layout based on the expectation of scripts under /usr/lib/oozie/bin.
* made /usr/lib/oozie/lib symlink to embedded-oozie-server/webapp/WEB-INF/lib.
* set guava version to 27.0-jre.
* set JETTY_PID_FILE  to /var/run/oozie/oozie.pid.
* fixed /etc/init.d/oozie.
* excluded log4j2 from transitive dependencies of hive3 artifacts.

Let me address smoke-tests issue on [BIGTOP-3532](https://issues.apache.org/jira/browse/BIGTOP-3532) after this is merged.