### PR TITLE
BIGTOP-3565. Fix build failure of Alluxio on Cent OS 7 ppc64le.

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -18,4 +18,9 @@ set -ex
 
 . `dirname $0`/bigtop.bom
 
-mvn clean install -DskipTests -Dhadoop.version=3.2.2 -Phadoop-3 -Pyarn "$@"
+if [ $HOSTTYPE = "powerpc64le" ] ; then
+  sed -i "s|<nodeVersion>v10.11.0</nodeVersion>|<nodeVersion>v12.22.1</nodeVersion>|" webui/pom.xml
+  sed -i "s|<npmVersion>6.4.1</npmVersion>|<npmVersion>6.14.7</npmVersion>|" webui/pom.xml
+fi
+
+mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Phadoop-3 -Pyarn "$@"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3565

```
[INFO] Running 'npm install --production --no-save --no-package-lock --no-shrinkwrap' in /bigtop/build/alluxio/rpm/BUILD/alluxio-2.4.1/webui
[ERROR] /bigtop/build/alluxio/rpm/BUILD/alluxio-2.4.1/webui/node/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /bigtop/build/alluxio/rpm/BUILD/alluxio-2.4.1/webui/node/node)
```

Upgrading node.js to 12 same as done for https://github.com/apache/bigtop/pull/793 should be the fix. We need to upgrade npm too to the version supporting node 12 here.
