### PR TITLE
BIGTOP-3616. Bump Flink to 1.11.6.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -233,7 +233,7 @@ bigtop {
     'flink' {
       name    = 'flink'
       relNotes = 'Apache Flink'
-      version { base = '1.11.3'; pkg = base; release = 1 }
+      version { base = '1.11.6'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3616

Bump Flink to 1.11.6 addressing CVE-2021-44228.