### PR TITLE
BIGTOP-3601. Bump Kafka to 2.8.1.

### DIFF
--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
@@ -136,3 +136,5 @@ zookeeper.connect=<%= @zookeeper_connection_string %>
 
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms=1000000
+
+delete.topic.enable=true

--- a/bigtop-packages/src/common/kafka/do-component-build
+++ b/bigtop-packages/src/common/kafka/do-component-build
@@ -27,8 +27,6 @@ BUILD_OPTS="-Divy.home=${HOME}/.ivy2 -Dsbt.ivy.home=${HOME}/.ivy2 -Duser.home=${
 #        http://maven.40175.n5.nabble.com/Not-finding-artifact-in-local-repo-td3727753.html
 export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
 
-gradle wrapper
-
 # Rewrite the zookeeper version defined in gradle/dependencies.gradle directly
 # with $ZOOKEEPER_VERSION, because we can't override it via command line option.
 sed -i -e 's/zookeeper: *"\([0-9]\{1,\}\.\)*[0-9]\{1,\}"/zookeeper: "'${ZOOKEEPER_VERSION}'"/' gradle/dependencies.gradle

--- a/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
+++ b/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
@@ -32,20 +32,7 @@ class TestKafkaSmoke {
   static Shell sh = new Shell("/bin/bash -s");
 
   static final String KAFKA_HOME = "/usr/lib/kafka"
-  static final String KAFKA_CONFIG = KAFKA_HOME + "/config/server.properties "
   static final String KAFKA_TOPICS = KAFKA_HOME + "/bin/kafka-topics.sh "
-  static final String KAFKA_SERVER_START = KAFKA_HOME + "/bin/kafka-server-start.sh "
-  static final String KAFKA_SERVER_STOP = KAFKA_HOME + "/bin/kafka-server-stop.sh "
-
-  @BeforeClass
-  static void kafkaSetUp() {
-    /* Restart kafka server for Enabling 'delete.topic.enable' */
-    sh.exec(KAFKA_SERVER_STOP);
-    sh.exec(KAFKA_SERVER_START + KAFKA_CONFIG
-      + " --override delete.topic.enable=true &"
-    );
-    assertTrue("Restart Kafka server failed. ", sh.getRet() == 0);
-  }
 
   @AfterClass
   public static void deleteKafkaTopics() {

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -291,7 +291,7 @@ bigtop {
     'kafka' {
       name    = 'kafka'
       relNotes = 'Apache Kafka'
-      version { base = '2.4.1'; pkg = base; release = 1 }
+      version { base = '2.8.1'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3601

We can upgrade to recent Kafka requiring ZooKeeper 3.5 now.