### PR TITLE
BIGTOP-3659. Ambari deployment fails due to the odpi-ambari-mpack version mismatch.

### DIFF
--- a/bigtop-deploy/puppet/modules/ambari/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ambari/manifests/init.pp
@@ -29,7 +29,7 @@ class ambari {
 
     exec {
         "mpack install":
-           command => "/bin/bash -c 'echo yes | /usr/sbin/ambari-server install-mpack --purge --verbose --mpack=/var/lib/ambari-server/resources/odpi-ambari-mpack-1.0.0.0-SNAPSHOT.tar.gz'",
+           command => "/bin/bash -c 'echo yes | /usr/sbin/ambari-server install-mpack --purge --verbose --mpack=/var/lib/ambari-server/resources/odpi-ambari-mpack-2.7.5.0.0.tar.gz'",
            require => [ Package["ambari-server"] ]
     }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR fixes the Ambari deployment failure caused by the version mismatch of ODPi Mpack.

### How was this patch tested?

I confirmed that the following commands succeeded with this PR on x86_64 platform.
```
./docker-hadoop.sh -d -i bigtop/puppet:3.0.1-fedora-33 -r 'http://repos.bigtop.apache.org/releases/3.0.1/fedora/33/$basearch' -k bigtop-utils,ambari -s ambari -F docker-compose-cgroupv2.yml -c 1
```
```
./docker-hadoop.sh -d -i bigtop/puppet:3.0.1-ubuntu-20.04 -r 'http://repos.bigtop.apache.org/releases/3.0.1/ubuntu/20.04/$(ARCH)' -k bigtop-utils,ambari -s ambari -F docker-compose-cgroupv2.yml -c 1
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/