### PR TITLE
BIGTOP-3658. Add Fedora 35 support and drop 33.

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch10-MAPREDUCE-7373.diff
+++ b/bigtop-packages/src/common/hadoop/patch10-MAPREDUCE-7373.diff
@@ -1,0 +1,13 @@
+diff --git a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/CMakeLists.txt b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/CMakeLists.txt
+index ae3b9c6029e..ed03a1b127f 100644
+--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/CMakeLists.txt
++++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/CMakeLists.txt
+@@ -26,7 +26,7 @@ set(GTEST_SRC_DIR ${CMAKE_SOURCE_DIR}/../../../../hadoop-common-project/hadoop-c
+ 
+ # Add extra compiler and linker flags.
+ # -Wno-sign-compare
+-hadoop_add_compiler_flags("-DNDEBUG -DSIMPLE_MEMCPY -fno-strict-aliasing -fsigned-char")
++hadoop_add_compiler_flags("-DNDEBUG -DSIMPLE_MEMCPY -fno-strict-aliasing -fsigned-char -std=c++11")
+ 
+ # Source location.
+ set(SRC main/native)

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -21,7 +21,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case ${ID}-${VERSION_ID} in
-    fedora-33)
+    fedora-35)
         dnf -y install yum-utils
         dnf -y check-update
         dnf -y install hostname diffutils findutils curl sudo unzip wget puppet procps-ng libxcrypt-compat

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -297,5 +297,16 @@ class bigtop_toolchain::packages {
         target => '/usr/bin/cmake3',
       }
     }
+
+    # The rpm-build package had installed brp-python-bytecompile
+    # just under /usr/lib/rpm until Fedora 34,
+    # but it seems to have been removed in Fedora 35.
+    # So we manually create a symlink instead.
+    if ($operatingsystem == 'Fedora' and versioncmp($operatingsystemmajrelease, '35') >= 0) {
+      file { '/usr/lib/rpm/brp-python-bytecompile':
+        ensure => 'link',
+        target => '/usr/lib/rpm/redhat/brp-python-bytecompile',
+      }
+    }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ task toolchain(type:Exec,
   if ('3.7' <= version && version < '4') {
     command.addAll(['--parser', 'future'])
   }
-  command.addAll(["--modulepath=${projectDir.absolutePath}:/etc/puppet/modules:/usr/share/puppet/modules:/etc/puppetlabs/code/modules",
+  command.addAll(["--modulepath=${projectDir.absolutePath}:/etc/puppet/modules:/usr/share/puppet/modules:/etc/puppetlabs/code/modules:/etc/puppet/code/modules",
     '-e', 'include bigtop_toolchain::installer'])
   workingDir '.'
   commandLine command
@@ -268,7 +268,7 @@ Properties:
   -Pmemory=[4g|8g|...]
   -Pnum_instances=[NUM_INSTANCES]
   -Pnexus=[NEXUS_URL] (NEXUS_URL is optional)
-  -POS=[centos-7|fedora-33|debian-10|ubuntu-18.04|opensuse-42.3]
+  -POS=[centos-7|fedora-35|debian-10|ubuntu-18.04|opensuse-42.3]
   -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...]
   -Prepository=[REPO_URL]
   -Prun_smoke_tests (run test components defined in config file)
@@ -563,7 +563,7 @@ task "bigtop-puppet"(type:Exec,
     description: '''
 Build bigtop/puppet images
 Usage:
-  $ ./gradlew -POS=[centos-7|fedora-33|debian-10|ubuntu-18.04|opensuse-42.3] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-puppet
+  $ ./gradlew -POS=[centos-7|fedora-35|debian-10|ubuntu-18.04|opensuse-42.3] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-puppet
 Example:
   $ ./gradlew -POS=debian-10 -Pprefix=3.0.0 bigtop-puppet
   The built image name: bigtop/puppet:3.0.0-debian-10
@@ -582,7 +582,7 @@ task "bigtop-slaves"(type:Exec,
     description: '''
 Build bigtop/slaves images
 Usage:
-  $ ./gradlew -POS=[centos-7|fedora-33|debian-10|ubuntu-18.04|opensuse-42.3] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-slaves
+  $ ./gradlew -POS=[centos-7|fedora-35|debian-10|ubuntu-18.04|opensuse-42.3] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-slaves
 Example:
   $ ./gradlew -POS=debian-10 -Pprefix=3.0.0 bigtop-slaves
   The built image name: bigtop/slaves:3.0.0-debian-10

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -56,7 +56,7 @@ case ${OS} in
         UPDATE_SOURCE="apt-get clean \&\& apt-get update"
         ;;
     fedora)
-        PUPPET_MODULES="/etc/puppet/modules/bigtop_toolchain"
+        PUPPET_MODULES="/etc/puppet/code/modules/bigtop_toolchain"
         UPDATE_SOURCE="dnf clean all \&\& dnf updateinfo"
         ;;
     centos)

--- a/packages.gradle
+++ b/packages.gradle
@@ -508,6 +508,7 @@ def genTasks = { target ->
     exec {
       workingDir BASE_DIR
       executable 'rpmbuild'
+      environment QA_RPATHS: 0x0002
       args command
     }
     copy {
@@ -645,7 +646,7 @@ def genTasks = { target ->
   }
   task "$target-pkg-ind" (
           description: "Invoking a native binary packaging for $target in Docker. Usage: \$ ./gradlew " +
-                  "-POS=[centos-7|fedora-33|debian-10|ubuntu-18.04] " +
+                  "-POS=[centos-7|fedora-35|debian-10|ubuntu-18.04] " +
                   "-Pprefix=[trunk|1.4.0|1.3.0|1.2.1|...] $target-pkg-ind " +
                   "-Pnexus=[true|false]",
           group: PACKAGES_GROUP) doLast {
@@ -864,7 +865,7 @@ if (nativePackaging) {
 
 task "repo-ind" (
     description: "Invoking a native repository in Docker. Usage: \$ ./gradlew " +
-            "-POS=[centos-7|fedora-33|debian-10|ubuntu-18.04] " +
+            "-POS=[centos-7|fedora-35|debian-10|ubuntu-18.04] " +
             "-Pprefix=[trunk|1.4.0|1.3.0|1.2.1|...] repo-ind",
     group: PACKAGES_GROUP) doLast {
   def _prefix = project.hasProperty("prefix") ? prefix : "trunk"

--- a/provisioner/docker/config_fedora-35.yaml
+++ b/provisioner/docker/config_fedora-35.yaml
@@ -15,9 +15,9 @@
 
 docker:
         memory_limit: "4g"
-        image: "bigtop/puppet:trunk-fedora-33"
+        image: "bigtop/puppet:trunk-fedora-35"
 
-repo: "http://repos.bigtop.apache.org/releases/3.0.0/fedora/33/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/fedora/35/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades supported Fedora version from 33 to 35.

### How was this patch tested?

I confirmed that several components were successfully built on Fedora 35 with this PR, including ZK, Hadoop, HBase, Hive, Kafka, etc.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/