### PR TITLE
BIGTOP-3657. Revert the download site to archive.apache.org partially

### DIFF
--- a/bigtop-packages/src/common/ambari/patch5-AMBARI-25599.diff
+++ b/bigtop-packages/src/common/ambari/patch5-AMBARI-25599.diff
@@ -64,7 +64,7 @@ index a0a11b8e6e..282041fab6 100644
 +    <hadoop.folder>hadoop-3.1.1</hadoop.folder>
 +    <grafana.folder>grafana-6.7.4</grafana.folder>
 +    <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.7.4.linux-amd64.tar.gz</grafana.tar>
-+    <phoenix.tar>https://dlcdn.apache.org/phoenix/apache-phoenix-5.0.0-HBase-2.0/bin/apache-phoenix-5.0.0-HBase-2.0-bin.tar.gz</phoenix.tar>
++    <phoenix.tar>https://archive.apache.org/dist/phoenix/apache-phoenix-5.0.0-HBase-2.0/bin/apache-phoenix-5.0.0-HBase-2.0-bin.tar.gz</phoenix.tar>
 +    <phoenix.folder>apache-phoenix-5.0.0-HBase-2.0-bin</phoenix.folder>
      <resmonitor.install.dir>/usr/lib/python2.6/site-packages/resource_monitoring</resmonitor.install.dir>
      <powermock.version>1.6.2</powermock.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

We change the ASF download site to dlcdn.apache.org in BIGTOP-3648 for avoiding IP ban,
but the old version of Phoenix seems to be removed from that site and it causes build failures.
This PR fixes the problem above.

### How was this patch tested?

I confirmed the replaced link was alive via browser.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/