### PR TITLE
BIGTOP-3309 - Update ca-certificates for CentOS 7

### DIFF
--- a/bigtop_toolchain/manifests/ant.pp
+++ b/bigtop_toolchain/manifests/ant.pp
@@ -16,26 +16,31 @@
 class bigtop_toolchain::ant {
 
   require bigtop_toolchain::gnupg
+  require bigtop_toolchain::packages
 
   # Ant version restricted to 1.9 because 1.10 supports Java>=8 only.
   $ant =  latest_ant_binary("1.9.[0-9]*")
   $apache_prefix = nearest_apache_mirror()
 
-  exec {"/usr/bin/wget $apache_prefix/ant/binaries/$ant-bin.tar.gz":
+  exec { 'Download Ant binaries':
+    command => "/usr/bin/wget $apache_prefix/ant/binaries/$ant-bin.tar.gz",
     cwd     => "/usr/src",
     unless  => "/usr/bin/test -f /usr/src/$ant-bin.tar.gz",
   } ~>
 
-  exec {"/usr/bin/wget https://www.apache.org/dist/ant/binaries/$ant-bin.tar.gz.asc":
+  exec { 'Download Ant binaries signature':
+    command => "/usr/bin/wget https://www.apache.org/dist/ant/binaries/$ant-bin.tar.gz.asc",
     cwd     => "/usr/src",
     unless  => "/usr/bin/test -f /usr/src/$ant-bin.tar.gz.asc",
   } ~>
 
-  exec {"/usr/bin/$bigtop_toolchain::gnupg::cmd -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com:80 $ant-bin.tar.gz.asc":
+  exec { 'Verify Ant binaries':
+    command => "/usr/bin/$bigtop_toolchain::gnupg::cmd -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com:80 $ant-bin.tar.gz.asc",
     cwd     => "/usr/src",
   } ->
 
-  exec {"/bin/tar xvzf /usr/src/$ant-bin.tar.gz":
+  exec { 'Extract Ant binaries':
+    command => "/bin/tar xvzf /usr/src/$ant-bin.tar.gz",
     cwd     => '/usr/local',
     creates => "/usr/local/$ant",
   } ->

--- a/bigtop_toolchain/manifests/groovy.pp
+++ b/bigtop_toolchain/manifests/groovy.pp
@@ -15,16 +15,20 @@
 
 class bigtop_toolchain::groovy {
 
+  require bigtop_toolchain::packages
+
   $groovy_version = '2.5.4'
   $groovy = "apache-groovy-binary-${groovy_version}"
 
-  exec {"/usr/bin/wget https://dl.bintray.com/groovy/maven/${groovy}.zip":
+  exec { 'Download Groovy':
+    command => "/usr/bin/wget https://dl.bintray.com/groovy/maven/${groovy}.zip",
     cwd     => "/usr/src",
     unless  => "/usr/bin/test -f /usr/src/${groovy}.zip",
   } ~>
 
-  exec {"/usr/bin/unzip -x -o /usr/src/${groovy}.zip":
-    cwd         => '/usr/local',
+  exec {'Extract Groovy':
+    command => /usr/bin/unzip -x -o /usr/src/${groovy}.zip":
+    cwd     => '/usr/local',
   } ->
 
   file {'/usr/local/groovy':

--- a/bigtop_toolchain/manifests/maven.pp
+++ b/bigtop_toolchain/manifests/maven.pp
@@ -16,31 +16,36 @@
 class bigtop_toolchain::maven {
 
   require bigtop_toolchain::gnupg
+  require bigtop_toolchain::packages
 
   $mvnversion = latest_maven_binary("3.6.[0-9]*")
   $mvn = "apache-maven-$mvnversion"
 
   $apache_prefix = nearest_apache_mirror()
 
-  exec {"/usr/bin/wget $apache_prefix/maven/maven-3/$mvnversion/binaries/$mvn-bin.tar.gz":
+  exec { 'Download Maven binaries':
+    command => "/usr/bin/wget $apache_prefix/maven/maven-3/$mvnversion/binaries/$mvn-bin.tar.gz",
     cwd     => "/usr/src",
     unless  => "/usr/bin/test -f /usr/src/$mvn-bin.tar.gz",
   } ~>
 
-  exec {"/usr/bin/wget https://www.apache.org/dist/maven/maven-3/$mvnversion/binaries/$mvn-bin.tar.gz.asc":
+  exec { 'Download Maven binaries signature':
+    command => "/usr/bin/wget https://www.apache.org/dist/maven/maven-3/$mvnversion/binaries/$mvn-bin.tar.gz.asc",
     cwd     => "/usr/src",
     unless  => "/usr/bin/test -f /usr/src/$mvn-bin.tar.gz.asc",
   } ~>
 
-  exec {"/usr/bin/$bigtop_toolchain::gnupg::cmd --no-tty -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com:80 $mvn-bin.tar.gz.asc":
+  exec { 'Verify Maven binaries signature':
+    command => "/usr/bin/$bigtop_toolchain::gnupg::cmd --no-tty -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com:80 $mvn-bin.tar.gz.asc",
     cwd     => "/usr/src",
   } ->
 
-  exec {"/bin/tar xvzf /usr/src/$mvn-bin.tar.gz":
+  exec { 'Extract Maven binaries':
+    command => "/bin/tar xvzf /usr/src/$mvn-bin.tar.gz",
     cwd     => '/usr/local',
     creates => "/usr/local/$mvn",
   } ->
-  
+
   file {'/usr/local/maven':
     ensure  => link,
     target  => "/usr/local/$mvn",

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -65,6 +65,7 @@ class bigtop_toolchain::packages {
         "net-tools",
         "perl-Digest-SHA"
       ]
+
       if ($operatingsystem == 'Fedora' or $operatingsystemmajrelease !~ /^[0-7]$/) {
         $pkgs = concat($_pkgs, ["python2-devel", "libtirpc-devel", "cmake"])
       } else {
@@ -234,6 +235,13 @@ class bigtop_toolchain::packages {
   if $operatingsystem == 'CentOS' {
     package { 'epel-release':
       ensure => installed
+    }
+
+    if $operatingsystemmajrelease == 7 {
+      # https://access.redhat.com/errata/RHBA-2021:3649
+      package { 'ca-certificates':
+        ensure => latest
+      }
     }
     if $operatingsystemmajrelease !~ /^[0-7]$/ {
       # On CentOS 8, EPEL requires that the PowerTools repository is enabled.


### PR DESCRIPTION
Due to https://access.redhat.com/articles/6338021 ant and  maven classes
fail to download due to TLS certificate expiration check issues.
Since the issue is related to CentOS 7 and earlier, it seems sensible
to force the upgrade of the ca-certificates package (that in its latest
versions contain a fix).

While at it:
1) Add a specific dependency to 'ca-certificates' for CentOS 7.
2) Require bigtop_toolchain::packages in the varios ant/maven/groovy
   classes, so that we'll be able to rely on packages being
   installed when running the Execs. It may not be strictly required
   now but it seems good for future code.
3) Refactor a bit the Execs to be more readable when puppet runs
   (easier to track what's happening).

Tested rebuilding the puppet image and the slave image.