### PR TITLE
[BIGTOP-3645] upgrade fedora version to 33 in gradle files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ Properties:
   -Pmemory=[4g|8g|...]
   -Pnum_instances=[NUM_INSTANCES]
   -Pnexus=[NEXUS_URL] (NEXUS_URL is optional)
-  -POS=[centos-7|fedora-26|debian-10|ubuntu-18.04|opensuse-42.3]
+  -POS=[centos-7|fedora-33|debian-10|ubuntu-18.04|opensuse-42.3]
   -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...]
   -Prepository=[REPO_URL]
   -Prun_smoke_tests (run test components defined in config file)
@@ -503,7 +503,7 @@ task "bigtop-puppet"(type:Exec,
     description: '''
 Build bigtop/puppet images
 Usage:
-  $ ./gradlew -POS=[centos-7|fedora-26|debian-10|ubuntu-18.04|opensuse-42.3] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-puppet
+  $ ./gradlew -POS=[centos-7|fedora-33|debian-10|ubuntu-18.04|opensuse-42.3] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-puppet
 Example:
   $ ./gradlew -POS=debian-10 -Pprefix=3.0.0 bigtop-puppet
   The built image name: bigtop/puppet:3.0.0-debian-10
@@ -522,7 +522,7 @@ task "bigtop-slaves"(type:Exec,
     description: '''
 Build bigtop/slaves images
 Usage:
-  $ ./gradlew -POS=[centos-7|fedora-26|debian-10|ubuntu-18.04|opensuse-42.3] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-slaves
+  $ ./gradlew -POS=[centos-7|fedora-33|debian-10|ubuntu-18.04|opensuse-42.3] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-slaves
 Example:
   $ ./gradlew -POS=debian-10 -Pprefix=3.0.0 bigtop-slaves
   The built image name: bigtop/slaves:3.0.0-debian-10

--- a/packages.gradle
+++ b/packages.gradle
@@ -645,7 +645,7 @@ def genTasks = { target ->
   }
   task "$target-pkg-ind" (
           description: "Invoking a native binary packaging for $target in Docker. Usage: \$ ./gradlew " +
-                  "-POS=[centos-7|fedora-31|debian-10|ubuntu-18.04] " +
+                  "-POS=[centos-7|fedora-33|debian-10|ubuntu-18.04] " +
                   "-Pprefix=[trunk|1.4.0|1.3.0|1.2.1|...] $target-pkg-ind " +
                   "-Pnexus=[true|false]",
           group: PACKAGES_GROUP) doLast {
@@ -864,7 +864,7 @@ if (nativePackaging) {
 
 task "repo-ind" (
     description: "Invoking a native repository in Docker. Usage: \$ ./gradlew " +
-            "-POS=[centos-7|fedora-31|debian-10|ubuntu-18.04] " +
+            "-POS=[centos-7|fedora-33|debian-10|ubuntu-18.04] " +
             "-Pprefix=[trunk|1.4.0|1.3.0|1.2.1|...] repo-ind",
     group: PACKAGES_GROUP) doLast {
   def _prefix = project.hasProperty("prefix") ? prefix : "trunk"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Upgrade the usage example on the task description, from fedora 26, 31 to 33, the version which Bigtop 3.0 supports.

### How was this patch tested?
Check by 

```
./gradlew tasks|grep fedora-26  
./gradlew tasks|grep fedora-31
./gradlew tasks|grep fedora-33
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/