### PR TITLE
BIGTOP-3639. Alluxio build fails on ppc64le (addendum).

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -19,7 +19,7 @@ set -ex
 . `dirname $0`/bigtop.bom
 
 if [ $HOSTTYPE = "powerpc64le" ] ; then
-  mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.28.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/src/grpc-java-1.28.0/compiler/build/exe/java_plugin/protoc-gen-grpc-java
+  mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.28.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/src/grpc-java-1.28.0/compiler/build/exe/java_plugin/protoc-gen-grpc-java "$@"
 
   sed -i "s|<nodeVersion>v10.11.0</nodeVersion>|<nodeVersion>v12.22.1</nodeVersion>|" webui/pom.xml
   sed -i "s|<npmVersion>6.4.1</npmVersion>|<npmVersion>6.14.7</npmVersion>|" webui/pom.xml


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This is a follow-up for #861. Building Alluxio for Debian or Ubuntu fails on a ppc64le machine because fakeroot tries to use the root user's home directory instead of jenkins' to create local maven repository for some reason. This PR avoids this problem by leveraging the maven.repo.local property passed from bigtop-packages/src/deb/alluxio/rules.

### How was this patch tested?

Ran `./gradlew allclean alluxio-pkg` in a ubuntu-18.04 container on a ppc64le machine and confirmed it succeeced.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/