### PR TITLE
BIGTOP-3597. Fix build failure of Hadoop 3.2 against ZooKeeper 3.5.

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch11-YARN-9783.diff
+++ b/bigtop-packages/src/common/hadoop/patch11-YARN-9783.diff
@@ -1,0 +1,58 @@
+qdiff --git a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
+index 9d5848ea034..27d32ea9d26 100644
+--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
++++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
+@@ -24,16 +24,12 @@
+ import org.apache.hadoop.registry.client.impl.zk.CuratorService;
+ import org.apache.hadoop.registry.client.impl.zk.RegistrySecurity;
+ import org.apache.zookeeper.CreateMode;
+-import org.apache.zookeeper.Login;
+-import org.apache.zookeeper.server.ZooKeeperSaslServer;
+-import org.apache.zookeeper.server.auth.SaslServerCallbackHandler;
+ import org.junit.After;
+ import org.junit.Before;
+ import org.junit.Test;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
+-import javax.security.auth.login.AppConfigurationEntry;
+ import javax.security.auth.login.LoginContext;
+ 
+ import static org.apache.hadoop.registry.client.api.RegistryConstants.*;
+@@ -58,36 +54,6 @@ public void afterTestSecureZKService() throws Throwable {
+     RegistrySecurity.clearZKSaslClientProperties();
+   }
+ 
+-  /**
+-  * this is a cut and paste of some of the ZK internal code that was
+-   * failing on windows and swallowing its exceptions
+-   */
+-  @Test
+-  public void testLowlevelZKSaslLogin() throws Throwable {
+-    RegistrySecurity.bindZKToServerJAASContext(ZOOKEEPER_SERVER_CONTEXT);
+-    String serverSection =
+-        System.getProperty(ZooKeeperSaslServer.LOGIN_CONTEXT_NAME_KEY,
+-            ZooKeeperSaslServer.DEFAULT_LOGIN_CONTEXT_NAME);
+-    assertEquals(ZOOKEEPER_SERVER_CONTEXT, serverSection);
+-
+-    AppConfigurationEntry entries[];
+-    entries = javax.security.auth.login.Configuration.getConfiguration()
+-                                                     .getAppConfigurationEntry(
+-                                                         serverSection);
+-
+-    assertNotNull("null entries", entries);
+-
+-    SaslServerCallbackHandler saslServerCallbackHandler =
+-        new SaslServerCallbackHandler(
+-            javax.security.auth.login.Configuration.getConfiguration());
+-    Login login = new Login(serverSection, saslServerCallbackHandler);
+-    try {
+-      login.startThreadIfNeeded();
+-    } finally {
+-      login.shutdown();
+-    }
+-  }
+-
+   @Test
+   public void testCreateSecureZK() throws Throwable {
+     startSecureZK();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3597

Backporting [YARN-9783](https://issues.apache.org/jira/browse/YARN-9783) fixes the issue.

While this is a follow-up of https://github.com/apache/bigtop/pull/827, merging this first should be harmless.