### PR TITLE
BIGTOP-3685: make docker-provisioner to be used both in docker-compose v1 and v2

### DIFF
--- a/provisioner/docker/docker-compose-cgroupv2.yml
+++ b/provisioner/docker/docker-compose-cgroupv2.yml
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bigtop:
+services:
+  bigtop:
     image: ${DOCKER_IMAGE}
     command: /sbin/init
     domainname: bigtop.apache.org

--- a/provisioner/docker/docker-compose-cgroupv2.yml
+++ b/provisioner/docker/docker-compose-cgroupv2.yml
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 services:
-  bigtop:
-    image: ${DOCKER_IMAGE}
-    command: /sbin/init
-    domainname: bigtop.apache.org
-    privileged: true
-    mem_limit: ${MEM_LIMIT}
-    volumes:
-    - ../../:/bigtop-home
-    - ./config/hiera.yaml:/etc/puppet/hiera.yaml
-    - ./config/hieradata:/etc/puppet/hieradata
-    - ./config/hosts:/etc/hosts
+    bigtop:
+        image: ${DOCKER_IMAGE}
+        command: /sbin/init
+        domainname: bigtop.apache.org
+        privileged: true
+        mem_limit: ${MEM_LIMIT}
+        volumes:
+        - ../../:/bigtop-home
+        - ./config/hiera.yaml:/etc/puppet/hiera.yaml
+        - ./config/hieradata:/etc/puppet/hieradata
+        - ./config/hosts:/etc/hosts

--- a/provisioner/docker/docker-compose.yml
+++ b/provisioner/docker/docker-compose.yml
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bigtop:
+services:
+  bigtop:
     image: ${DOCKER_IMAGE}
     command: /sbin/init
     domainname: bigtop.apache.org

--- a/provisioner/docker/docker-compose.yml
+++ b/provisioner/docker/docker-compose.yml
@@ -14,15 +14,15 @@
 # limitations under the License.
 
 services:
-  bigtop:
-    image: ${DOCKER_IMAGE}
-    command: /sbin/init
-    domainname: bigtop.apache.org
-    privileged: true
-    mem_limit: ${MEM_LIMIT}
-    volumes:
-    - ../../:/bigtop-home
-    - ./config/hiera.yaml:/etc/puppet/hiera.yaml
-    - ./config/hieradata:/etc/puppet/hieradata
-    - ./config/hosts:/etc/hosts
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    bigtop:
+        image: ${DOCKER_IMAGE}
+        command: /sbin/init
+        domainname: bigtop.apache.org
+        privileged: true
+        mem_limit: ${MEM_LIMIT}
+        volumes:
+        - ../../:/bigtop-home
+        - ./config/hiera.yaml:/etc/puppet/hiera.yaml
+        - ./config/hieradata:/etc/puppet/hieradata
+        - ./config/hosts:/etc/hosts
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -128,7 +128,7 @@ create() {
 generate-hosts() {
     get_nodes
     for node in ${NODES[*]}; do
-        entry=`docker inspect --format "{{.NetworkSettings.IPAddress}} {{.Config.Hostname}}.{{.Config.Domainname}} {{.Config.Hostname}}" $node`
+        entry=`docker inspect --format "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}} {{.Config.Hostname}}.{{.Config.Domainname}} {{.Config.Hostname}}" $node`
         docker exec ${NODES[0]} bash -c "echo $entry >> /etc/hosts"
     done
     wait
@@ -141,7 +141,7 @@ generate-config() {
     # add ip of all nodes to config
     get_nodes
     for node in ${NODES[*]}; do
-        this_node_ip=`docker inspect --format "{{.NetworkSettings.IPAddress}}" $node`
+        this_node_ip=`docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $node`
         node_list="$node_list$this_node_ip "
     done
     node_list=$(echo "$node_list" | xargs | sed 's/ /, /g')
@@ -405,7 +405,7 @@ while [ $# -gt 0 ]; do
         shift 2;;
     -n|--nexus)
         if [ $# -lt 2 ] || [[ $2 == -* ]]; then
-            NEXUS_IP=`docker inspect --format "{{.NetworkSettings.IPAddress}}" nexus`
+            NEXUS_IP=`docker inspect --format "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" nexus`
             if [ $? != 0 ]; then
                 log "No container named nexus exists. To create one:\n $ docker run -d --name nexus sonatype/nexus"
                 exit 1

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -53,7 +53,7 @@ create() {
         log "Cluster already exist! Run ./$PROG -d to destroy the cluster or delete .provision_id file and containers manually."
         exit 1;
     fi
-    echo "`date +'%Y%m%d_%H%M%S'`_R$RANDOM" > .provision_id
+    echo "`date +'%Y%m%d_%H%M%S'`_r$RANDOM" > .provision_id
     PROVISION_ID=`cat .provision_id`
     # Create a shared /etc/hosts and hiera.yaml that will be both mounted to each container soon
     mkdir -p config/hieradata 2> /dev/null


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Currently docker-provisioner could not used in docker-compose v2.
This PR
- Add `services` level to docker-compose.yml.
  Bigtop is still using deprecated format v1.
  https://docs.docker.com/compose/compose-file/compose-versioning/#version-1-deprecated
  (It is complicated, about yaml format, there are v1, v2, and v3, and v1 is now deprecated.)
  By adding `services` level, we can use the provisioner both in v1 and v2.
- Fix provision_id's name.
  docker-compose v2 seems case sensitive when using -p option.

### How was this patch tested?
Check that `./gradlew docker-provisioner` get succeeded in docker-compose `v1.29.2` and `v2.4.0`.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/