### PR TITLE
BIGTOP-3642. Upgrade log4j to 2.17.1 on all components.

### DIFF
--- a/bigtop-packages/src/common/alluxio/patch1-BIGTOP-3634-log4j.diff
+++ b/bigtop-packages/src/common/alluxio/patch1-BIGTOP-3634-log4j.diff
@@ -7,7 +7,7 @@ index 5392c1b91e1..9dc04086324 100644
      <jetty.version>9.4.31.v20200723</jetty.version>
      <junit.version>4.13</junit.version>
 -    <log4j.version>2.13.3</log4j.version>
-+    <log4j.version>2.17.0</log4j.version>
++    <log4j.version>2.17.1</log4j.version>
      <maven.version>3.3.9</maven.version>
      <metrics.version>4.1.11</metrics.version>
      <orc.version>1.6.3</orc.version>

--- a/bigtop-packages/src/common/elasticsearch/patch0-log4j2-2.17.1.diff
+++ b/bigtop-packages/src/common/elasticsearch/patch0-log4j2-2.17.1.diff
@@ -7,7 +7,7 @@ index fea5aea..9b731d0 100644
  snakeyaml         = 1.15
  # when updating log4j, please update also docs/java-api/index.asciidoc
 -log4j             = 2.11.1
-+log4j             = 2.17.0
++log4j             = 2.17.1
  slf4j             = 1.6.2
  
  # when updating the JNA version, also update the version in buildSrc/build.gradle
@@ -37,11 +37,11 @@ index 575d75d..0000000
 @@ -1 +0,0 @@
 -3aba3398fe064a3eab4331f88161c7480e848418
 \ No newline at end of file
-diff --git a/core/licenses/log4j-1.2-api-2.17.0.jar.sha1 b/core/licenses/log4j-1.2-api-2.17.0.jar.sha1
+diff --git a/core/licenses/log4j-1.2-api-2.17.1.jar.sha1 b/core/licenses/log4j-1.2-api-2.17.1.jar.sha1
 new file mode 100644
 index 0000000..e589ba5
 --- /dev/null
-+++ b/core/licenses/log4j-1.2-api-2.17.0.jar.sha1
++++ b/core/licenses/log4j-1.2-api-2.17.1.jar.sha1
 @@ -0,0 +1 @@
 +aaf998968370edf738322fb750fbda118055508b
 \ No newline at end of file
@@ -53,11 +53,11 @@ index 4b1bfff..0000000
 @@ -1 +0,0 @@
 -268f0fe4df3eefe052b57c87ec48517d64fb2a10
 \ No newline at end of file
-diff --git a/core/licenses/log4j-api-2.17.0.jar.sha1 b/core/licenses/log4j-api-2.17.0.jar.sha1
+diff --git a/core/licenses/log4j-api-2.17.1.jar.sha1 b/core/licenses/log4j-api-2.17.1.jar.sha1
 new file mode 100644
 index 0000000..400d6bd
 --- /dev/null
-+++ b/core/licenses/log4j-api-2.17.0.jar.sha1
++++ b/core/licenses/log4j-api-2.17.1.jar.sha1
 @@ -0,0 +1 @@
 +bbd791e9c8c9421e45337c4fe0a10851c086e36c
 \ No newline at end of file
@@ -69,11 +69,11 @@ index 2fb8589..0000000
 @@ -1 +0,0 @@
 -592a48674c926b01a9a747c7831bcd82a9e6d6e4
 \ No newline at end of file
-diff --git a/core/licenses/log4j-core-2.17.0.jar.sha1 b/core/licenses/log4j-core-2.17.0.jar.sha1
+diff --git a/core/licenses/log4j-core-2.17.1.jar.sha1 b/core/licenses/log4j-core-2.17.1.jar.sha1
 new file mode 100644
 index 0000000..933b970
 --- /dev/null
-+++ b/core/licenses/log4j-core-2.17.0.jar.sha1
++++ b/core/licenses/log4j-core-2.17.1.jar.sha1
 @@ -0,0 +1 @@
 +fe6e7a32c1228884b9691a744f953a55d0dd8ead
 \ No newline at end of file
@@ -97,11 +97,11 @@ index 6178556..0000000
 @@ -1 +0,0 @@
 -4b41b53a3a2d299ce381a69d165381ca19f62912
 \ No newline at end of file
-diff --git a/plugins/repository-hdfs/licenses/log4j-slf4j-impl-2.17.0.jar.sha1 b/plugins/repository-hdfs/licenses/log4j-slf4j-impl-2.17.0.jar.sha1
+diff --git a/plugins/repository-hdfs/licenses/log4j-slf4j-impl-2.17.1.jar.sha1 b/plugins/repository-hdfs/licenses/log4j-slf4j-impl-2.17.1.jar.sha1
 new file mode 100644
 index 0000000..fad46c4
 --- /dev/null
-+++ b/plugins/repository-hdfs/licenses/log4j-slf4j-impl-2.17.0.jar.sha1
++++ b/plugins/repository-hdfs/licenses/log4j-slf4j-impl-2.17.1.jar.sha1
 @@ -0,0 +1 @@
 +1ec25ce0254749c94549ea9c3cea34bd0488c9c6
 \ No newline at end of file

--- a/bigtop-packages/src/common/flink/patch0-FLINK-25472.diff
+++ b/bigtop-packages/src/common/flink/patch0-FLINK-25472.diff
@@ -1,0 +1,58 @@
+diff --git a/docs/dev/project-configuration.md b/docs/dev/project-configuration.md
+index d6443012..15d597c3 100644
+--- a/docs/dev/project-configuration.md
++++ b/docs/dev/project-configuration.md
+@@ -305,7 +305,7 @@ ext {
+     flinkVersion = '{{ site.version }}'
+     scalaBinaryVersion = '{{ site.scala_version }}'
+     slf4jVersion = '1.7.15'
+-    log4jVersion = '2.15.0'
++    log4jVersion = '2.17.1'
+ }
+ 
+ 
+diff --git a/docs/dev/project-configuration.zh.md b/docs/dev/project-configuration.zh.md
+index d6443012..15d597c3 100644
+--- a/docs/dev/project-configuration.zh.md
++++ b/docs/dev/project-configuration.zh.md
+@@ -305,7 +305,7 @@ ext {
+     flinkVersion = '{{ site.version }}'
+     scalaBinaryVersion = '{{ site.scala_version }}'
+     slf4jVersion = '1.7.15'
+-    log4jVersion = '2.15.0'
++    log4jVersion = '2.17.1'
+ }
+ 
+ 
+diff --git a/pom.xml b/pom.xml
+index 333e5e29..cb80a410 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -108,7 +108,7 @@ under the License.
+ 		<akka.version>2.5.21</akka.version>
+ 		<java.version>1.8</java.version>
+ 		<slf4j.version>1.7.15</slf4j.version>
+-		<log4j.version>2.16.0</log4j.version>
++		<log4j.version>2.17.1</log4j.version>
+ 		<!-- Overwrite default values from parent pom.
+ 			 Intellij is (sometimes?) using those values to choose target language level
+ 			 and thus is changing back to java 1.6 on each maven re-import -->
+diff --git a/tools/releasing/NOTICE-binary_PREAMBLE.txt b/tools/releasing/NOTICE-binary_PREAMBLE.txt
+index 257fcc70..6228b0bd 100644
+--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
++++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
+@@ -8,10 +8,10 @@ Copyright 2014-2021 The Apache Software Foundation
+ 
+ This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+ 
+-- org.apache.logging.log4j:log4j-api:2.16.0
+-- org.apache.logging.log4j:log4j-core:2.16.0
+-- org.apache.logging.log4j:log4j-slf4j-impl:2.16.0
+-- org.apache.logging.log4j:log4j-1.2-api:2.16.0
++- org.apache.logging.log4j:log4j-api:2.17.1
++- org.apache.logging.log4j:log4j-core:2.17.1
++- org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
++- org.apache.logging.log4j:log4j-1.2-api:2.17.1
+ 
+ This project bundles the following dependencies under the BSD license.
+ See bundled license files for details.

--- a/bigtop-packages/src/common/hive/patch9-log4j2-2.17.1.diff
+++ b/bigtop-packages/src/common/hive/patch9-log4j2-2.17.1.diff
@@ -20,7 +20,7 @@ index 32865dd448..32f66359f4 100644
      <libthrift.version>0.9.3</libthrift.version>
      <mockito-all.version>1.10.19</mockito-all.version>
 -    <log4j2.version>2.15.0</log4j2.version>
-+    <log4j2.version>2.16.0</log4j2.version>
++    <log4j2.version>2.17.1</log4j2.version>
      <orc.version>1.5.1</orc.version>
      <protobuf.version>2.5.0</protobuf.version>
      <sqlline.version>1.3.0</sqlline.version>

--- a/bigtop-packages/src/common/logstash/patch3-log4j2-2.17.1.diff
+++ b/bigtop-packages/src/common/logstash/patch3-log4j2-2.17.1.diff
@@ -42,16 +42,16 @@ index 2968c3a..c8bd292 100644
  dependencies {
 -    compile 'org.apache.logging.log4j:log4j-api:2.6.2'
 -    compile 'org.apache.logging.log4j:log4j-core:2.6.2'
-+    compile 'org.apache.logging.log4j:log4j-api:2.17.0'
-+    compile 'org.apache.logging.log4j:log4j-core:2.17.0'
++    compile 'org.apache.logging.log4j:log4j-api:2.17.1'
++    compile 'org.apache.logging.log4j:log4j-core:2.17.1'
      compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
      compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
      compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'
      compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.7.4'
 -    testCompile 'org.apache.logging.log4j:log4j-core:2.6.2:tests'
 -    testCompile 'org.apache.logging.log4j:log4j-api:2.6.2:tests'
-+    testCompile 'org.apache.logging.log4j:log4j-core:2.17.0:tests'
-+    testCompile 'org.apache.logging.log4j:log4j-api:2.17.0:tests'
++    testCompile 'org.apache.logging.log4j:log4j-core:2.17.1:tests'
++    testCompile 'org.apache.logging.log4j:log4j-api:2.17.1:tests'
      testCompile 'junit:junit:4.12'
      testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
      provided 'org.jruby:jruby-core:9.1.9.0'
@@ -65,8 +65,8 @@ index 2459f5d..9f27b11 100644
  
 -gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.6.2"
 -gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.6.2"
-+gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.17.0"
-+gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.17.0"
++gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.17.1"
++gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.17.1"
  gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.7.4"
  gem.requirements << "jar com.fasterxml.jackson.core:jackson-databind, 2.7.4"
  gem.requirements << "jar com.fasterxml.jackson.module:jackson-module-afterburner, 2.7.4"
@@ -79,10 +79,10 @@ index 8ccd269..c9a9818 100644
    require 'jar_dependencies'
  rescue LoadError
 -  require 'org/apache/logging/log4j/log4j-core/2.6.2/log4j-core-2.6.2.jar'
-+  require 'org/apache/logging/log4j/log4j-core/2.17.0/log4j-core-2.17.0.jar'
++  require 'org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar'
    require 'com/fasterxml/jackson/module/jackson-module-afterburner/2.7.4/jackson-module-afterburner-2.7.4.jar'
 -  require 'org/apache/logging/log4j/log4j-api/2.6.2/log4j-api-2.6.2.jar'
-+  require 'org/apache/logging/log4j/log4j-api/2.17.0/log4j-api-2.17.0.jar'
++  require 'org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar'
    require 'com/fasterxml/jackson/core/jackson-core/2.7.4/jackson-core-2.7.4.jar'
    require 'com/fasterxml/jackson/core/jackson-annotations/2.7.0/jackson-annotations-2.7.0.jar'
    require 'com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.7.4/jackson-dataformat-cbor-2.7.4.jar'
@@ -91,10 +91,10 @@ index 8ccd269..c9a9818 100644
  
  if defined? Jars
 -  require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.6.2' )
-+  require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.17.0' )
++  require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.17.1' )
    require_jar( 'com.fasterxml.jackson.module', 'jackson-module-afterburner', '2.7.4' )
 -  require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.6.2' )
-+  require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.17.0' )
++  require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.17.1' )
    require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.4' )
    require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
    require_jar( 'com.fasterxml.jackson.dataformat', 'jackson-dataformat-cbor', '2.7.4' )

--- a/bigtop-packages/src/common/solr/patch0-SOLR-15871.diff
+++ b/bigtop-packages/src/common/solr/patch0-SOLR-15871.diff
@@ -1,0 +1,125 @@
+diff --git a/lucene/ivy-versions.properties b/lucene/ivy-versions.properties
+index 3b314c7..2ce0f2b 100644
+--- a/lucene/ivy-versions.properties
++++ b/lucene/ivy-versions.properties
+@@ -234,7 +234,7 @@ org.apache.kerby.version = 1.0.1
+ /org.apache.kerby/kerby-pkix = ${org.apache.kerby.version}
+ /org.apache.kerby/kerby-util = ${org.apache.kerby.version}
+ 
+-org.apache.logging.log4j.version = 2.16.0
++org.apache.logging.log4j.version = 2.17.1
+ /org.apache.logging.log4j/log4j-1.2-api = ${org.apache.logging.log4j.version}
+ /org.apache.logging.log4j/log4j-api = ${org.apache.logging.log4j.version}
+ /org.apache.logging.log4j/log4j-core = ${org.apache.logging.log4j.version}
+diff --git a/lucene/licenses/log4j-api-2.16.0.jar.sha1 b/lucene/licenses/log4j-api-2.16.0.jar.sha1
+deleted file mode 100644
+index b95c0d0..0000000
+--- a/lucene/licenses/log4j-api-2.16.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-4727d93a76616ffc4149dffac5801827c0f4ac71
+diff --git a/lucene/licenses/log4j-api-2.17.1.jar.sha1 b/lucene/licenses/log4j-api-2.17.1.jar.sha1
+new file mode 100644
+index 0000000..acdf9dd
+--- /dev/null
++++ b/lucene/licenses/log4j-api-2.17.1.jar.sha1
+@@ -0,0 +1 @@
++d771af8e336e372fb5399c99edabe0919aeaf5b2
+diff --git a/lucene/licenses/log4j-core-2.16.0.jar.sha1 b/lucene/licenses/log4j-core-2.16.0.jar.sha1
+deleted file mode 100644
+index 953dbb9..0000000
+--- a/lucene/licenses/log4j-core-2.16.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-ca12fb3902ecfcba1e1357ebfc55407acec30ede
+diff --git a/lucene/licenses/log4j-core-2.17.1.jar.sha1 b/lucene/licenses/log4j-core-2.17.1.jar.sha1
+new file mode 100644
+index 0000000..aa16b80
+--- /dev/null
++++ b/lucene/licenses/log4j-core-2.17.1.jar.sha1
+@@ -0,0 +1 @@
++779f60f3844dadc3ef597976fcb1e5127b1f343d
+diff --git a/solr/licenses/log4j-1.2-api-2.16.0.jar.sha1 b/solr/licenses/log4j-1.2-api-2.16.0.jar.sha1
+deleted file mode 100644
+index f5179d6..0000000
+--- a/solr/licenses/log4j-1.2-api-2.16.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-ecbcfa4162e35b831705e97bbee546f81280ee6f
+diff --git a/solr/licenses/log4j-1.2-api-2.17.1.jar.sha1 b/solr/licenses/log4j-1.2-api-2.17.1.jar.sha1
+new file mode 100644
+index 0000000..99b2488
+--- /dev/null
++++ b/solr/licenses/log4j-1.2-api-2.17.1.jar.sha1
+@@ -0,0 +1 @@
++db3a7e7f07e878b92ac4a8f1100bee8325d5713a
+diff --git a/solr/licenses/log4j-api-2.16.0.jar.sha1 b/solr/licenses/log4j-api-2.16.0.jar.sha1
+deleted file mode 100644
+index b95c0d0..0000000
+--- a/solr/licenses/log4j-api-2.16.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-4727d93a76616ffc4149dffac5801827c0f4ac71
+diff --git a/solr/licenses/log4j-api-2.17.1.jar.sha1 b/solr/licenses/log4j-api-2.17.1.jar.sha1
+new file mode 100644
+index 0000000..acdf9dd
+--- /dev/null
++++ b/solr/licenses/log4j-api-2.17.1.jar.sha1
+@@ -0,0 +1 @@
++d771af8e336e372fb5399c99edabe0919aeaf5b2
+diff --git a/solr/licenses/log4j-core-2.16.0.jar.sha1 b/solr/licenses/log4j-core-2.16.0.jar.sha1
+deleted file mode 100644
+index 953dbb9..0000000
+--- a/solr/licenses/log4j-core-2.16.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-ca12fb3902ecfcba1e1357ebfc55407acec30ede
+diff --git a/solr/licenses/log4j-core-2.17.1.jar.sha1 b/solr/licenses/log4j-core-2.17.1.jar.sha1
+new file mode 100644
+index 0000000..aa16b80
+--- /dev/null
++++ b/solr/licenses/log4j-core-2.17.1.jar.sha1
+@@ -0,0 +1 @@
++779f60f3844dadc3ef597976fcb1e5127b1f343d
+diff --git a/solr/licenses/log4j-layout-template-json-2.16.0.jar.sha1 b/solr/licenses/log4j-layout-template-json-2.16.0.jar.sha1
+deleted file mode 100644
+index d97f9bc..0000000
+--- a/solr/licenses/log4j-layout-template-json-2.16.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-257d34c9f0942a834ddd972f177c4e8c7da877cc
+diff --git a/solr/licenses/log4j-layout-template-json-2.17.1.jar.sha1 b/solr/licenses/log4j-layout-template-json-2.17.1.jar.sha1
+new file mode 100644
+index 0000000..10052b3
+--- /dev/null
++++ b/solr/licenses/log4j-layout-template-json-2.17.1.jar.sha1
+@@ -0,0 +1 @@
++fb9cdcd21b45a6da4eead9f6333e220f36ef2066
+diff --git a/solr/licenses/log4j-slf4j-impl-2.16.0.jar.sha1 b/solr/licenses/log4j-slf4j-impl-2.16.0.jar.sha1
+deleted file mode 100644
+index a34c4ea..0000000
+--- a/solr/licenses/log4j-slf4j-impl-2.16.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-d4cc7712ebb4744681db815679248e4312f61b32
+diff --git a/solr/licenses/log4j-slf4j-impl-2.17.1.jar.sha1 b/solr/licenses/log4j-slf4j-impl-2.17.1.jar.sha1
+new file mode 100644
+index 0000000..b29c261
+--- /dev/null
++++ b/solr/licenses/log4j-slf4j-impl-2.17.1.jar.sha1
+@@ -0,0 +1 @@
++84692d456bcce689355d33d68167875e486954dd
+diff --git a/solr/licenses/log4j-web-2.16.0.jar.sha1 b/solr/licenses/log4j-web-2.16.0.jar.sha1
+deleted file mode 100644
+index 7624114..0000000
+--- a/solr/licenses/log4j-web-2.16.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-4bf36dca045fa113f625324013fbf57f938cd1c3
+diff --git a/solr/licenses/log4j-web-2.17.1.jar.sha1 b/solr/licenses/log4j-web-2.17.1.jar.sha1
+new file mode 100644
+index 0000000..eefd0a0
+--- /dev/null
++++ b/solr/licenses/log4j-web-2.17.1.jar.sha1
+@@ -0,0 +1 @@
++1a9e4a6ba9ac4e82c9d57ba7425168555b636d4f

--- a/bigtop-packages/src/common/ycsb/patch1-log4j.diff
+++ b/bigtop-packages/src/common/ycsb/patch1-log4j.diff
@@ -7,13 +7,13 @@ index 5d3ff06710..f10476cf05 100644
        <groupId>org.apache.logging.log4j</groupId>
        <artifactId>log4j-api</artifactId>
 -      <version>2.8.2</version>
-+      <version>2.17.0</version>
++      <version>2.17.1</version>
      </dependency>
      <dependency>
        <groupId>org.apache.logging.log4j</groupId>
        <artifactId>log4j-core</artifactId>
 -      <version>2.8.2</version>
-+      <version>2.17.0</version>
++      <version>2.17.1</version>
      </dependency>
      <dependency>
        <groupId>junit</groupId>
@@ -26,14 +26,14 @@ index eabf8d67d9..7b3ed0d496 100644
        <groupId>org.apache.logging.log4j</groupId>
        <artifactId>log4j-api</artifactId>
 -      <version>2.11.0</version>
-+      <version>2.17.0</version>
++      <version>2.17.1</version>
      </dependency>
  
      <dependency>
        <groupId>org.apache.logging.log4j</groupId>
        <artifactId>log4j-core</artifactId>
 -      <version>2.11.0</version>
-+      <version>2.17.0</version>
++      <version>2.17.1</version>
      </dependency>
    </dependencies>
  </project>
@@ -46,19 +46,19 @@ index ab870853ad..6c8cbd2b74 100644
  			<groupId>org.apache.logging.log4j</groupId>
  			<artifactId>log4j-api</artifactId>
 -			<version>2.7</version>
-+			<version>2.17.0</version>
++			<version>2.17.1</version>
  		</dependency>
  		<dependency>
  			<groupId>org.apache.logging.log4j</groupId>
  			<artifactId>log4j-core</artifactId>
 -			<version>2.7</version>
-+			<version>2.17.0</version>
++			<version>2.17.1</version>
  		</dependency>
  		<dependency>
  			<groupId>org.apache.logging.log4j</groupId>
  			<artifactId>log4j-slf4j-impl</artifactId>
 -			<version>2.7</version>
-+			<version>2.17.0</version>
++			<version>2.17.1</version>
  		</dependency>
  		<!-- https://mvnrepository.com/artifact/org.voltdb/voltdbclient -->
  		<dependency>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades log4j to 2.17.1 for Alluxio, Elasticsearch, Flink, Hive, Logstash, Solr, and YCSB.

### How was this patch tested?

Built the components above with this patch and ensured they succeeded.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/