### PR TITLE
BIGTOP-3532. Fix smoke-tests for Oozie 5.2.1.

### DIFF
--- a/bigtop-tests/test-artifacts/oozie/src/main/groovy/org/apache/bigtop/itest/ooziesmoke/TestOozieSmoke.groovy
+++ b/bigtop-tests/test-artifacts/oozie/src/main/groovy/org/apache/bigtop/itest/ooziesmoke/TestOozieSmoke.groovy
@@ -53,7 +53,7 @@ class TestOozieSmoke {
     oozie_tar_home = System.getProperty("org.apache.bigtop.itest.oozie_tar_home",
       (new File("/usr/share/doc/packages/oozie/")).exists() ?
         "/usr/share/doc/packages/oozie/" :
-        "/usr/share/doc/oozie*/");
+        "/usr/lib/oozie");
 
     sh.exec("mkdir /tmp/${tmp_dir}",
       "cd /tmp/${tmp_dir}",
@@ -71,7 +71,7 @@ class TestOozieSmoke {
   }
 
   void testOozieExamplesCommon(String testname) {
-    sh.exec("oozie job -oozie ${oozie_url} -run -DjobTracker=${resourcemanager} -DnameNode=${namenode} " +
+    sh.exec("oozie job -oozie ${oozie_url} -run -DresourceManager=${resourcemanager} -DnameNode=${namenode} " +
       "-DexamplesRoot=${tmp_dir}/examples -config /tmp/${tmp_dir}/examples/apps/${testname}/job.properties");
     assertEquals("Oozie job submition ${testname} failed",
       0, sh.ret);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3532 

This patch depends on #763.