### PR TITLE
BIGTOP-3592: Remove Ambari stack-select tool dependency from stack hooks

### DIFF
--- a/bigtop-packages/src/common/ambari/patch8-stack-hooks.diff
+++ b/bigtop-packages/src/common/ambari/patch8-stack-hooks.diff
@@ -1,0 +1,23 @@
+diff --git a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
+index ca3cdc64b1..ef6cc10655 100644
+--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
++++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
+@@ -49,11 +49,6 @@ def setup_stack_symlinks(struct_out_file):
+     Logger.warning("Skipping running stack-selector-tool because this is a sys_prepped host. This may cause symlink pointers not to be created for HDP components installed later on top of an already sys_prepped host")
+     return
+ 
+-  # get the packages which the stack-select tool should be used on
+-  stack_packages = stack_select.get_packages(stack_select.PACKAGE_SCOPE_INSTALL)
+-  if stack_packages is None:
+-    return
+-
+   json_version = load_version(struct_out_file)
+ 
+   if not json_version:
+@@ -145,4 +140,4 @@ def link_configs(struct_out_file):
+     with open(params.conf_select_marker_file, "wb") as fp:
+       pass
+   else:
+-    Logger.info(format("Skipping conf-select stage, since cluster-env/sysprep_skip_conf_select is set and mark file {conf_select_marker_file} exists"))
+\ No newline at end of file
++    Logger.info(format("Skipping conf-select stage, since cluster-env/sysprep_skip_conf_select is set and mark file {conf_select_marker_file} exists"))


### PR DESCRIPTION
The patch is related to PR #824.
It removed Ambari stack-select tool dependency from stack hooks when deploying mpack services.