### PR TITLE
BIGTOP-3548: Hive build failure caused by protoc-jar-maven-plugin mis…

### DIFF
--- a/bigtop-packages/src/common/hive/patch6-HIVE-21939.diff
+++ b/bigtop-packages/src/common/hive/patch6-HIVE-21939.diff
@@ -1,0 +1,60 @@
+diff --git a/standalone-metastore/pom.xml b/standalone-metastore/pom.xml
+index 884dbfdf31..6d2ca187df 100644
+--- a/standalone-metastore/pom.xml
++++ b/standalone-metastore/pom.xml
+@@ -81,7 +81,9 @@
+     <log4j2.version>2.8.2</log4j2.version>
+     <mockito-all.version>1.10.19</mockito-all.version>
+     <orc.version>1.5.1</orc.version>
+-    <protobuf.version>2.5.0</protobuf.version>
++    <protobuf.group>com.google.protobuf</protobuf.group>
++    <protobuf.version>2.6.1</protobuf.version>
++    <protobuf-exc.version>2.6.1</protobuf-exc.version>
+     <sqlline.version>1.3.0</sqlline.version>
+     <storage-api.version>2.7.0</storage-api.version>
+ 
+@@ -480,6 +482,35 @@
+       </build>
+     </profile>
+     -->
++    <!-- use com.github.os72 on aarch64 and ppc64le platform -->
++    <profile>
++      <id>aarch64</id>
++      <properties>
++        <protobuf.group>com.github.os72</protobuf.group>
++        <protobuf-exc.version>2.6.1-build3</protobuf-exc.version>
++      </properties>
++      <activation>
++        <os>
++          <family>unix</family>
++          <name>Linux</name>
++          <arch>aarch64</arch>
++        </os>
++      </activation>
++    </profile>
++    <profile>
++      <id>ppc64le</id>
++      <properties>
++        <protobuf.group>com.github.os72</protobuf.group>
++        <protobuf-exc.version>2.6.1-build3</protobuf-exc.version>
++      </properties>
++      <activation>
++        <os>
++          <family>unix</family>
++          <name>Linux</name>
++          <arch>ppc64le</arch>
++        </os>
++      </activation>
++    </profile>
+   </profiles>
+ 
+   <build>
+@@ -599,7 +630,7 @@
+               <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
++              <protocArtifact>${protobuf.group}:protoc:${protobuf-exc.version}</protocArtifact>
+               <addSources>none</addSources>
+               <inputDirectories>
+                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>


### PR DESCRIPTION
…sing aarch64 support

Hive uses protoc-jar to provide protoc executable to
process *.proto files. The protoc-jar-maven-plugin-2.5.0
doesn't include non-x86 binaries which caused build
failure on non-x86 platforms.
Backport HIVE-21939 to 3.1.2 branch and added ppc64le support.

Change-Id: I14f9ce54272a3eda1557710ab4276d999eed4a57
Signed-off-by: Jun He <jun.he@arm.com>