### PR TITLE
BIGTOP-3563. Building Hadoop for CentOS 8 fails due to cmake error.

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -232,14 +232,20 @@ class bigtop_toolchain::packages {
     package { 'epel-release':
       ensure => installed
     }
-    # On CentOS 8, EPEL requires that the PowerTools repository is enabled.
-    # See https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F
     if $operatingsystemmajrelease !~ /^[0-7]$/ {
+      # On CentOS 8, EPEL requires that the PowerTools repository is enabled.
+      # See https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F
       yumrepo { 'powertools':
         ensure  => 'present',
         enabled => '1'
       }
       Yumrepo<||> -> Package<||>
+
+      # On CentOS 8, cmake-3.18.2-9.el8 does not work without updated libarchive.
+      # https://bugs.centos.org/view.php?id=18212
+      package { libarchive:
+        ensure => latest
+      }
     }
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3563

The latest cmake does not work without latest libarchive.

```
$ rpm -q cmake
cmake-3.18.2-9.el8.x86_64

$ cmake --version
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd
Updating libarhcive fixed the issue.

$ rpm -q libarchive
libarchive-3.3.2-8.el8_1.x86_64

$ sudo dnf update -y libarchive

$ rpm -q libarchive
libarchive-3.3.3-1.el8.x86_64

$ cmake --version
cmake version 3.18.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```