### PR TITLE
BIGTOP-3654. Building Hadoop fails on ppc64le.

### DIFF
--- a/bigtop-packages/src/common/hadoop/do-component-build
+++ b/bigtop-packages/src/common/hadoop/do-component-build
@@ -20,7 +20,7 @@ set -ex
 # with version of leveldbjni-all library that is not x86 specific
 if [ $HOSTTYPE = "powerpc64le" ] ; then
         #download the POWER version of leveldb
-        git clone git://github.com/ibmsoe/leveldb.git
+        git clone https://github.com/ibmsoe/leveldb.git
         git clone https://github.com/ibmsoe/leveldbjni.git
         export SNAPPY_HOME=/usr/lib
         export LEVELDB_HOME=`cd leveldb; pwd`


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR fixes Hadoop build failure on ppc64le caused by accessing GitHub via prohibited protocol.


### How was this patch tested?

Not tested, since it's a slight and obvious fix. We can test it on the CI environment after merging.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/