### PR TITLE
BIGTOP-3653. Building Kibana fails due to the npm error.

### DIFF
--- a/bigtop-packages/src/common/kibana/do-component-build
+++ b/bigtop-packages/src/common/kibana/do-component-build
@@ -19,6 +19,7 @@ set -ex
 . `dirname ${0}`/bigtop.bom
 
 # Install the specific version of nodejs defined in Kibana
+git config --global url."https://".insteadOf git://
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR fixes Kibana's build error caused by the following change of GitHub.
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

### How was this patch tested?

Ran `./gradlew allclean kibana-pkg-ind` locally and confirmed it succeeded.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/