### PR TITLE
BIGTOP-3588. Pin redis-rb version for Logstash to 4.4.0

### DIFF
--- a/bigtop-packages/src/common/logstash/patch1-gem-version-compatibility.diff
+++ b/bigtop-packages/src/common/logstash/patch1-gem-version-compatibility.diff
@@ -2,6 +2,14 @@ diff --git a/Gemfile b/Gemfile
 index e6b55ded0..ee2f4ef0a 100644
 --- a/Gemfile
 +++ b/Gemfile
+@@ -25,6 +25,7 @@ gem "term-ansicolor", "~> 1.3.2", :group => :development
+ gem "docker-api", "1.31.0", :group => :development
+ gem "rest-client", "1.8.0", :group => :development
+ gem "pleaserun", "~>0.0.28"
++gem "redis", "<= 4.4.0"
+ gem "logstash-input-heartbeat"
+ gem "logstash-codec-collectd"
+ gem "logstash-output-xmpp"
 @@ -139,3 +139,5 @@ gem "poseidon", ">= 0"
  gem "snappy", ">= 0"
  gem "webmock", "~> 1.21.0"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3588