### PR TITLE
BIGTOP-3677 (addendum). Building HBase for CentOS 7 on arm64 and ppc64le fails due to missing libraries.

### DIFF
--- a/bigtop-packages/src/common/zeppelin/do-component-build
+++ b/bigtop-packages/src/common/zeppelin/do-component-build
@@ -47,7 +47,7 @@ BUILD_OPTS="-Dhadoop3.2.version=${HADOOP_VERSION} \
 
 if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=3.5.0 \
-      -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-3.5.1.1/bin/protoc
+      -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-3.17.3/bin/protoc
   
   mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.28.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/src/grpc-java-1.28.0/compiler/build/exe/java_plugin/protoc-gen-grpc-java
 sed -i "s|<node.version>v12.3.1</node.version>|<node.version>v12.22.1</node.version>|" pom.xml

--- a/bigtop_toolchain/manifests/grpc.pp
+++ b/bigtop_toolchain/manifests/grpc.pp
@@ -19,8 +19,8 @@ class bigtop_toolchain::grpc {
   require bigtop_toolchain::protobuf
 
   $grpc_version = '1.28.0'
-  $proto_version = '3.5.1.1'
-  $proto_home = "/usr/local/protobuf-3.5.1.1"
+  $proto_version = '3.17.3'
+  $proto_home = "/usr/local/protobuf-3.17.3"
 
   if ($architecture == 'ppc64le') {
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

#896 upgraded the protobuf version to 3.17.3, so we have to use it to build gRPC and Zeppelin.

### How was this patch tested?

Confirmed that the followings succeeded on ppc64le:

* Building the toolchain image with this PR
* Building Alluxio and Zeppelin with that image

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/