### PR TITLE
BIGTOP-3582. Logstash RPM Build Fails.

### DIFF
--- a/bigtop-packages/src/common/logstash/patch2-pin-logstash-output-elasticsearch.diff
+++ b/bigtop-packages/src/common/logstash/patch2-pin-logstash-output-elasticsearch.diff
@@ -1,0 +1,13 @@
+diff --git a/Gemfile b/Gemfile
+index c206ff423..104624a83 100644
+--- a/Gemfile
++++ b/Gemfile
+@@ -96,7 +96,7 @@ gem "logstash-input-kafka", "~> 5"
+ gem "logstash-input-beats"
+ gem "logstash-output-cloudwatch"
+ gem "logstash-output-csv"
+-gem "logstash-output-elasticsearch"
++gem "logstash-output-elasticsearch", "11.0.2"
+ gem "logstash-output-file"
+ gem "logstash-output-graphite"
+ gem "logstash-output-http"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3582

I found that logstash package successfully built on my local (Ubuntu) environment contains logstash-output-elasticsearch-11.0.2-java. Pinning the version to 11.0.2 could be quick fix.

```
$ dpkg -c output/logstash/logstash_5.4.1-1_all.deb | grep logstash-output-elasticsearch | head -n 1
drwxr-xr-x root/root         0 2021-06-27 01:28 ./usr/lib/logstash/vendor/bundle/jruby/2.3.0/gems/logstash-output-elasticsearch-11.0.2-java/
```
