### PR TITLE
BIGTOP-3655. Cluster deployment via Ambari fails on CentOS due to the lack of execute permission.

### DIFF
--- a/bigtop-packages/src/rpm/ambari/SPECS/ambari.spec
+++ b/bigtop-packages/src/rpm/ambari/SPECS/ambari.spec
@@ -447,6 +447,7 @@ exit 0
 %attr(644,root,root) /etc/init/ambari-server.conf
 %defattr(644,root,root,755)
 /usr/lib/ambari-server
+%attr(755,root,root) /usr/lib/ambari-server/lib/ambari_server/bootstrap.py
 %attr(755,root,root) /usr/sbin/ambari-server.py
 %attr(755,root,root) /usr/sbin/ambari_server_main.py
 %attr(755,root,root) %{initd_dir}/ambari-server


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Currently, Ambari fails to deploy a cluster on CentOS due to the lack of execute permission on the bootstrap script. This PR adds the required permission to it.


### How was this patch tested?

I deployed a single node cluster on CentOS 7 via Ambari which was built with this PR.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/