### PR TITLE
BIGTOP-3557: Java on Fedora-33 is set to JDK11 as default

### DIFF
--- a/bigtop_toolchain/manifests/cleanup.pp
+++ b/bigtop_toolchain/manifests/cleanup.pp
@@ -19,6 +19,12 @@ class bigtop_toolchain::cleanup {
     /(?i:(SLES|opensuse))/ => 'zypper clean -a',
     /Ubuntu|Debian/        => 'apt-get clean',
   } 
+
+  if ($operatingsystem == 'fedora' and versioncmp($operatingsystemmajrelease, '33')) {
+    exec { "Restore JDK to 8":
+      command => "/usr/sbin/alternatives --set java /usr/lib/jvm/java-1.8.0-openjdk-1.8.*/jre/bin/java",
+    }
+  }
   
   exec { 'remove archives':
     cwd         => '/usr/src',


### PR DESCRIPTION
On Fedora-33, JDK-11 is set as default JDK when installing
pandoc for R. This patch adds extra step in toolchain cleanup
to restore JDK to v8.

Change-Id: Iefa5e9b7903cfa8bebf10774dc55705357d1356f
Signed-off-by: Jun He <jun.he@arm.com>