### PR TITLE
BIGTOP-3678. Building Zeppelin fails due to dependency convergence error.

### DIFF
--- a/bigtop-packages/src/common/zeppelin/patch0-exclude-conflicting-packages.diff
+++ b/bigtop-packages/src/common/zeppelin/patch0-exclude-conflicting-packages.diff
@@ -1,0 +1,79 @@
+diff --git a/zeppelin-interpreter/pom.xml b/zeppelin-interpreter/pom.xml
+index a7b36c92b..f866e33e5 100644
+--- a/zeppelin-interpreter/pom.xml
++++ b/zeppelin-interpreter/pom.xml
+@@ -62,6 +62,10 @@
+           <groupId>org.apache.commons</groupId>
+           <artifactId>commons-lang3</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>org.ow2.asm</groupId>
++          <artifactId>asm</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+ 
+@@ -209,6 +213,12 @@
+       <artifactId>hadoop-client</artifactId>
+       <!-- Should always use provided, yarn container (YarnInterpreterLauncher) will provide all the hadoop jars -->
+       <scope>provided</scope>
++      <exclusions>
++        <exclusion>
++          <groupId>org.codehaus.woodstox</groupId>
++          <artifactId>stax2-api</artifactId>
++        </exclusion>
++      </exclusions>
+     </dependency>
+ 
+     <dependency>
+diff --git a/zeppelin-plugins/notebookrepo/filesystem/pom.xml b/zeppelin-plugins/notebookrepo/filesystem/pom.xml
+index 5c645738e..f5cb1d579 100644
+--- a/zeppelin-plugins/notebookrepo/filesystem/pom.xml
++++ b/zeppelin-plugins/notebookrepo/filesystem/pom.xml
+@@ -42,6 +42,12 @@
+         <dependency>
+             <groupId>org.apache.hadoop</groupId>
+             <artifactId>hadoop-client</artifactId>
++            <exclusions>
++                <exclusion>
++                    <groupId>org.codehaus.woodstox</groupId>
++                    <artifactId>stax2-api</artifactId>
++                </exclusion>
++            </exclusions>
+         </dependency>
+     </dependencies>
+
+diff --git a/zeppelin-server/pom.xml b/zeppelin-server/pom.xml
+index f719b9b65..f84f3e384 100644
+--- a/zeppelin-server/pom.xml
++++ b/zeppelin-server/pom.xml
+@@ -298,6 +298,12 @@
+       <artifactId>hadoop-common</artifactId>
+       <classifier>tests</classifier>
+       <scope>test</scope>
++      <exclusions>
++        <exclusion>
++          <groupId>org.codehaus.woodstox</groupId>
++          <artifactId>stax2-api</artifactId>
++        </exclusion>
++      </exclusions>
+     </dependency>
+ 
+     <dependency>
+diff --git a/zeppelin-zengine/pom.xml b/zeppelin-zengine/pom.xml
+index b8c1be2f5..82b7e7171 100644
+--- a/zeppelin-zengine/pom.xml
++++ b/zeppelin-zengine/pom.xml
+@@ -218,6 +218,12 @@
+     <dependency>
+       <groupId>org.apache.hadoop</groupId>
+       <artifactId>hadoop-client</artifactId>
++      <exclusions>
++        <exclusion>
++          <groupId>org.codehaus.woodstox</groupId>
++          <artifactId>stax2-api</artifactId>
++        </exclusion>
++      </exclusions>
+     </dependency>
+ 
+     <dependency>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR is for addressing [BIGTOP-3678](https://issues.apache.org/jira/browse/BIGTOP-3678).

### How was this patch tested?

Ran `./gradlew zeppelin-clean zeppelin-pkg` locally and ensured it succeeded.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/