### PR TITLE
BIGTOP-3571. Ensure Hadoop and Flink are deployed in the correct order.

### DIFF
--- a/bigtop-deploy/puppet/modules/flink/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/flink/manifests/init.pp
@@ -48,6 +48,8 @@ class flink {
       hasrestart => true,
       hasstatus => true
     }
+
+    Package<| title == 'hadoop-hdfs' |> -> Package['flink-jobmanager']
   }
 
   class taskmanager {
@@ -64,5 +66,7 @@ class flink {
       hasrestart => true,
       hasstatus => true,
     }
+
+    Package<| title == 'hadoop-hdfs' |> -> Package['flink-taskmanager']
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3571