### PR TITLE
BIGTOP-3662. Bump HBase to 2.4.11.

### DIFF
--- a/bigtop-packages/src/common/hbase/do-component-build
+++ b/bigtop-packages/src/common/hbase/do-component-build
@@ -48,7 +48,6 @@ fi
 MVN_ARGS="-Phadoop-3.0 "
 MVN_ARGS+="-Dhadoop-three.version=${HADOOP_VERSION} "
 MVN_ARGS+="-Dhadoop.guava.version=27.0-jre "
-MVN_ARGS+="-Dslf4j.version=1.7.25 "
 MVN_ARGS+="-Djetty.version=9.3.29.v20201019 "
 MVN_ARGS+="-Dzookeeper.version=${ZOOKEEPER_VERSION} "
 MVN_ARGS+="-DskipTests "

--- a/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
+++ b/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
@@ -103,6 +103,9 @@ Requires: bsh-utils
 Requires: coreutils
 %endif
 
+%if %{?el7}0
+AutoReq: no
+%endif
 
 %description 
 HBase is an open-source, distributed, column-oriented store modeled after Google' Bigtable: A Distributed Storage System for Structured Data by Chang et al. Just as Bigtable leverages the distributed data storage provided by the Google File System, HBase provides Bigtable-like capabilities on top of Hadoop. HBase includes:

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -155,7 +155,7 @@ bigtop {
     'hbase' {
       name    = 'hbase'
       relNotes = 'Apache HBase'
-      version { base = '2.4.8'; pkg = base; release = 1 }
+      version { base = '2.4.11'; pkg = base; release = 1 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3662

HBase 2.4.11 was released. We can pick this low-hanging fruit for Bigtop 3.1.
