### PR TITLE
BIGTOP-3541: Smoke test on odpi-runtime failed

### DIFF
--- a/bigtop-tests/smoke-tests/odpi-runtime/build.gradle
+++ b/bigtop-tests/smoke-tests/odpi-runtime/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'java'
 
 repositories {
   maven {
-    url "https://conjars.org/repo/"
+    url "https://public.nexus.pentaho.org/repository/proxy-public-3rd-party-release"
   }
 }
 dependencies {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3541

This was probably because https://conjars.org/repo/ stopped providing jars.

To avoid the issue, change the maven repository url from https://conjars.org/repo/ to https://public.nexus.pentaho.org/repository/proxy-public-3rd-party-release

Apache Beam had the same kinds of issue, and they switched to the pentaho's own repository.
https://issues.apache.org/jira/browse/BEAM-11689