### PR TITLE
BIGTOP-3646. Upgrade Geode and TableStore SDK version for YCSB.

### DIFF
--- a/bigtop-packages/src/common/ycsb/patch1-log4j.diff
+++ b/bigtop-packages/src/common/ycsb/patch1-log4j.diff
@@ -1,5 +1,5 @@
 diff --git a/elasticsearch5/pom.xml b/elasticsearch5/pom.xml
-index 5d3ff06710..f10476cf05 100644
+index 5d3ff067..77cbe0dd 100644
 --- a/elasticsearch5/pom.xml
 +++ b/elasticsearch5/pom.xml
 @@ -165,12 +165,12 @@ LICENSE file.
@@ -18,7 +18,7 @@ index 5d3ff06710..f10476cf05 100644
      <dependency>
        <groupId>junit</groupId>
 diff --git a/ignite/pom.xml b/ignite/pom.xml
-index eabf8d67d9..7b3ed0d496 100644
+index eabf8d67..f99edf65 100644
 --- a/ignite/pom.xml
 +++ b/ignite/pom.xml
 @@ -87,13 +87,13 @@ LICENSE file.
@@ -37,8 +37,30 @@ index eabf8d67d9..7b3ed0d496 100644
      </dependency>
    </dependencies>
  </project>
+diff --git a/pom.xml b/pom.xml
+index d38c1874..e76f7c9d 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -81,7 +81,7 @@ LICENSE file.
+ 		<crail.version>1.1-incubating</crail.version>
+     <elasticsearch5-version>5.5.1</elasticsearch5-version>
+     <foundationdb.version>5.2.5</foundationdb.version>
+-    <geode.version>1.2.0</geode.version>
++    <geode.version>1.14.1</geode.version>
+     <googlebigtable.version>1.4.0</googlebigtable.version>
+     <griddb.version>4.0.0</griddb.version>
+     <hbase098.version>0.98.14-hadoop2</hbase098.version>
+@@ -109,7 +109,7 @@ LICENSE file.
+     <tarantool.version>1.6.5</tarantool.version>
+     <thrift.version>0.8.0</thrift.version>
+     <voldemort.version>0.81</voldemort.version>
+-    <tablestore.version>4.8.0</tablestore.version>
++    <tablestore.version>5.13.6</tablestore.version>
+     <voltdb.version>9.1.1</voltdb.version>
+   </properties>
+ 
 diff --git a/voltdb/pom.xml b/voltdb/pom.xml
-index ab870853ad..6c8cbd2b74 100644
+index df56baae..1af04016 100644
 --- a/voltdb/pom.xml
 +++ b/voltdb/pom.xml
 @@ -44,17 +44,17 @@
@@ -62,4 +84,3 @@ index ab870853ad..6c8cbd2b74 100644
  		</dependency>
  		<!-- https://mvnrepository.com/artifact/org.voltdb/voltdbclient -->
  		<dependency>
-


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades the version of Geode and TableStore SDK so that YCSB doesn't have the jar files which have the Log4Shell vulnerabilities.


### How was this patch tested?

I built YCSB with this PR on CentOS 7 and confirmed that there was no log4j2 jar file before 2.17.1 in the generated package.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/