### PR TITLE
BIGTOP-3621: Bump Oozie's log4j dependencies to 2.17.0

### DIFF
--- a/bigtop-packages/src/deb/oozie/rules
+++ b/bigtop-packages/src/deb/oozie/rules
@@ -36,7 +36,7 @@ override_dh_auto_build:
 	tar cf - --exclude=debian/\* . | (cd debian/tmp && tar xf -)
 
 override_dh_auto_install:
-	sh -x debian/install_oozie.sh --extra-dir=debian/ --build-dir=$(PWD) --server-dir=./debian/oozie --client-dir=./debian/oozie-client --docs-dir=./debian/oozie-client/usr/share/doc/oozie --initd-dir=./debian/oozie/etc/init.d --conf-dir=./debian/oozie/etc/oozie/conf.dist
+	sh -x debian/install_oozie.sh --extra-dir=debian/ --build-dir=$(CURDIR) --server-dir=./debian/oozie --client-dir=./debian/oozie-client --docs-dir=./debian/oozie-client/usr/share/doc/oozie --initd-dir=./debian/oozie/etc/init.d --conf-dir=./debian/oozie/etc/oozie/conf.dist
 	ln -s -f /var/lib/oozie/ext-2.2 debian/oozie/usr/lib/oozie/webapps/oozie/ext-2.2
 	rm -rf                        debian/oozie/usr/lib/oozie/webapps/oozie/docs
 	ln -s -f /usr/share/doc/oozie debian/oozie/usr/lib/oozie/webapps/oozie/docs

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -220,7 +220,7 @@ bigtop {
     'oozie' {
       name    = 'oozie'
       relNotes = 'Apache Oozie'
-      version { base = '4.3.0'; pkg = base; release = 1 }
+      version { base = '4.3.0'; pkg = base; release = 2 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
This pull request bumps the bigtop.bom's release number for
the Oozie package. In order to pull the right log4j dependencies,
the package needs to be built after the Hive one, reusing
the maven cache (like `./gradlew hive-pkg oozie-pkg`).

Also include a fix for the Oozie's Debian rules file, to fix BIGTOP-3622.