### PR TITLE
BIGTOP-3647. Change RPM repository for CentOS 8 to Vault Mirror.

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -47,7 +47,10 @@ case ${ID}-${VERSION_ID} in
         yum -y install hostname curl sudo unzip wget puppet
         puppet module install puppetlabs-stdlib --version 4.12.0
         ;;
-    centos-8*|rocky-8*)
+    centos-8*)
+        sed -i -e 's/^\(mirrorlist\)/#\1/' -e 's,^#baseurl=http://mirror.centos.org,baseurl=http://vault.centos.org,' /etc/yum.repos.d/CentOS-Linux-*
+        ;&
+    rocky-8*)
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         dnf -y check-update
         dnf -y install glibc-langpack-en hostname diffutils curl sudo unzip wget puppet 'dnf-command(config-manager)'


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Creating the bigtop-puppet image of CentOS 8 fails for now because it's already EOL'd.
This PR changes the RPM repository for CentOS 8 to fix it.


### How was this patch tested?

I locally confirmed that running `./build.sh 3.0.1-centos-8` with this PR in docker/bigtop-puppet succeeded.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/