### PR TITLE
BIGTOP-3618. Bump Solr to 8.11.1.

### DIFF
--- a/bigtop-packages/src/common/solr/do-component-build
+++ b/bigtop-packages/src/common/solr/do-component-build
@@ -44,7 +44,6 @@ mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.solr -Dartif
 mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.solr -DartifactId=solr-solrj -Dversion=$SOLR_VERSION -Dpackaging=jar -Dfile=solr/dist/solr-solrj-$SOLR_VERSION.jar
 mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.solr -DartifactId=solr-test-framework -Dversion=$SOLR_VERSION -Dpackaging=jar -Dfile=solr/dist/solr-test-framework-$SOLR_VERSION.jar
 mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.solr -DartifactId=solr-cell -Dversion=$SOLR_VERSION -Dpackaging=jar -Dfile=solr/dist/solr-cell-$SOLR_VERSION.jar
-mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.solr -DartifactId=solr-clustering -Dversion=$SOLR_VERSION -Dpackaging=jar -Dfile=solr/dist/solr-clustering-$SOLR_VERSION.jar
 mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.solr -DartifactId=solr-core -Dversion=$SOLR_VERSION -Dpackaging=jar -Dfile=solr/dist/solr-core-$SOLR_VERSION.jar
 mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.solr -DartifactId=solr-velocity -Dversion=$SOLR_VERSION -Dpackaging=jar -Dfile=solr/dist/solr-velocity-$SOLR_VERSION.jar
 mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.solr -DartifactId=solr-langid -Dversion=$SOLR_VERSION -Dpackaging=jar -Dfile=solr/dist/solr-langid-$SOLR_VERSION.jar

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -206,7 +206,7 @@ bigtop {
     'solr' {
       name    = 'solr'
       relNotes = 'Apache Solr'
-      version { base = '8.7.0'; pkg = base; release = 1 }
+      version { base = '8.11.1'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tgz"
                 source      = destination }
       url     { download_path = "lucene/$name/${version.base}"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3618

* Bump Solr 8.11.1 addressing CVE-2021-44228 was released.
* [SOLR-14981](https://issues.apache.org/jira/browse/SOLR-14981) removed contrib/clustering. We need to fix do-component-build for this.
