### PR TITLE
BIGTOP-3575. Fix Hive rpm build warning due to missing dependency.

### DIFF
--- a/bigtop-packages/src/common/hive/patch6-HIVE-21777.diff
+++ b/bigtop-packages/src/common/hive/patch6-HIVE-21777.diff
@@ -1,0 +1,17 @@
+diff --git a/service/pom.xml b/service/pom.xml
+index 6723a70098..fdbecfaf84 100644
+--- a/service/pom.xml
++++ b/service/pom.xml
+@@ -299,6 +299,12 @@
+       <artifactId>apacheds-server-integ</artifactId>
+       <version>${apache-directory-server.version}</version>
+       <scope>test</scope>
++        <exclusions>
++            <exclusion>
++                <groupId>org.apache.directory.client.ldap</groupId>
++                <artifactId>ldap-client-api</artifactId>
++            </exclusion>
++        </exclusions>
+     </dependency>
+ 
+     <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3575