### PR TITLE
BIGTOP-3682: Failed to build sqoop for Debian 11 on Arm64

### DIFF
--- a/bigtop-packages/src/common/sqoop/do-component-build
+++ b/bigtop-packages/src/common/sqoop/do-component-build
@@ -17,6 +17,9 @@
 set -ex
 . `dirname ${0}`/bigtop.bom
 
+# BIGTOP-3682: Cannot run program "python" No such file or directory.
+sudo ln -s /usr/bin/python2.7 /usr/bin/python
+
 ant -f build.xml \
   -Dhadoop.version=$HADOOP_VERSION \
   -Dhbase.version=$HBASE_VERSION \


### PR DESCRIPTION
Failed to build: Cannot run program "python" No such file or directory.


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
This PR is to fix build issue of sqoop for Debian 11 on Arm64, which is described in BIGTOP-3682.

### How was this patch tested?
Successfully build on Arm64 Debian 11.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/