### PR TITLE
BIGTOP-3540. Fix toolchain to abort if R installation failed.

### DIFF
--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -79,14 +79,14 @@ class bigtop_toolchain::renv {
 
     exec { "install_r_packages" :
       cwd     => "/usr/local/bin",
-      command => "/usr/local/bin/R -e \"install.packages(c('devtools', 'evaluate', 'rmarkdown', 'knitr', 'roxygen2', 'testthat', 'e1071'), repos = 'http://cran.r-project.org/')\"",
+      command => '/usr/local/bin/R -e \'pkgs <- c("devtools", "evaluate", "rmarkdown", "knitr", "roxygen2", "testthat", "e1071"); install.packages(pkgs, repo="http://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)\'',
       require => [Exec["install_R"]],
       timeout => 6000
     }
   } else {
     exec { "install_r_packages" :
       cwd     => "/usr/bin",
-      command => "/usr/bin/R -e \"install.packages(c('devtools', 'evaluate', 'rmarkdown', 'knitr', 'roxygen2', 'testthat', 'e1071'), repos = 'http://cran.r-project.org/')\"",
+      command => '/usr/bin/R -e \'pkgs <- c("devtools", "evaluate", "rmarkdown", "knitr", "roxygen2", "testthat", "e1071"); install.packages(pkgs, repo="http://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)\'',
       timeout => 6000
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3540

Currently, `./gradlew toolchain` succeeds silently even if it fails to install R libraries.
With this PR, users can get aware of that failure from the message as follows (manually edited renv.pp for testing purpose, to specify non-existent package):

```
Debug: Exec[install_r_packages](provider=posix): Executing '/usr/bin/R -e 'pkgs <- c("foo"); install.packages(pkgs, repo="http://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)''
Debug: Executing '/usr/bin/R -e 'pkgs <- c("foo"); install.packages(pkgs, repo="http://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)''

...

Error: /usr/bin/R -e 'pkgs <- c("foo"); install.packages(pkgs, repo="http://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)' returned 1 instead of one of [0]
Error: /Stage[main]/Bigtop_toolchain::Renv/Exec[install_r_packages]/returns: change from notrun to 0 failed: /usr/bin/R -e 'pkgs <- c("foo"); install.packages(pkgs, repo="http://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)' returned 1 instead of one of [0]

...

BUILD SUCCESSFUL in 19s
1 actionable task: 1 executed
```

In the above example, `puppet apply` itself still succeeded, but it's already filed as https://issues.apache.org/jira/browse/BIGTOP-3402 and will be addressed separately.