### PR TITLE
BIGTOP-3600 - Deploy python*-dev deps on Debian images

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -151,7 +151,7 @@ class bigtop_toolchain::packages {
       "libffi-devel"
     ] }
     /(Ubuntu|Debian)/: {
-      $_pkgs = [
+      $pkgs = [
         "unzip",
         "curl",
         "wget",
@@ -206,13 +206,10 @@ class bigtop_toolchain::packages {
         "bison",
         "flex",
         "python-setuptools",
-        "libffi-dev"
+        "libffi-dev",
+        "python3-dev",
+        "python2.7-dev"
       ]
-      if ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') < 0) {
-        $pkgs = concat($_pkgs, ["python-dev", "python2.7-dev"])
-      } else {
-        $pkgs = concat($_pkgs, ["python3-dev"])
-      }
       file { '/etc/apt/apt.conf.d/01retries':
         content => 'Aquire::Retries "5";'
       } -> Package <| |>


### PR DESCRIPTION
In https://github.com/apache/bigtop/pull/829 I caused some
failures in gpdb package builds, since python2.7-dev
dependencies are needed.

On Debian 9/10/11 python3-dev and python2.7-dev are available,
so better to be explicit and install both at the same time.