### PR TITLE
BIGTOP-3600 - Allow HTTP 201 values for configure-nexus steps

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -151,7 +151,7 @@ class bigtop_toolchain::packages {
       "libffi-devel"
     ] }
     /(Ubuntu|Debian)/: {
-      $_pkgs = [
+      $pkgs = [
         "unzip",
         "curl",
         "wget",
@@ -206,13 +206,10 @@ class bigtop_toolchain::packages {
         "bison",
         "flex",
         "python-setuptools",
-        "libffi-dev"
+        "libffi-dev",
+        "python3-dev",
+        "python2.7-dev"
       ]
-      if ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') < 0) {
-        $pkgs = concat($_pkgs, ["python-dev", "python2.7-dev"])
-      } else {
-        $pkgs = concat($_pkgs, ["python3-dev"])
-      }
       file { '/etc/apt/apt.conf.d/01retries':
         content => 'Aquire::Retries "5";'
       } -> Package <| |>


### PR DESCRIPTION
While debugging some CI issues with Bigtop-trunk-packages,
I noticed the following error:

Execution failed for task ':configure-nexus-repository.jboss.org'.
> Failed to configure Nexus proxy repository.jboss.org with http code 201 returned.

In theory HTTP 201 should indicate a positive outcome, and it shouldn't
cause a failure of the build.