### PR TITLE
BIGTOP-3693: Update the Docker Version

### DIFF
--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -273,8 +273,8 @@ env-check() {
     echo "Environment check..."
     echo "Check docker:"
     docker -v || exit 1
-    echo "Check docker-compose:"
-    $DOCKER_COMPOSE_CMD -v || exit 1
+    echo "Check docker compose:"
+    $DOCKER_COMPOSE_CMD version || exit 1
     echo "Check ruby:"
     ruby -v || exit 1
 }
@@ -314,7 +314,7 @@ if [ $# -eq 0 ]; then
 fi
 
 yamlconf="config.yaml"
-DOCKER_COMPOSE_CMD="docker-compose"
+DOCKER_COMPOSE_CMD="docker compose"
 
 BIGTOP_PUPPET_DIR=../../bigtop-deploy/puppet
 if [ -e .provision_id ]; then


### PR DESCRIPTION
### Description of PR
The lastest version docker has many useful features, such as docker-compose become a plugin and not need to install individually. So I submit the patch to improve it.

### How was this patch tested?
1. build bigtop docker images
```shell
cd $BIGTOP_HOME/docker/bigtop-puppet
for i in trunk-centos-7 trunk-centos-8 trunk-rockylinux-8 trunk-fedora-35 \
         trunk-debian-10 trunk-debian-11 \
         trunk-ubuntu-18.04 trunk-ubuntu-20.04; do 
  ./build.sh $i 
done

```
2. create bigtop docker container 
```shell
cd $BIGTOP_HOME/provisioner/docker
./docker-hadoop.sh -c 1
```
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/