### PR TITLE
BIGTOP-3669. Use maven instead of ant to build ZooKeeper.

### DIFF
--- a/bigtop-packages/src/common/zookeeper/do-component-build
+++ b/bigtop-packages/src/common/zookeeper/do-component-build
@@ -18,10 +18,19 @@ set -ex
 
 . `dirname ${0}`/bigtop.bom
 
-ANT_OPTS="-Dversion=$ZOOKEEPER_VERSION -f build.xml $@"
-sed -i.orig -e 's#test-jar,api-report#test-jar#g' build.xml
-ant compile ${ANT_OPTS}
-ant package package-native tar ${ANT_OPTS}
+mvn clean install -DskipTests -Pfull-build
+(cd zookeeper-contrib/zookeeper-contrib-rest ; mvn dependency:copy-dependencies)
 
-mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.zookeeper -DartifactId=zookeeper -Dversion=$ZOOKEEPER_VERSION -Dpackaging=jar -Dfile=build/zookeeper-$ZOOKEEPER_VERSION.jar -DpomFile=build/zookeeper-$ZOOKEEPER_VERSION/dist-maven/zookeeper-$ZOOKEEPER_VERSION.pom
-mvn install:install-file -DcreateChecksum=true -DgroupId=org.apache.zookeeper -DartifactId=zookeeper -Dversion=$ZOOKEEPER_VERSION -Dclassifier=tests -Dpackaging=jar -Dfile=build/zookeeper-$ZOOKEEPER_VERSION-test.jar -DpomFile=build/zookeeper-$ZOOKEEPER_VERSION/dist-maven/zookeeper-$ZOOKEEPER_VERSION.pom
+mkdir -p build
+(cd build ; tar --strip-components=1 -xzvf  ../zookeeper-assembly/target/apache-zookeeper-${ZOOKEEPER_VERSION}-bin.tar.gz)
+
+mkdir -p build/native
+cp -R zookeeper-client/zookeeper-client-c/target/c/include build/native/
+cp -R zookeeper-client/zookeeper-client-c/target/c/lib build/native/
+cp -R zookeeper-client/zookeeper-client-c/target/c/bin build/native/
+
+mkdir -p build/contrib/rest
+mkdir -p build/contrib/rest/lib
+cp -R zookeeper-contrib/zookeeper-contrib-rest/conf build/contrib/rest/
+cp zookeeper-contrib/zookeeper-contrib-rest/target/zookeeper-contrib-rest-${ZOOKEEPER_VERSION}.jar build/contrib/rest/
+cp zookeeper-contrib/zookeeper-contrib-rest/target/dependency/* build/contrib/rest/lib/

--- a/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
+++ b/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
@@ -117,7 +117,7 @@ cp -r ${BUILD_DIR}/contrib/rest/lib ${PREFIX}/${LIB_DIR}/contrib/rest/
 cp -r ${BUILD_DIR}/contrib/rest/conf/* ${PREFIX}/${CONF_DIST_DIR}/rest/
 
 # Make a symlink of zookeeper.jar to zookeeper-version.jar
-for x in $PREFIX/$LIB_DIR/zookeeper-[:digit:]*.jar ; do
+for x in $PREFIX/$LIB_DIR/zookeeper-[[:digit:]]*.jar ; do
   x=$(basename $x)
   ln -s $x $PREFIX/$LIB_DIR/zookeeper.jar
 done

--- a/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
+++ b/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
@@ -106,17 +106,18 @@ CONF_DIST_DIR=/etc/zookeeper/conf.dist/
 SYSTEM_INCLUDE_DIR=${SYSTEM_INCLUDE_DIR:-/usr/include}
 SYSTEM_LIB_DIR=${SYSTEM_LIB_DIR:-/usr/lib}
 
+tar -z -x -f zookeeper-assembly/target/apache-zookeeper-*-bin.tar.gz
 install -d -m 0755 $PREFIX/$LIB_DIR/
 rm -f $BUILD_DIR/zookeeper-*-javadoc.jar $BUILD_DIR/zookeeper-*-bin.jar $BUILD_DIR/zookeeper-*-sources.jar $BUILD_DIR/zookeeper-*-test.jar
-cp $BUILD_DIR/zookeeper*.jar $PREFIX/$LIB_DIR/
+cp $BUILD_DIR/lib/zookeeper*.jar $PREFIX/$LIB_DIR/
 install -d -m 0755 ${PREFIX}/${LIB_DIR}/contrib/rest
 install -d -m 0755 ${PREFIX}/${CONF_DIST_DIR}/rest
-cp ${BUILD_DIR}/zookeeper-contrib/zookeeper-contrib-rest/zookeeper-*-rest.jar ${PREFIX}/${LIB_DIR}/contrib/rest/
-cp -r ${BUILD_DIR}/zookeeper-contrib/zookeeper-contrib-rest/lib ${PREFIX}/${LIB_DIR}/contrib/rest/
-cp -r ${BUILD_DIR}/zookeeper-contrib/zookeeper-contrib-rest/conf/* ${PREFIX}/${CONF_DIST_DIR}/rest/
+cp ${BUILD_DIR}/contrib/rest/zookeeper-contrib-rest-*.jar ${PREFIX}/${LIB_DIR}/contrib/rest/
+cp -r ${BUILD_DIR}/contrib/rest/lib ${PREFIX}/${LIB_DIR}/contrib/rest/
+cp -r ${BUILD_DIR}/contrib/rest/conf/* ${PREFIX}/${CONF_DIST_DIR}/rest/
 
 # Make a symlink of zookeeper.jar to zookeeper-version.jar
-for x in $PREFIX/$LIB_DIR/zookeeper*jar ; do
+for x in $PREFIX/$LIB_DIR/zookeeper-[:digit:]*.jar ; do
   x=$(basename $x)
   ln -s $x $PREFIX/$LIB_DIR/zookeeper.jar
 done
@@ -196,11 +197,9 @@ install -d ${PREFIX}/$SYSTEM_INCLUDE_DIR
 install -d ${PREFIX}/$SYSTEM_LIB_DIR
 install -d ${PREFIX}/${LIB_DIR}-native
 
-mkdir ${BUILD_DIR}/../native
-(cd ${BUILD_DIR}/../native && tar xzf ../zookeeper-*-lib.tar.gz)
-cp -R ${BUILD_DIR}/../native/include/* ${PREFIX}/${SYSTEM_INCLUDE_DIR}/
-cp -R ${BUILD_DIR}/../native/lib*/* ${PREFIX}/${SYSTEM_LIB_DIR}/
-cp -R ${BUILD_DIR}/../native/bin/* ${PREFIX}/${LIB_DIR}-native/
+cp -R ${BUILD_DIR}/native/include/* ${PREFIX}/${SYSTEM_INCLUDE_DIR}/
+cp -R ${BUILD_DIR}/native/lib*/* ${PREFIX}/${SYSTEM_LIB_DIR}/
+cp -R ${BUILD_DIR}/native/bin/* ${PREFIX}/${LIB_DIR}-native/
 for binary in ${PREFIX}/${LIB_DIR}-native/*; do
   cat > ${PREFIX}/${BIN_DIR}/`basename ${binary}` <<EOF
 #!/bin/bash

--- a/bigtop-packages/src/deb/zookeeper/rules
+++ b/bigtop-packages/src/deb/zookeeper/rules
@@ -36,7 +36,7 @@ override_dh_auto_build:
 override_dh_auto_install:
 	cp debian/zookeeper.1 debian/zoo.cfg debian/zookeeper.default .
 	bash -x debian/install_zookeeper.sh \
-	  --build-dir=build/zookeeper-${ZOOKEEPER_BASE_VERSION} \
+	  --build-dir=build \
 	  --prefix=debian/$(zookeeper_pkg_name)
 	   # Move native files to a dedicated package
 	   mkdir -p debian/zookeeper-native/usr/bin

--- a/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
+++ b/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
@@ -154,7 +154,7 @@ bash %{SOURCE1}
 %__rm -rf $RPM_BUILD_ROOT
 cp $RPM_SOURCE_DIR/zookeeper.1 $RPM_SOURCE_DIR/zoo.cfg $RPM_SOURCE_DIR/zookeeper.default .
 bash %{SOURCE2} \
-          --build-dir=build/%{name}-%{zookeeper_base_version} \
+          --build-dir=build \
           --doc-dir=%{doc_zookeeper} \
           --prefix=$RPM_BUILD_ROOT \
           --system-include-dir=%{_includedir} \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3669

There is no way to create binary tarball of zookeeper-rest. I used `mvn dependency:copy-dependencies` to collect dependencies on our own.