### PR TITLE
BIGTOP-3666: Replace the Docker provisioner config for CentOS 8 with Rocky 8

### DIFF
--- a/provisioner/docker/README.md
+++ b/provisioner/docker/README.md
@@ -149,5 +149,5 @@ By default, Apache Hadoop and YARN will be installed.
 
 ## Experimental
 
-With recent OS versions, like Debian 11, the cgroupsv2 settings are enabled by default. Running Docker compose seems to require different settings. For example, mounting /sys/fs/cgroup:ro to the containers breaks systemd and dbus when they are installed and started (in the container). The `docker-hadoop.sh` script offers an option, `-F`, to load a different configuration file for Docker compose (by default, `docker-compose.yml` is picked up). The configuration file to load is `docker-compose-cgroupsv2.yml`. More info in BIGTOP-3614.
+With recent OS versions, like Debian 11  Fedora 35, the cgroupsv2 settings are enabled by default. Running Docker compose seems to require different settings. For example, mounting /sys/fs/cgroup:ro to the containers breaks systemd and dbus when they are installed and started (in the container). The `docker-hadoop.sh` script offers an option, `-F`, to load a different configuration file for Docker compose (by default, `docker-compose.yml` is picked up). The configuration file to load is `docker-compose-cgroupsv2.yml`. More info in BIGTOP-3614, BIGTOP-3665.
 

--- a/provisioner/docker/config_rockylinux-8.yaml
+++ b/provisioner/docker/config_rockylinux-8.yaml
@@ -15,7 +15,7 @@
 
 docker:
         memory_limit: "4g"
-        image: "bigtop/puppet:trunk-centos-8"
+        image: "bigtop/puppet:trunk-rockylinux-8"
 
 repo: "http://repos.bigtop.apache.org/releases/3.0.0/centos/8/$basearch"
 distro: centos


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
This PR will replace centos8 with rocky linux 8 on docker provisioner.

### How was this patch tested?

```
./docker-hadoop.sh \
   --create 3 \
   --memory 4g \
   -C config_rockylinux-8.yaml \
   -d  \
   --stack hdfs,yarn,mapreduce \
   --smoke-tests hdfs,yarn,mapreduce
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/