### PR TITLE
BIGTOP-3635: Bump logstash's log4j dependencies to 2.17.0

### DIFF
--- a/bigtop-packages/src/common/logstash/patch3-log4j2-2.17.0.diff
+++ b/bigtop-packages/src/common/logstash/patch3-log4j2-2.17.0.diff
@@ -1,0 +1,148 @@
+diff --git a/Gemfile b/Gemfile
+index 5d96255..6895ce3 100644
+--- a/Gemfile
++++ b/Gemfile
+@@ -73,12 +73,10 @@ gem "logstash-input-ganglia"
+ gem "logstash-input-gelf"
+ gem "logstash-input-generator"
+ gem "logstash-input-graphite"
+-gem "logstash-input-http"
+ gem "logstash-input-http_poller"
+ gem "logstash-input-imap"
+ gem "logstash-input-irc"
+ gem "logstash-input-jdbc"
+-gem "logstash-input-log4j"
+ gem "logstash-input-lumberjack"
+ gem "logstash-input-pipe"
+ gem "logstash-input-rabbitmq"
+@@ -93,8 +91,6 @@ gem "logstash-input-twitter"
+ gem "logstash-input-udp"
+ gem "logstash-input-unix"
+ gem "logstash-input-xmpp"
+-gem "logstash-input-kafka", "~> 5"
+-gem "logstash-input-beats"
+ gem "logstash-output-cloudwatch"
+ gem "logstash-output-csv"
+ gem "logstash-output-elasticsearch", "11.0.2"
+@@ -102,7 +98,6 @@ gem "logstash-output-file"
+ gem "logstash-output-graphite"
+ gem "logstash-output-http"
+ gem "logstash-output-irc"
+-gem "logstash-output-kafka", "~> 5"
+ gem "logstash-output-nagios"
+ gem "logstash-output-null"
+ gem "logstash-output-pagerduty"
+diff --git a/logstash-core/build.gradle b/logstash-core/build.gradle
+index 2968c3a..c8bd292 100644
+--- a/logstash-core/build.gradle
++++ b/logstash-core/build.gradle
+@@ -110,14 +110,14 @@ idea {
+ }
+ 
+ dependencies {
+-    compile 'org.apache.logging.log4j:log4j-api:2.6.2'
+-    compile 'org.apache.logging.log4j:log4j-core:2.6.2'
++    compile 'org.apache.logging.log4j:log4j-api:2.17.0'
++    compile 'org.apache.logging.log4j:log4j-core:2.17.0'
+     compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
+     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
+     compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'
+     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.7.4'
+-    testCompile 'org.apache.logging.log4j:log4j-core:2.6.2:tests'
+-    testCompile 'org.apache.logging.log4j:log4j-api:2.6.2:tests'
++    testCompile 'org.apache.logging.log4j:log4j-core:2.17.0:tests'
++    testCompile 'org.apache.logging.log4j:log4j-api:2.17.0:tests'
+     testCompile 'junit:junit:4.12'
+     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
+     provided 'org.jruby:jruby-core:9.1.9.0'
+diff --git a/logstash-core/gemspec_jars.rb b/logstash-core/gemspec_jars.rb
+index 2459f5d..9f27b11 100644
+--- a/logstash-core/gemspec_jars.rb
++++ b/logstash-core/gemspec_jars.rb
+@@ -2,8 +2,8 @@
+ # runtime dependencies to generate this gemspec dependencies file to be eval'ed by the gemspec
+ # for the jar-dependencies requirements.
+ 
+-gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.6.2"
+-gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.6.2"
++gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.17.0"
++gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.17.0"
+ gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.7.4"
+ gem.requirements << "jar com.fasterxml.jackson.core:jackson-databind, 2.7.4"
+ gem.requirements << "jar com.fasterxml.jackson.module:jackson-module-afterburner, 2.7.4"
+diff --git a/logstash-core/lib/logstash-core_jars.rb b/logstash-core/lib/logstash-core_jars.rb
+index 8ccd269..c9a9818 100644
+--- a/logstash-core/lib/logstash-core_jars.rb
++++ b/logstash-core/lib/logstash-core_jars.rb
+@@ -2,9 +2,9 @@
+ begin
+   require 'jar_dependencies'
+ rescue LoadError
+-  require 'org/apache/logging/log4j/log4j-core/2.6.2/log4j-core-2.6.2.jar'
++  require 'org/apache/logging/log4j/log4j-core/2.17.0/log4j-core-2.17.0.jar'
+   require 'com/fasterxml/jackson/module/jackson-module-afterburner/2.7.4/jackson-module-afterburner-2.7.4.jar'
+-  require 'org/apache/logging/log4j/log4j-api/2.6.2/log4j-api-2.6.2.jar'
++  require 'org/apache/logging/log4j/log4j-api/2.17.0/log4j-api-2.17.0.jar'
+   require 'com/fasterxml/jackson/core/jackson-core/2.7.4/jackson-core-2.7.4.jar'
+   require 'com/fasterxml/jackson/core/jackson-annotations/2.7.0/jackson-annotations-2.7.0.jar'
+   require 'com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.7.4/jackson-dataformat-cbor-2.7.4.jar'
+@@ -12,9 +12,9 @@ rescue LoadError
+ end
+ 
+ if defined? Jars
+-  require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.6.2' )
++  require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.17.0' )
+   require_jar( 'com.fasterxml.jackson.module', 'jackson-module-afterburner', '2.7.4' )
+-  require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.6.2' )
++  require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.17.0' )
+   require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.4' )
+   require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
+   require_jar( 'com.fasterxml.jackson.dataformat', 'jackson-dataformat-cbor', '2.7.4' )
+diff --git a/rakelib/plugins-metadata.json b/rakelib/plugins-metadata.json
+index a2356db..ef976ef 100644
+--- a/rakelib/plugins-metadata.json
++++ b/rakelib/plugins-metadata.json
+@@ -329,7 +329,7 @@
+ 		"skip-list": false
+ 	},
+ 	"logstash-input-http": {
+-		"default-plugins": true,
++		"default-plugins": false,
+ 		"core-specs": false,
+ 		"test-jar-dependencies": false,
+ 		"test-vendor-plugins": false,
+@@ -364,7 +364,7 @@
+ 		"skip-list": true
+ 	},
+ 	"logstash-input-log4j": {
+-		"default-plugins": true,
++		"default-plugins": false,
+ 		"core-specs": false,
+ 		"test-jar-dependencies": false,
+ 		"test-vendor-plugins": false,
+@@ -469,14 +469,14 @@
+ 		"skip-list": false
+ 	},
+ 	"logstash-input-kafka": {
+-		"default-plugins": true,
++		"default-plugins": false,
+ 		"core-specs": false,
+ 		"test-jar-dependencies": true,
+ 		"test-vendor-plugins": false,
+ 		"skip-list": false
+ 	},
+ 	"logstash-input-beats": {
+-		"default-plugins": true,
++		"default-plugins": false,
+ 		"core-specs": false,
+ 		"test-jar-dependencies": false,
+ 		"test-vendor-plugins": false,
+@@ -532,7 +532,7 @@
+ 		"skip-list": false
+ 	},
+ 	"logstash-output-kafka": {
+-		"default-plugins": true,
++		"default-plugins": false,
+ 		"core-specs": false,
+ 		"test-jar-dependencies": false,
+ 		"test-vendor-plugins": false,

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -368,7 +368,7 @@ bigtop {
     'logstash' {
       name    = 'logstash'
       relNotes = 'Data processing pipeline'
-      version { base = '5.4.1'; pkg = base; release = 1 }
+      version { base = '5.4.1'; pkg = base; release = 2 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "v${version.base}.zip" }
       url     { site = "https://github.com/elastic/logstash/archive"


### PR DESCRIPTION
Update log4j2 version to 2.17.0 to keep up the issue https://issues.apache.org/jira/browse/BIGTOP-3613.

This PR omits default plugins
- logstash-input-http
- logstash-input-log4j
- logstash-input-kafka
- logstash-input-beats
- logstash-output-kafka
that includes older versions of log4j.
Those plugins do not seem to be maintained now so I would rather remove them than make efforts to path those plugins.