### PR TITLE
BIGTOP-3663. Hadoop deployment fails on Fedora 35.

### DIFF
--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -208,6 +208,11 @@ BuildRequires: pkgconfig, libfuse-devel, libfuse2 , libopenssl-devel, gcc-c++, l
 Requires: chkconfig, xinetd-simple-services, zlib, initscripts
 %endif
 
+# Fedora 35: we need initscripts for /etc/init.d/functions and
+# initscripts-service for /sbin/service.
+%if %{?fc35}0
+Requires: initscripts, initscripts-service
+%endif
 
 %description
 Hadoop is a software platform that lets one easily write and

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -239,7 +239,7 @@ bigtop-puppet() {
       future="--parser future"
     fi
     # BIGTOP-3401 Modify Puppet modulepath for puppetlabs-4.12
-    docker exec $1 bash -c "puppet apply --detailed-exitcodes $future --hiera_config=/etc/puppet/hiera.yaml --modulepath=/bigtop-home/bigtop-deploy/puppet/modules:/etc/puppet/modules:/usr/share/puppet/modules:/etc/puppetlabs/code/modules /bigtop-home/bigtop-deploy/puppet/manifests"
+    docker exec $1 bash -c "puppet apply --detailed-exitcodes $future --hiera_config=/etc/puppet/hiera.yaml --modulepath=/bigtop-home/bigtop-deploy/puppet/modules:/etc/puppet/modules:/usr/share/puppet/modules:/etc/puppetlabs/code/modules:/etc/puppet/code/modules /bigtop-home/bigtop-deploy/puppet/manifests"
 }
 
 get-yaml-config() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3663

* We need to add `/etc/puppet/code/modules` to `--modulepath` for puppetlabs-stdlib.
* Both initscripts and initscripts-service are required.