### PR TITLE
BIGTOP-3552. Add missing files to ambari-agent RPM.

### DIFF
--- a/bigtop-packages/src/rpm/ambari/SPECS/ambari.spec
+++ b/bigtop-packages/src/rpm/ambari/SPECS/ambari.spec
@@ -469,6 +469,7 @@ exit 0
 %dir  /var/log/ambari-server
 
 %files agent
+/usr/lib/ambari-agent
 %attr(644,root,root) /etc/init/ambari-agent.conf
 %attr(755,root,root) /var/lib/ambari-agent/ambari-python-wrap
 %attr(755,root,root) /var/lib/ambari-agent/ambari-sudo.sh


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3552

smoke-tests of ambari succeeded on CentOS 7:
```
$ ./docker-hadoop.sh \
   --create 1 \
   --image bigtop/puppet:trunk-centos-7 \
   --memory 16g \
   --repo file:///bigtop-home/output \
   --disable-gpg-check \
   --stack bigtop-utils,ambari \
   --smoke-tests ambari
...
Now testing...
:bigtop-tests:smoke-tests:ambari:test (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 1.745 secs.

BUILD SUCCESSFUL in 52s
35 actionable tasks: 7 executed, 28 up-to-date
Stopped 1 worker daemon(s).
+ rm -rf buildSrc/build/test-results/binary
+ rm -rf /bigtop-home/.gradle
```

It seems not to work on CentOS 8. I filed [BIGTOP-3553](https://issues.apache.org/jira/browse/BIGTOP-3553) for that.