### PR TITLE
BIGTOP-3576. Deploying Ambari to Fedora 33 fails on ppc64le.

### DIFF
--- a/bigtop-packages/src/common/ambari/patch6-support-fedora-ppc.diff
+++ b/bigtop-packages/src/common/ambari/patch6-support-fedora-ppc.diff
@@ -1,0 +1,12 @@
+diff --git a/ambari-common/src/main/python/ambari_commons/resources/os_family.json b/ambari-common/src/main/python/ambari_commons/resources/os_family.json
+index 0634988657..f6b9b91c4f 100644
+--- a/ambari-common/src/main/python/ambari_commons/resources/os_family.json
++++ b/ambari-common/src/main/python/ambari_commons/resources/os_family.json
+@@ -25,6 +25,7 @@
+         "extends" : "redhat",
+         "distro": [
+           "redhat-ppc",
++          "fedora-ppc",
+           "centos-ppc"
+         ],
+         "versions": [


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3576