### PR TITLE
BIGTOP-3589. Fix build failure of Alluxio caused by buildnumber-maven-plugin.

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -23,4 +23,4 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
   sed -i "s|<npmVersion>6.4.1</npmVersion>|<npmVersion>6.14.7</npmVersion>|" webui/pom.xml
 fi
 
-mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Phadoop-3 -Pyarn "$@"
+mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3589

`./gradlew alluxio-pkg` fails on non-Git source tree since buildnumber-maven-plugin invokes git command to get scm revision number. 

```
[INFO] --- buildnumber-maven-plugin:1.4:create-metadata (default) @ alluxio-core-common ---
[INFO] Executing: /bin/sh -c cd '/home/centos/srcs/bigtop-3.0.0/build/alluxio/rpm/BUILD/alluxio-2.4.1/core/common' && 'git' 'rev-parse' '--verify' 'HEAD'
[INFO] Working directory: /home/centos/srcs/bigtop-3.0.0/build/alluxio/rpm/BUILD/alluxio-2.4.1/core/common
...
[INFO] Alluxio Core - Common Utilities 2.4.1 .............. FAILURE [01:00 min]
...
[ERROR] Failed to execute goal org.codehaus.mojo:buildnumber-maven-plugin:1.4:create-metadata (default) on project alluxio-core-common: Execution default of goal org.codehaus.mojo:buildnumber-maven-plugin:1.4:create-metadata failed.: NullPointerException -> [Help 1]
```

The issue can not be reproduced by running `./gradlew alluxio-pkg` on the Bigtop source tree checked out from Git repository since the `git` works on that environment. I found this issue by checking source tarball of [3.0.0-RC0](https://dist.apache.org/repos/dist/dev/bigtop/bigtop-3.0.0-RC0/).

[Setting fallback revision number](https://www.mojohaus.org/buildnumber-maven-plugin/create-mojo.html#revisionOnScmFailure) would be the fix.
