### PR TITLE
BIGTOP-3652. Add the python-is-python2 package to the toolchain for Ubuntu 20.04.

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -152,7 +152,7 @@ class bigtop_toolchain::packages {
       "libffi-devel"
     ] }
     /(Ubuntu|Debian)/: {
-      $pkgs = [
+      $_pkgs = [
         "unzip",
         "curl",
         "wget",
@@ -211,6 +211,13 @@ class bigtop_toolchain::packages {
         "python3-dev",
         "python2.7-dev"
       ]
+
+      if ($operatingsystem == 'Ubuntu' and 0 <= versioncmp($operatingsystemmajrelease, '20.04')) {
+        $pkgs = concat($_pkgs, ["python-is-python2"])
+      } else {
+        $pkgs = $_pkgs
+      }
+
       file { '/etc/apt/apt.conf.d/01retries':
         content => 'Aquire::Retries "5";'
       } -> Package <| |>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR adds the python-is-python2 package to the Docker image for Ubuntu 20.04 so that building Ambari succeeds.

### How was this patch tested?

Tested on Ubuntu 20.04 and 18.04 (for regression).

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/