### PR TITLE
BIGTOP-3640: Upgrade hive's log4j2 version to 2.17.1 for Bigtop 3.0.x

### DIFF
--- a/bigtop-packages/src/common/hive/patch9-log4j2-2.17.1.diff
+++ b/bigtop-packages/src/common/hive/patch9-log4j2-2.17.1.diff
@@ -7,7 +7,7 @@ index e97c9187ab..bd9c1457f5 100644
      <libfb303.version>0.9.3</libfb303.version>
      <libthrift.version>0.9.3</libthrift.version>
 -    <log4j2.version>2.15.0</log4j2.version>
-+    <log4j2.version>2.16.0</log4j2.version>
++    <log4j2.version>2.17.1</log4j2.version>
      <opencsv.version>2.3</opencsv.version>
      <orc.version>1.5.6</orc.version>
      <mockito-all.version>1.10.19</mockito-all.version>

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -166,7 +166,7 @@ bigtop {
     'hive' {
       name    = 'hive'
       relNotes = 'Apache Hive'
-      version { base = '3.1.2'; pkg = base; release = 2 }
+      version { base = '3.1.2'; pkg = base; release = 3 }
       tarball { destination = "apache-${name}-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}/"

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -166,7 +166,7 @@ bigtop {
     'hive' {
       name    = 'hive'
       relNotes = 'Apache Hive'
-      version { base = '3.1.2'; pkg = base; release = 3 }
+      version { base = '3.1.2'; pkg = base; release = 2 }
       tarball { destination = "apache-${name}-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}/"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Upgrade hive's log4j2 version to 2.17.1 for Bigtop 3.0.x.
cf. Bigtop 1.5 has already been patched by
https://issues.apache.org/jira/browse/BIGTOP-3619 / https://github.com/apache/bigtop/pull/844 

### How was this patch tested?

```
./gradlew hive-pkg-ind
./gradlew docker-provisioner -Pstack="hive" -Psmoke_tests="hive"
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/