### PR TITLE
BIGTOP-3600 - Add Debian 11 support to the Docker provisioner

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -38,7 +38,7 @@ case ${ID}-${VERSION_ID} in
         apt-get update
         apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv
         ;;
-    debian-10*)
+    debian-10*|debian-11*)
         apt-get update
         apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv gnupg procps
         ;;

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -151,7 +151,7 @@ class bigtop_toolchain::packages {
       "libffi-devel"
     ] }
     /(Ubuntu|Debian)/: {
-      $pkgs = [
+      $_pkgs = [
         "unzip",
         "curl",
         "wget",
@@ -181,7 +181,6 @@ class bigtop_toolchain::packages {
         "dh-python",
         "libfuse2",
         "libjansi-java",
-        "python2.7-dev",
         "libxml2-dev",
         "libxslt1-dev",
         "zlib1g-dev",
@@ -206,10 +205,14 @@ class bigtop_toolchain::packages {
         "libcurl4-gnutls-dev",
         "bison",
         "flex",
-        "python-dev",
         "python-setuptools",
         "libffi-dev"
       ]
+      if ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') < 0) {
+        $pkgs = concat($_pkgs, ["python-dev", "python2.7-dev"])
+      } else {
+        $pkgs = concat($_pkgs, ["python3-dev"])
+      }
       file { '/etc/apt/apt.conf.d/01retries':
         content => 'Aquire::Retries "5";'
       } -> Package <| |>


### PR DESCRIPTION
Built locally:
```
bigtop/slaves   trunk-debian-11     16fa6cdec6a7   7 minutes ago       3.89GB
bigtop/puppet  trunk-debian-11     f2fb226b4e3c   2 hours ago         330MB
```