### PR TITLE
BIGTOP-3672: Always use HTTPS when accessing repos and not plain HTTP.

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -48,7 +48,7 @@ case ${ID}-${VERSION_ID} in
         puppet module install puppetlabs-stdlib --version 4.12.0
         ;;
     centos-8*)
-        sed -i -e 's/^\(mirrorlist\)/#\1/' -e 's,^#baseurl=http://mirror.centos.org,baseurl=http://vault.centos.org,' /etc/yum.repos.d/CentOS-Linux-*
+        sed -i -e 's/^\(mirrorlist\)/#\1/' -e 's,^#baseurl=http://mirror.centos.org,baseurl=https://vault.centos.org,' /etc/yum.repos.d/CentOS-Linux-*
         ;&
     rocky-8*)
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm

--- a/bigtop_toolchain/manifests/ant.pp
+++ b/bigtop_toolchain/manifests/ant.pp
@@ -35,7 +35,7 @@ class bigtop_toolchain::ant {
   } ~>
 
   exec { 'Verify Ant binaries':
-    command => "/usr/bin/$bigtop_toolchain::gnupg::cmd -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com:80 $ant-bin.tar.gz.asc",
+    command => "/usr/bin/$bigtop_toolchain::gnupg::cmd -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com $ant-bin.tar.gz.asc",
     cwd     => "/usr/src",
   } ->
 

--- a/bigtop_toolchain/manifests/maven.pp
+++ b/bigtop_toolchain/manifests/maven.pp
@@ -36,7 +36,7 @@ class bigtop_toolchain::maven {
   } ~>
 
   exec { 'Verify Maven binaries signature':
-    command => "/usr/bin/$bigtop_toolchain::gnupg::cmd --no-tty -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com:80 $mvn-bin.tar.gz.asc",
+    command => "/usr/bin/$bigtop_toolchain::gnupg::cmd --no-tty -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com $mvn-bin.tar.gz.asc",
     cwd     => "/usr/src",
   } ->
 

--- a/bigtop_toolchain/manifests/protobuf.pp
+++ b/bigtop_toolchain/manifests/protobuf.pp
@@ -28,7 +28,7 @@ class bigtop_toolchain::protobuf {
 
   exec { "download protobuf":
      cwd  => "/usr/src",
-     command => "/usr/bin/wget $url/$protobuf8 && mkdir -p $protobuf8dir && /bin/tar -xvzf $protobuf8 -C $protobuf8dir --strip-components=1 && cd $protobuf8dir && /usr/bin/patch -p1 </usr/src/0001-Backport-atomic-operations-with-support-of-arm64-and.patch && curl -o config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' && cp config.guess gtest/build-aux/",
+     command => "/usr/bin/wget $url/$protobuf8 && mkdir -p $protobuf8dir && /bin/tar -xvzf $protobuf8 -C $protobuf8dir --strip-components=1 && cd $protobuf8dir && /usr/bin/patch -p1 </usr/src/0001-Backport-atomic-operations-with-support-of-arm64-and.patch && curl -o config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' && cp config.guess gtest/build-aux/",
      creates => "/usr/src/$protobuf8dir",
      require => File["/usr/src/0001-Backport-atomic-operations-with-support-of-arm64-and.patch"]
   }

--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -62,7 +62,7 @@ class bigtop_toolchain::renv {
   # Then Install required R packages dependency
   if (($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemmajrelease, '18.04') <= 0) or
       ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') < 0)) {
-    $url = "http://cran.r-project.org/src/base/R-3/"
+    $url = "https://cran.r-project.org/src/base/R-3/"
     $rfile = "R-3.6.3.tar.gz"
     $rdir = "R-3.6.3"
 
@@ -81,14 +81,14 @@ class bigtop_toolchain::renv {
 
     exec { "install_r_packages" :
       cwd     => "/usr/local/bin",
-      command => '/usr/local/bin/R -e \'pkgs <- c("devtools", "evaluate", "rmarkdown", "knitr", "roxygen2", "testthat", "e1071"); install.packages(pkgs, repo="http://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)\'',
+      command => '/usr/local/bin/R -e \'pkgs <- c("devtools", "evaluate", "rmarkdown", "knitr", "roxygen2", "testthat", "e1071"); install.packages(pkgs, repo="https://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)\'',
       require => [Exec["install_R"]],
       timeout => 6000
     }
   } else {
     exec { "install_r_packages" :
       cwd     => "/usr/bin",
-      command => '/usr/bin/R -e \'pkgs <- c("devtools", "evaluate", "rmarkdown", "knitr", "roxygen2", "testthat", "e1071"); install.packages(pkgs, repo="http://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)\'',
+      command => '/usr/bin/R -e \'pkgs <- c("devtools", "evaluate", "rmarkdown", "knitr", "roxygen2", "testthat", "e1071"); install.packages(pkgs, repo="https://cran.r-project.org/"); for (pkg in pkgs[pkgs != "devtools"]) if (!library(pkg, character.only=TRUE, logical.return=TRUE)) q(save="no", status=1)\'',
       timeout => 6000
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Use HTTPS instead of HTTP when building the images.

### How was this patch tested?
I was able to use the new Docker image to build HBase for CentOS 8 and Rocky 8.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [X] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/