### PR TITLE
BIGTOP-3573. Tez smoke test fails on the ARM platform.

### DIFF
--- a/bigtop-packages/src/common/tez/patch1-snappy-java-dependency.diff
+++ b/bigtop-packages/src/common/tez/patch1-snappy-java-dependency.diff
@@ -1,0 +1,31 @@
+diff --git a/pom.xml b/pom.xml
+index 05fcc6d..70cc871 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -333,6 +333,10 @@
+             <groupId>commons-el</groupId>
+             <artifactId>commons-el</artifactId>
+           </exclusion>
++          <exclusion>
++            <groupId>org.xerial.snappy</groupId>
++            <artifactId>snappy-java</artifactId>
++          </exclusion>
+         </exclusions>
+       </dependency>
+       <dependency>
+diff --git a/tez-api/pom.xml b/tez-api/pom.xml
+index 9c9d7af..5d51e74 100644
+--- a/tez-api/pom.xml
++++ b/tez-api/pom.xml
+@@ -110,6 +110,11 @@
+       <artifactId>mockito-all</artifactId>
+       <scope>test</scope>
+     </dependency>
++    <dependency>
++        <groupId>org.xerial.snappy</groupId>
++        <artifactId>snappy-java</artifactId>
++        <version>1.1.8.4</version>
++    </dependency>
+   </dependencies>
+ 
+   <build>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3573

Tez implicitly depends on snappy-java-1.0.5 which does not support aarch64. The dependency on snappy-java seems to be pulled from Avro. Adding explicit dependency on upstream snappy-java should address issues on aarch64.

https://github.com/apache/tez/blob/rel/release-0.10.0/tez-api/src/main/java/org/apache/tez/common/TezUtils.java#L44-L45
```
$ mvn dependency:tree -Dhadoop.version=3.2.2
...
[INFO] org.apache.tez:tez-api:jar:0.10.0
...
[INFO] +- org.apache.hadoop:hadoop-common:jar:3.2.2:compile
...
[INFO] |  +- org.apache.avro:avro:jar:1.7.7:compile
[INFO] |  |  +- com.thoughtworks.paranamer:paranamer:jar:2.3:compile
[INFO] |  |  \- org.xerial.snappy:snappy-java:jar:1.0.5:compile
...
```
