### PR TITLE
BIGTOP-3599. Bump Phoenix to 5.1.2.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -245,7 +245,7 @@ bigtop {
     'phoenix' {
       name    = 'phoenix'
       relNotes = 'Apache Phoenix: A SQL skin over HBase'
-      version { base = "5.1.0"; pkg = base; release = 1 }
+      version { base = "5.1.2"; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3599

Phoenix 5.1.0 has compilation error against HBase 2.4.8. Upgrading to Phoenix 5.1.2 should fix this.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project phoenix-core: Compilation failure: Compilation failure:
[ERROR] /home/fedora/srcs/bigtop/build/phoenix/rpm/BUILD/phoenix-5.1.0/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/MultiHfileOutputFormat.java:[262,69] cannot find symbol
[ERROR]   symbol:   method getBytesPerChecksum(org.apache.hadoop.conf.Configuration)
[ERROR]   location: class org.apache.hadoop.hbase.regionserver.HStore
[ERROR] /home/fedora/srcs/bigtop/build/phoenix/rpm/BUILD/phoenix-5.1.0/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/MultiHfileOutputFormat.java:[261,65] cannot find symbol
[ERROR]   symbol:   method getChecksumType(org.apache.hadoop.conf.Configuration)
[ERROR]   location: class org.apache.hadoop.hbase.regionserver.HStore
```

Since Phoenix 5.1.2 can be built against HBase 2.2.6 too, we can merge this even before https://github.com/apache/bigtop/pull/830.