### PR TITLE
BIGTOP-3559. Fix the download URL for pip2 in the GPDB deployment manifest.

### DIFF
--- a/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
@@ -101,7 +101,7 @@ class gpdb {
       # here to install it on all distros.
       exec { 'download_get_pip':
         cwd => '/tmp',
-        command => '/usr/bin/curl -sLO https://bootstrap.pypa.io/2.7/get-pip.py'
+        command => '/usr/bin/curl -sLO https://bootstrap.pypa.io/pip/2.7/get-pip.py'
       }
       exec { 'install_pip':
         cwd => '/tmp',


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3559