### PR TITLE
BIGTOP-3627. Pinning the version of puppetlabs-stdlib

### DIFF
--- a/bigtop_toolchain/manifests/puppet_modules.pp
+++ b/bigtop_toolchain/manifests/puppet_modules.pp
@@ -17,7 +17,7 @@ class bigtop_toolchain::puppet_modules {
 
   exec { 'install-puppet-stdlib':
     path    => '/usr/bin:/bin',
-    command => 'puppet module install puppetlabs-stdlib',
+    command => 'puppet module install puppetlabs-stdlib --version 4.12.0',
     creates => '/etc/puppet/modules/stdlib',
   }
 


### PR DESCRIPTION
When I deploy components according to the Readme doc, I find an error occur
![image](https://user-images.githubusercontent.com/49220700/147937496-6e6ab2d7-d056-46e4-b9aa-0fc0f9ae7033.png)
Then, I find such a issue to discribe it
https://issues.apache.org/jira/browse/BIGTOP-3088
The issue has been fixed, but the doc haven't updated, so I make this commit to fix the gap.