### PR TITLE
BIGTOP-3564. Fix build failure of Flink on Cent OS 7 ppc64le.

### DIFF
--- a/bigtop-packages/src/common/flink/do-component-build
+++ b/bigtop-packages/src/common/flink/do-component-build
@@ -20,6 +20,10 @@ set -ex
 #load versions
 . `dirname $0`/bigtop.bom
 
+if [ $HOSTTYPE = "powerpc64le" ] ; then
+  sed -i "s|<nodeVersion>v10.9.0</nodeVersion>|<nodeVersion>v12.22.1</nodeVersion>|" flink-runtime-web/pom.xml
+fi
+
 # Use Maven to build Flink from source
 mvn install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"
 cd flink-dist


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3564

Build fails due to error related to node.js.
```
Running 'npm ci --cache-max=0 --no-save' in /bigtop/build/flink/rpm/BUILD/flink-1.11.3/flink-runtime-web/web-dashboard
/bigtop/build/flink/rpm/BUILD/flink-1.11.3/flink-runtime-web/web-dashboard/node/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /bigtop/build/flink/rpm/BUILD/flink-1.11.3/flink-runtime-web/web-dashboard/node/node)
```

https://github.com/eirslett/frontend-maven-plugin/issues/852 reported that using v.12 node.js fixed similar issue.

**I did not test this on ppc64le.**

