### PR TITLE
BIGTOP-3610 - Use a stricter match for the zookeeper jar in hadoop packaging

### DIFF
--- a/bigtop-packages/src/deb/hadoop/rules
+++ b/bigtop-packages/src/deb/hadoop/rules
@@ -66,7 +66,7 @@ override_dh_auto_install:
 	  --native-build-string=${native_dir} \
 	  --installed-lib-dir=/usr/lib/hadoop
 	# Forcing Zookeeper dependency to be on the packaged jar
-	ln -sf /usr/lib/zookeeper/zookeeper.jar debian/tmp/usr/lib/hadoop/lib/zookeeper*.jar
+	ln -sf /usr/lib/zookeeper/zookeeper.jar debian/tmp/usr/lib/hadoop/lib/zookeeper-[[:digit:]]*.jar
 	# Workaround for BIGTOP-583
 	rm -f debian/tmp/usr/lib/hadoop-*/lib/slf4j-log4j12-*.jar
 	# FIXME: BIGTOP-463

--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -559,7 +559,7 @@ env HADOOP_VERSION=%{hadoop_base_version} bash %{SOURCE2} \
   --man-dir=$RPM_BUILD_ROOT%{man_hadoop} \
 
 # Forcing Zookeeper dependency to be on the packaged jar
-%__ln_s -f /usr/lib/zookeeper/zookeeper.jar $RPM_BUILD_ROOT/%{lib_hadoop}/lib/zookeeper*.jar
+%__ln_s -f /usr/lib/zookeeper/zookeeper.jar $RPM_BUILD_ROOT/%{lib_hadoop}/lib/zookeeper-[[:digit:]]*.jar
 # Workaround for BIGTOP-583
 %__rm -f $RPM_BUILD_ROOT/%{lib_hadoop}-*/lib/slf4j-log4j12-*.jar
 


### PR DESCRIPTION
The new Zookeeper 3.5.x dependency seems to have brought a new
zookeeper jar under the lib directory, namely zookeeper-jute-3.5.9.jar.
In our rpm/deb packaging code we create a symlink to
the zookeeper-x.x.x.jar assuming (afaics) that no other zookeeper-*
library is around, and this currently breaks our builds.

This change adds a stricter match for the jar to link, and it works
with debian-10/centos-8 x86 builds (from my tests).