### PR TITLE
BIGTOP-3538. Building GPDB fails on Fedora 33.

### DIFF
--- a/bigtop-packages/src/common/gpdb/do-component-configure
+++ b/bigtop-packages/src/common/gpdb/do-component-configure
@@ -16,4 +16,4 @@
 
 set -ex
 
-./configure --prefix=$1 --disable-orca
+./configure --prefix=$1 --disable-orca CFLAGS=-fcommon


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3538

This PR contains the following fixes so as to satisfy recent stricter compiler:

* Backport https://github.com/greenplum-db/gpdb/pull/10663
* Remove duplicate variable declarations

Tested on all distros we support using an x86_64 machine.