### PR TITLE
BIGTOP-3569. Applying GPDB Puppet manifest fails on arm64 (addendum).

### DIFF
--- a/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
@@ -113,6 +113,7 @@ class gpdb {
       exec { 'install_python_packages':
         command => "/usr/bin/env pip install -q 'cryptography<3.3' lockfile paramiko psutil",
         require => [Exec["install_pip"]],
+        timeout => 600,
       }
       package { ["gpdb"]:
         ensure => latest,


### PR DESCRIPTION
Addendum PR for https://issues.apache.org/jira/browse/BIGTOP-3569. See https://github.com/apache/bigtop/pull/797#issuecomment-877890859 for details.