### PR TITLE
BIGTOP-3705: Refine the Ambari RPM spec to fix warning after rpm uninstallation

### DIFF
--- a/bigtop-packages/src/rpm/ambari/SPECS/ambari.spec
+++ b/bigtop-packages/src/rpm/ambari/SPECS/ambari.spec
@@ -199,7 +199,11 @@ if [ "$1" -eq 0 ]; then  # Action is uninstall
         rm /usr/sbin/ambari-server
     fi
 
-    mv /etc/ambari-server/conf /etc/ambari-server/conf.save
+    if [ -d "/etc/ambari-server/conf" ]; then
+        # Save conf files here instead of '%config'(auto generating xxx.rpmsave)
+        # '/etc/ambari-server/conf' would be auto-removed in '%files'
+        cp -rp /etc/ambari-server/conf /etc/ambari-server/conf.save
+    fi
 
     if [ -f "/var/lib/ambari-server/install-helper.sh" ]; then
       /var/lib/ambari-server/install-helper.sh remove
@@ -391,7 +395,10 @@ if [ "$1" -eq 0 ]; then  # Action is uninstall
     if [ -d "/etc/ambari-agent/conf.save" ]; then
         mv /etc/ambari-agent/conf.save /etc/ambari-agent/conf_$(date '+%d_%m_%y_%H_%M').save
     fi
-    mv /etc/ambari-agent/conf /etc/ambari-agent/conf.save
+
+    if [ -d "/etc/ambari-agent/conf" ]; then
+        cp -rp /etc/ambari-agent/conf /etc/ambari-agent/conf.save
+    fi
 
     if [ -f "/var/lib/ambari-agent/install-helper.sh" ]; then
       /var/lib/ambari-agent/install-helper.sh remove
@@ -453,7 +460,7 @@ exit 0
 %attr(755,root,root) %{initd_dir}/ambari-server
 /var/lib/ambari-server
 %attr(755,root,root) /var/lib/ambari-server/ambari-python-wrap
-%config  /etc/ambari-server/conf
+/etc/ambari-server/conf
 %config %attr(700,root,root) /var/lib/ambari-server//ambari-env.sh
 %attr(700,root,root) /var/lib/ambari-server//ambari-sudo.sh
 %attr(700,root,root) /var/lib/ambari-server//install-helper.sh
@@ -481,6 +488,7 @@ exit 0
 %attr(755,root,root) /usr/lib/ambari-agent/lib/ambari_jinja2
 %attr(755,root,root) /usr/lib/ambari-agent/lib/ambari_simplejson
 %attr(755,root,root) /usr/lib/ambari-agent/lib/examples
+/etc/ambari-agent/conf
 %attr(755,root,root) /etc/ambari-agent/conf/ambari-agent.ini
 %attr(755,root,root) /etc/ambari-agent/conf/logging.conf.sample
 %attr(755,root,root) /var/lib/ambari-agent/bin/ambari-agent 


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Duplicated deleting operation ('%files' and '%preun%') in Ambari RPM spec makes some warning issues when uninstalling Ambari rpm.
```
cp: cannot stat ‘/etc/ambari-server/conf’: No such file or directory
....
..
warning: file /etc/ambari-server/conf/metrics.properties: remove failed: No such file or directory
warning: file /etc/ambari-server/conf/log4j.properties: remove failed: No such file or directory
warning: file /etc/ambari-server/conf/krb5JAASLogin.conf: remove failed: No such file or directory
warning: file /etc/ambari-server/conf/ambari.properties: remove failed: No such file or directory
warning: file /etc/ambari-server/conf: remove failed: No such file or directory
.....
cp: cannot stat ‘/etc/ambari-agent/conf’: No such file or directory
warning: file /etc/ambari-agent/conf/logging.conf.sample: remove failed: No such file or directory
warning: file /etc/ambari-agent/conf/ambari-agent.ini: remove failed: No such file or directory
warning: file /etc/ambari-agent/conf: remove failed: No such file or directory

```

And remove '%config' (auto generating xxx.rpmsave); 
`/etc/ambari-server/conf` and `/etc/ambari-agent/conf` would be auto-removed in '%files'


### How was this patch tested?
Install Ambari rpms and uninstall them.

No warning there.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/