### PR TITLE
BIGTOP-3585. Remove obsolete text replacement from do-component-build of Ambari.

### DIFF
--- a/bigtop-packages/src/common/ambari/do-component-build
+++ b/bigtop-packages/src/common/ambari/do-component-build
@@ -19,10 +19,6 @@ set -ex
 
 export _JAVA_OPTIONS="-Xmx2048m -Djava.awt.headless=true"
 
-# these two repos haven updated to accpet https access only
-sed -i "s|http://download.java.net|https://download.java.net|g" pom.xml
-sed -i "s|http://repo.spring.io|https://repo.spring.io|g" pom.xml
-
 mvn clean package -DskipTests -Drat.skip
 
 (cd contrib/management-packs/odpi-ambari-mpack ; mvn clean package -DskipTests -Drat.skip)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3585

We do not need the test replacement after https://github.com/apache/ambari/pull/3000.