### PR TITLE
BIGTOP-3626: Upgrade ycsb and its log4j dependencies

### DIFF
--- a/bigtop-packages/src/common/ycsb/patch1-log4j.diff
+++ b/bigtop-packages/src/common/ycsb/patch1-log4j.diff
@@ -1,0 +1,65 @@
+diff --git a/elasticsearch5/pom.xml b/elasticsearch5/pom.xml
+index 5d3ff06710..f10476cf05 100644
+--- a/elasticsearch5/pom.xml
++++ b/elasticsearch5/pom.xml
+@@ -165,12 +165,12 @@ LICENSE file.
+     <dependency>
+       <groupId>org.apache.logging.log4j</groupId>
+       <artifactId>log4j-api</artifactId>
+-      <version>2.8.2</version>
++      <version>2.17.0</version>
+     </dependency>
+     <dependency>
+       <groupId>org.apache.logging.log4j</groupId>
+       <artifactId>log4j-core</artifactId>
+-      <version>2.8.2</version>
++      <version>2.17.0</version>
+     </dependency>
+     <dependency>
+       <groupId>junit</groupId>
+diff --git a/ignite/pom.xml b/ignite/pom.xml
+index eabf8d67d9..7b3ed0d496 100644
+--- a/ignite/pom.xml
++++ b/ignite/pom.xml
+@@ -87,13 +87,13 @@ LICENSE file.
+     <dependency>
+       <groupId>org.apache.logging.log4j</groupId>
+       <artifactId>log4j-api</artifactId>
+-      <version>2.11.0</version>
++      <version>2.17.0</version>
+     </dependency>
+
+     <dependency>
+       <groupId>org.apache.logging.log4j</groupId>
+       <artifactId>log4j-core</artifactId>
+-      <version>2.11.0</version>
++      <version>2.17.0</version>
+     </dependency>
+   </dependencies>
+ </project>
+diff --git a/voltdb/pom.xml b/voltdb/pom.xml
+index ab870853ad..6c8cbd2b74 100644
+--- a/voltdb/pom.xml
++++ b/voltdb/pom.xml
+@@ -44,17 +44,17 @@
+ 		<dependency>
+ 			<groupId>org.apache.logging.log4j</groupId>
+ 			<artifactId>log4j-api</artifactId>
+-			<version>2.7</version>
++			<version>2.17.0</version>
+ 		</dependency>
+ 		<dependency>
+ 			<groupId>org.apache.logging.log4j</groupId>
+ 			<artifactId>log4j-core</artifactId>
+-			<version>2.7</version>
++			<version>2.17.0</version>
+ 		</dependency>
+ 		<dependency>
+ 			<groupId>org.apache.logging.log4j</groupId>
+ 			<artifactId>log4j-slf4j-impl</artifactId>
+-			<version>2.7</version>
++			<version>2.17.0</version>
+ 		</dependency>
+ 		<!-- https://mvnrepository.com/artifact/org.voltdb/voltdbclient -->
+ 		<dependency>
+

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -371,7 +371,7 @@ bigtop {
     'ycsb' {
       name    = 'ycsb'
       relNotes = 'Yahoo! Cloud Serving Benchmark'
-      version { base = '0.12.0'; pkg = base; release = 1 }
+      version { base = '0.17.0'; pkg = base; release = 2 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "${version.base}.tar.gz" }
       url     { site = "https://github.com/brianfrankcooper/YCSB/archive"


### PR DESCRIPTION
At the time of writing upstream didn't release any official fix
for the lo4j CVEs, but brianfrankcooper/YCSB#1583 seems taking care of it.
Credits for the upstream fix: Filipe Oliveira <filipecosta.90@gmail.com>

This change also bumps ycsb to its latest upstream, to allow the log4j
patch to be applied cleanly.