### PR TITLE
BIGTOP-3584. Fix build failure of Ambari due to missing dependency on javax.el.

### DIFF
--- a/bigtop-packages/src/common/ambari/patch7-exclude-glassfish-javax.diff
+++ b/bigtop-packages/src/common/ambari/patch7-exclude-glassfish-javax.diff
@@ -1,0 +1,52 @@
+diff --git a/ambari-metrics/ambari-metrics-timelineservice/pom.xml b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+index 95f9cac..f8e3449 100644
+--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
++++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+@@ -368,6 +368,14 @@
+           <artifactId>javax.ws.rs-api</artifactId>
+           <groupId>javax.ws.rs</groupId>
+         </exclusion>
++        <exclusion>
++          <groupId>org.glassfish</groupId>
++          <artifactId>javax.el</artifactId>
++        </exclusion>
++        <exclusion>
++          <groupId>org.glassfish.web</groupId>
++          <artifactId>javax.servlet.jsp</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+ 
+@@ -760,6 +768,10 @@
+           <artifactId>javax.ws.rs-api</artifactId>
+           <groupId>javax.ws.rs</groupId>
+         </exclusion>
++        <exclusion>
++          <groupId>org.glassfish</groupId>
++          <artifactId>javax.el</artifactId>
++        </exclusion>
+       </exclusions>
+       <version>${phoenix.version}</version>
+       <scope>test</scope>
+@@ -782,6 +794,10 @@
+           <groupId>com.fasterxml.jackson.core</groupId>
+           <artifactId>jackson-databind</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>org.glassfish</groupId>
++          <artifactId>javax.el</artifactId>
++        </exclusion>
+       </exclusions>
+       <classifier>tests</classifier>
+     </dependency>
+@@ -804,6 +820,10 @@
+           <groupId>com.fasterxml.jackson.core</groupId>
+           <artifactId>jackson-databind</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>org.glassfish</groupId>
++          <artifactId>javax.el</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+     <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3584

```
[ERROR] Failed to execute goal on project ambari-metrics-timelineservice: Could not resolve dependencies for project org.apache.ambari:ambari-metrics-timelineservice:jar:2.7.5.0.0: Failed to collect dependencies at org.apache.phoenix:phoenix-core:jar:5.0.0-HBase-2.0 -> org.apache.hbase:hbase-mapreduce:jar:2.0.0 -> org.apache.hbase:hbase-server:jar:2.0.0 -> org.glassfish.web:javax.servlet.jsp:jar:2.3.2 -> org.glassfish:javax.el:jar:3.0.1-b06-SNAPSHOT: Failed to read artifact descriptor for org.glassfish:javax.el:jar:3.0.1-b06-SNAPSHOT: Could not transfer artifact org.glassfish:javax.el:pom:3.0.1-b06-SNAPSHOT from/to apache-hadoop (https://repo.hortonworks.com/content/groups/public/): Transfer failed for https://repo.hortonworks.com/content/groups/public/org/glassfish/javax.el/3.0.1-b06-SNAPSHOT/javax.el-3.0.1-b06-SNAPSHOT.pom: Connect to repo.hortonworks.com:443 [repo.hortonworks.com/54.225.131.199] failed: Connection timed out (Connection timed out) -> [Help 1]
```

Excluding unresolvable packages of org.glassfish from transitive dependencies could be quick fix here.