### PR TITLE
Ambari Mpack fixes for debian/ubuntu

### DIFF
--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/repos/repoinfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/repos/repoinfo.xml
@@ -27,7 +27,8 @@
     <repo>
       <baseurl>http://repos.bigtop.apache.org/releases/1.5.0/ubuntu/18.04/$(ARCH)</baseurl>
       <repoid>BGTP-1.0</repoid>
-      <reponame>BGTP</reponame>
+      <reponame>bigtop</reponame>
+      <components>contrib</components>
     </repo>
   </os>
 </reposinfo>

--- a/bigtop-packages/src/deb/bigtop-ambari-mpack/source/include-binaries
+++ b/bigtop-packages/src/deb/bigtop-ambari-mpack/source/include-binaries
@@ -1,0 +1,1 @@
+debian/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/hooks/before-START/files/fast-hdfs-resource.jar


### PR DESCRIPTION
Hi,

with these commits i got the .deb for bigtop-ambari-mpack to build and i could install the mpack components in ambari