### PR TITLE
BIGTOP-3614: allow to change the docker-compose cfg in the provisioner

### DIFF
--- a/provisioner/docker/README.md
+++ b/provisioner/docker/README.md
@@ -146,3 +146,8 @@ components: "hadoop, hbase, yarn,..."
 ```
 
 By default, Apache Hadoop and YARN will be installed.
+
+## Experimental
+
+With recent OS versions, like Debian 11, the cgroupsv2 settings are enabled by default. Running Docker compose seems to require different settings. For example, mounting /sys/fs/cgroup:ro to the containers breaks systemd and dbus when they are installed and started (in the container). The `docker-hadoop.sh` script offers an option, `-F`, to load a different configuration file for Docker compose (by default, `docker-compose.yml` is picked up). The configuration file to load is `docker-compose-cgroupsv2.yml`. More info in BIGTOP-3614.
+

--- a/provisioner/docker/docker-compose-cgroupv2.yml
+++ b/provisioner/docker/docker-compose-cgroupv2.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bigtop:
+    image: ${DOCKER_IMAGE}
+    command: /sbin/init
+    domainname: bigtop.apache.org
+    privileged: true
+    mem_limit: ${MEM_LIMIT}
+    volumes:
+    - ../../:/bigtop-home
+    - ./config/hiera.yaml:/etc/puppet/hiera.yaml
+    - ./config/hieradata:/etc/puppet/hieradata
+    - ./config/hosts:/etc/hosts


### PR DESCRIPTION
This is a simple change to allow docker-compose to use a different
config file when creating instances. This is useful when testing
new settings and also to keep multiple versions of docker-compose.yml
(if the same version cannot be re-used across multiple OS etc..).

For example, from my recent tests the actual docker-compose.yml
config seems not to work with cgroup v2 and systemd on Debian 10/11.