### PR TITLE
BIGTOP-3556: Minimum chnages for upgrading Bigtop-ambari-mpack aligne…

### DIFF
--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/repos/repoinfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/repos/repoinfo.xml
@@ -18,14 +18,14 @@
 <reposinfo>
   <os family="redhat7">
     <repo>
-      <baseurl>http://repos.bigtop.apache.org/releases/1.4.0/centos/7/$basearch</baseurl>
+      <baseurl>http://repos.bigtop.apache.org/releases/1.5.0/centos/7/$basearch</baseurl>
       <repoid>BGTP-1.0</repoid>
       <reponame>BGTP</reponame>
     </repo>
   </os>
-  <os family="ubuntu16">
+  <os family="ubuntu18">
     <repo>
-      <baseurl>http://repos.bigtop.apache.org/releases/1.4.0/ubuntu/16.04/$(ARCH)</baseurl>
+      <baseurl>http://repos.bigtop.apache.org/releases/1.5.0/ubuntu/18.04/$(ARCH)</baseurl>
       <repoid>BGTP-1.0</repoid>
       <reponame>BGTP</reponame>
     </repo>

--- a/bigtop-packages/src/rpm/bigtop-ambari-mpack/SPECS/bigtop-ambari-mpack.spec
+++ b/bigtop-packages/src/rpm/bigtop-ambari-mpack/SPECS/bigtop-ambari-mpack.spec
@@ -31,7 +31,7 @@ Summary: Bigtop Ambari Management Packages
 Group: Application/Internet
 Buildroot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 License: ASL 2.0
-Source0: apache-ambari-2.6.1-src.tar.gz
+Source0: apache-ambari-%{bigtop_ambari_mpack_base_version}-src.tar.gz
 Source1: do-component-build
 Source2: install_mpack.sh
 Requires: bigtop-utils >= 0.7
@@ -45,7 +45,7 @@ from stack management and definition. Mpack can bundle multiple service definiti
 stack add-on service definitions, view definitions services.
 
 %prep
-%setup -n apache-ambari-2.6.1-src
+%setup -n apache-ambari-%{bigtop_ambari_mpack_base_version}-src
 
 %build
 bash $RPM_SOURCE_DIR/do-component-build

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -339,7 +339,7 @@ bigtop {
     'bigtop-ambari-mpack' {
       name    = 'bigtop-ambari-mpack'
       relNotes = 'Bigtop Mpack'
-      version { base = '2.6.1'; pkg = '2.6.1.0'; release = 1 }
+      version { base = '2.7.5'; pkg = '2.7.5.0'; release = 1 }
       tarball { destination = "apache-ambari-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/ambari/ambari-${version.base}/"


### PR DESCRIPTION


1. minimum changes for bumping Mpack version.
2. upgrade repo to 1.5.0 release.

