### PR TITLE
BIGTOP-3536. Fix build failure of Hadoop on Fedora 33.

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch8-HADOOP-17569.diff
+++ b/bigtop-packages/src/common/hadoop/patch8-HADOOP-17569.diff
@@ -1,0 +1,36 @@
+commit 1a83235fb0f32aca47be9dcd5c81da45f6c047dc
+Author: Masatake Iwasaki <iwasakims@apache.org>
+Date:   Thu Apr 15 21:33:18 2021 +0900
+
+    HADOOP-17569. Building native code fails on Fedora 33. (#2886)
+    
+    (cherry picked from commit 2717203f858ff654de0fc01cfb9afef2e705e33c)
+
+diff --git a/hadoop-common-project/hadoop-common/src/main/native/src/exception.c b/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
+index fc072e8002b..a25cc3d3b7e 100644
+--- a/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
++++ b/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
+@@ -111,8 +111,8 @@ jthrowable newIOException(JNIEnv* env, const char *fmt, ...)
+ const char* terror(int errnum)
+ {
+ 
+-#if defined(__sun)
+-// MT-Safe under Solaris which doesn't support sys_errlist/sys_nerr
++#if defined(__sun) || defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 32)
++// MT-Safe under Solaris or glibc >= 2.32 not supporting sys_errlist/sys_nerr
+   return strerror(errnum); 
+ #else
+   if ((errnum < 0) || (errnum >= sys_nerr)) {
+diff --git a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
+index cb8fe378515..18396c78554 100644
+--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
++++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
+@@ -65,6 +65,8 @@ if(WIN32)
+     set(OUT_DIR bin)
+ else()
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
++    # using old default behavior on GCC >= 10.0
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon")
+     set(OS_DIR ${CMAKE_SOURCE_DIR}/main/native/libhdfs/os/posix)
+ 
+     # IMPORTANT: OUT_DIR MUST be relative to maven's


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3536

We need apply the patch of (HADOOP-17569)[https://issues.apache.org/jira/browse/HADOOP-17569] to fix build failure of Hadoop on Fedora 33.