### PR TITLE
BIGTOP-3648. Change download site to dlcdn.apache.org for installing Ant and Maven.

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/repo.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/repo.yaml
@@ -1,5 +1,5 @@
 bigtop::bigtop_repo_gpg_check: true
 bigtop::bigtop_repo_apt_key: "01621A73025BDCA30F4159C62922A48261524827"
-bigtop::bigtop_repo_yum_key_url: "https://downloads.apache.org/bigtop/KEYS"
+bigtop::bigtop_repo_yum_key_url: "https://dlcdn.apache.org/bigtop/KEYS"
 bigtop::bigtop_repo_default_version: "3.0.0"
 

--- a/bigtop-packages/src/common/ambari/patch5-AMBARI-25599.diff
+++ b/bigtop-packages/src/common/ambari/patch5-AMBARI-25599.diff
@@ -64,7 +64,7 @@ index a0a11b8e6e..282041fab6 100644
 +    <hadoop.folder>hadoop-3.1.1</hadoop.folder>
 +    <grafana.folder>grafana-6.7.4</grafana.folder>
 +    <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.7.4.linux-amd64.tar.gz</grafana.tar>
-+    <phoenix.tar>https://downloads.apache.org/phoenix/apache-phoenix-5.0.0-HBase-2.0/bin/apache-phoenix-5.0.0-HBase-2.0-bin.tar.gz</phoenix.tar>
++    <phoenix.tar>https://dlcdn.apache.org/phoenix/apache-phoenix-5.0.0-HBase-2.0/bin/apache-phoenix-5.0.0-HBase-2.0-bin.tar.gz</phoenix.tar>
 +    <phoenix.folder>apache-phoenix-5.0.0-HBase-2.0-bin</phoenix.folder>
      <resmonitor.install.dir>/usr/lib/python2.6/site-packages/resource_monitoring</resmonitor.install.dir>
      <powermock.version>1.6.2</powermock.version>

--- a/bigtop_toolchain/lib/puppet/parser/functions/latest_ant_binary.rb
+++ b/bigtop_toolchain/lib/puppet/parser/functions/latest_ant_binary.rb
@@ -17,6 +17,6 @@ module Puppet::Parser::Functions
     newfunction(:latest_ant_binary, :type => :rvalue) do |args|
         versionmask=args[0]
         # We are using main mirror here because can't be sure about Apache Server config on every mirror. It could be Nginx, btw. 
-        %x(curl -L --stderr /dev/null 'https://downloads.apache.org/ant/binaries/?F=0&amp;V=1' | grep -o '<li>.*href="apache-ant-#{versionmask}-bin.tar.gz"'  |  grep -o "apache-ant-#{versionmask}" | tail -1 | tr -d '\r').chomp
+        %x(curl -L --stderr /dev/null 'https://dlcdn.apache.org/ant/binaries/?F=0&amp;V=1' | grep -o '<li>.*href="apache-ant-#{versionmask}-bin.tar.gz"'  |  grep -o "apache-ant-#{versionmask}" | tail -1 | tr -d '\r').chomp
     end
 end

--- a/bigtop_toolchain/lib/puppet/parser/functions/latest_maven_binary.rb
+++ b/bigtop_toolchain/lib/puppet/parser/functions/latest_maven_binary.rb
@@ -17,6 +17,6 @@ module Puppet::Parser::Functions
     newfunction(:latest_maven_binary, :type => :rvalue) do |args|
         versionmask=args[0]
         # We are using main mirror here because can't be sure about Apache Server config on every mirror. It could be Nginx, btw.
-        %x(curl -L --stderr /dev/null 'https://downloads.apache.org/maven/maven-3/?F=0&amp;V=1' | grep -o '<li>.*href="#{versionmask}/"' | tail -1 | grep -o '#{versionmask}'| tr -d '\r').chomp
+        %x(curl -L --stderr /dev/null 'https://dlcdn.apache.org/maven/maven-3/?F=0&amp;V=1' | grep -o '<li>.*href="#{versionmask}/"' | tail -1 | grep -o '#{versionmask}'| tr -d '\r').chomp
     end
 end

--- a/bigtop_toolchain/manifests/ant.pp
+++ b/bigtop_toolchain/manifests/ant.pp
@@ -29,7 +29,7 @@ class bigtop_toolchain::ant {
   } ~>
 
   exec { 'Download Ant binaries signature':
-    command => "/usr/bin/wget https://www.apache.org/dist/ant/binaries/$ant-bin.tar.gz.asc",
+    command => "/usr/bin/wget $apache_prefix/ant/binaries/$ant-bin.tar.gz.asc",
     cwd     => "/usr/src",
     unless  => "/usr/bin/test -f /usr/src/$ant-bin.tar.gz.asc",
   } ~>

--- a/bigtop_toolchain/manifests/maven.pp
+++ b/bigtop_toolchain/manifests/maven.pp
@@ -30,7 +30,7 @@ class bigtop_toolchain::maven {
   } ~>
 
   exec { 'Download Maven binaries signature':
-    command => "/usr/bin/wget https://www.apache.org/dist/maven/maven-3/$mvnversion/binaries/$mvn-bin.tar.gz.asc",
+    command => "/usr/bin/wget $apache_prefix/maven/maven-3/$mvnversion/binaries/$mvn-bin.tar.gz.asc",
     cwd     => "/usr/src",
     unless  => "/usr/bin/test -f /usr/src/$mvn-bin.tar.gz.asc",
   } ~>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

During installing toolchain, Ant and Maven is downloaded from downloads.apache.org.
But requesting to that site too many times causes IP ban, so this PR replaces it with dlcdn.apache.org,
which isn't supposed to have such a limitation.


### How was this patch tested?

I confirmed that `./gradlew toolchain` succeeded with this PR on the node in question, which was still banned from the ASF site.
Also, building and testing Ambari with this PR succeeded as before on another node, which was not blacklisted.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/