### PR TITLE
 BIGTOP-3644: Improve Gradle download resiliency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 }
 
 plugins {
-  id "de.undercouch.download" version "3.2.0"
+  id "de.undercouch.download" version "4.1.2"
   id "org.nosphere.apache.rat" version "0.2.0"
 }
 

--- a/packages.gradle
+++ b/packages.gradle
@@ -256,6 +256,7 @@ def genTasks = { target ->
       download {
         src DOWNLOAD_URL
         dest DOWNLOAD_DST
+        retries 3
       }
     }
     touchTargetFile(config.bigtop.components[target].targetdl)


### PR DESCRIPTION
This change bumps up the version of the de.undercouch.download
Gradle download plugin to add the `retries` parameter to the
download function used to retrieve upstream artifacts.

The bump from 3.x to 4.x should be supported, afaics, from our
current setup:
https://github.com/michel-kraemer/gradle-download-task#migrating-from-version-3x-to-4x