### PR TITLE
BIGTOP-3656. Fix Mpack's build and deployment problems on Ubuntu.

### DIFF
--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/repos/repoinfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/repos/repoinfo.xml
@@ -27,7 +27,8 @@
     <repo>
       <baseurl>http://repos.bigtop.apache.org/releases/1.5.0/ubuntu/18.04/$(ARCH)</baseurl>
       <repoid>BGTP-1.0</repoid>
-      <reponame>BGTP</reponame>
+      <reponame>bigtop</reponame>
+      <components>contrib</components>
     </repo>
   </os>
 </reposinfo>

--- a/bigtop-packages/src/deb/bigtop-ambari-mpack/source/include-binaries
+++ b/bigtop-packages/src/deb/bigtop-ambari-mpack/source/include-binaries
@@ -1,0 +1,1 @@
+debian/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/hooks/before-START/files/fast-hdfs-resource.jar


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Currently, building Mpack fails on Ubuntu due to an unwanted binary file, and deployment with it also fails due to a wrong repository definition. This PR fixes them.

### How was this patch tested?

Built Mpack with this PR and deploy a cluster via Ambari locally.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/