### PR TITLE
BIGTOP-3701: Remove deprecated Hadoop fs-image after uninstalling HDF namenode

### DIFF
--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -652,6 +652,13 @@ if [ "$1" = 0 ]; then
   %{alternatives_cmd} --remove %{name}-conf %{etc_hadoop}/conf.empty || :
 fi
 
+%preun hdfs
+if [ $1 = 0 ]; then
+  if [ -d "/hadoop/hdfs" ]; then
+      rm -rf /hadoop/hdfs
+  fi
+fi
+
 %preun httpfs
 if [ $1 = 0 ]; then
   service %{name}-httpfs stop > /dev/null 2>&1


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
When uninstalled Hadoop-2.10 and reinstalled Hadoop-3.2, it would fail to format namenode and The user have to restart NameNode with the "-rollingUpgrade started" option if a rolling upgrade is already started; or restart NameNode with the "-upgrade" option to start a new upgrade. 
It would confuse some new BIgtop Hadoop users. 

It's better to remove deprecated Hadoop fs-image file after uninstalling HDFS-namenode when uninstalling package.

### How was this patch tested?
Build Hadoop by Bigtop and install/remove Hadoop package.
```
e.g. :
rpm -e hadoop-hdfs-3.2.3-1.el7.x86_64.rpm
or
rpm -qa | grep hadoop | sudo xargs yum -y remove
```


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/