### PR TITLE
BIGTOP-3562. Building Logstash is failing due to the unavailability of keyserver.

### DIFF
--- a/bigtop-packages/src/common/logstash/do-component-build
+++ b/bigtop-packages/src/common/logstash/do-component-build
@@ -35,7 +35,7 @@ case ${ID}-${VERSION_ID} in
 esac
 
 # Install ruby-2.4.0 to build Logstash
-gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
 curl -sSL https://get.rvm.io | bash -s stable
 if ((UID == 0))
 then


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3562