### PR TITLE
BIGTOP-3679. Building Phoenix for CentOS 7 fails on aarch64.

### DIFF
--- a/bigtop-packages/src/common/phoenix/do-component-build
+++ b/bigtop-packages/src/common/phoenix/do-component-build
@@ -17,20 +17,24 @@
 set -ex
 . `dirname $0`/bigtop.bom
 
+MVN_ARGS="-DskipTests "
+MVN_ARGS+="-Dhadoop.version=$HADOOP_VERSION "
+MVN_ARGS+="-Dhbase.version=$HBASE_VERSION "
+MVN_ARGS+="-Dhbase.profile=${HBASE_VERSION%.*} "
+
 # create com.google.protobuf:protoc artifact with local protoc built by toolchain
 if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
             -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/bin/protoc
+  MVN_ARGS+="-Dprotobuf.group=com.google.protobuf -Dprotoc.version=2.5.0 "
 elif [ $HOSTTYPE = "aarch64" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
             -Dclassifier=linux-aarch_64 -Dpackaging=exe -Dfile=/usr/local/bin/protoc
+  MVN_ARGS+="-Dprotobuf.group=com.google.protobuf -Dprotoc.version=2.5.0 "
 fi
 
-mvn -DskipTests \
-    -Dhadoop.version=$HADOOP_VERSION  \
-    -Dhbase.version=$HBASE_VERSION  \
-    -Dhbase.profile=${HBASE_VERSION%.*} \
-    clean install "$@"
+mvn ${MVN_ARGS} clean install "$@"
+
 rm -rf build
 mkdir build
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3679

protoc provided by org.openlabtesting.protobuf is not portable enough. We should use our own patched protoc.