### PR TITLE
BIGTOP-3637. Add Rocky Linux 8 support.

### DIFF
--- a/bigtop-deploy/puppet/manifests/jdk.pp
+++ b/bigtop-deploy/puppet/manifests/jdk.pp
@@ -41,7 +41,7 @@ class jdk {
         noop => $jdk_preinstalled,
       }
     }
-    /(CentOS|Amazon|Fedora)/: {
+    /(CentOS|Amazon|Fedora|RedHat)/: {
       package { 'jdk':
         name => 'java-1.8.0-openjdk-devel',
         ensure => present,

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -47,7 +47,7 @@ case ${ID}-${VERSION_ID} in
         yum -y install hostname curl sudo unzip wget puppet
         puppet module install puppetlabs-stdlib --version 4.12.0
         ;;
-    centos-8*)
+    centos-8*|rocky-8*)
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         dnf -y check-update
         dnf -y install glibc-langpack-en hostname diffutils curl sudo unzip wget puppet 'dnf-command(config-manager)'

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -68,6 +68,10 @@ case ${OS} in
             UPDATE_SOURCE="yum clean all \&\& yum updateinfo"
         fi
         ;;
+    rockylinux)
+        PUPPET_MODULES="/etc/puppetlabs/code/environments/production/modules/bigtop_toolchain"
+        UPDATE_SOURCE="dnf clean all \&\& dnf updateinfo"
+        ;;
     opensuse)
         PUPPET_MODULES="/etc/puppet/modules/bigtop_toolchain"
         UPDATE_SOURCE="zypper clean \&\& zypper refresh"

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -378,7 +378,7 @@ while [ $# -gt 0 ]; do
         image_name=$2
         # Determine distro to bootstrap provisioning environment
         case "${image_name}" in
-          *-centos-*|*-fedora-*|*-opensuse-*)
+          *-centos-*|*-fedora-*|*-opensuse-*|*-rockylinux-*)
             distro=centos
             ;;
           *-debian-*|*-ubuntu-*)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3637

CentOS 8 reached End Of Life (EOL) on December 31st, 2021.

We need to update bigtop_toolchain first based on rocky facts.
```
$ sudo bigtop_toolchain/bin/puppetize.sh 
Unsupported OS rocky-8.5.
```
```
$ cat /etc/os-release 
NAME="Rocky Linux"
VERSION="8.5 (Green Obsidian)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.5"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Rocky Linux 8.5 (Green Obsidian)"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:rocky:rocky:8.5:GA"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
ROCKY_SUPPORT_PRODUCT="Rocky Linux"
ROCKY_SUPPORT_PRODUCT_VERSION="8"
```
```
$ facter --show-legacy | grep operatingsystem
operatingsystem => RedHat
operatingsystemmajrelease => 8
operatingsystemrelease => 8.5
```