### PR TITLE
BIGTOP-3590. Hbase smoke tests failed on Ubuntu 20.04.

### DIFF
--- a/bigtop-tests/test-artifacts/hbase/src/main/groovy/org/apache/bigtop/itest/hbase/smoke/TestHBaseImportExport.groovy
+++ b/bigtop-tests/test-artifacts/hbase/src/main/groovy/org/apache/bigtop/itest/hbase/smoke/TestHBaseImportExport.groovy
@@ -95,6 +95,7 @@ class TestHBaseImportExport {
     admin.deleteTable(orig)
     admin.disableTable(export)
     admin.deleteTable(export)
+    sh.exec("hadoop fs -rm -r -skipTrash 'orig_*'");
   }
 
   @Test

--- a/bigtop-tests/test-artifacts/hbase/src/main/groovy/org/apache/bigtop/itest/hbase/smoke/TestImportTsv.groovy
+++ b/bigtop-tests/test-artifacts/hbase/src/main/groovy/org/apache/bigtop/itest/hbase/smoke/TestImportTsv.groovy
@@ -92,8 +92,7 @@ public class TestImportTsv {
     // delete data and junk from HDFS
     sh.exec("hadoop fs -rm -r -skipTrash $DATADIR1",
       "hadoop fs -rm -r -skipTrash $DATADIR2",
-      "hadoop fs -rm -r -skipTrash /user/$USER/hbase*",
-      "hadoop fs -rm -r -skipTrash /user/$USER/orig_*");
+      "hadoop fs -rm -r -skipTrash '/user/$USER/hbase*'");
     assertTrue("teardown failed", sh.getRet() == 0);
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3590

The cause is non-deterministic order of test execution. The directory named as `/user/$USER/orig_*` is created by TestHBaseImportExport. If TestImportTsv is executed before the TestHBaseImportExport, TestImporptTsv#cleanUp raises exception since there is no such directory. Cleaning up of the `/user/$USER/orig_*` should be done in TestHBaseImportExport.