### PR TITLE
BIGTOP-3707: Update latest repo url for Provisioner docker yamls

### DIFF
--- a/provisioner/docker/config_centos-7.yaml
+++ b/provisioner/docker/config_centos-7.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-centos-7"
 
-repo: "http://repos.bigtop.apache.org/releases/3.0.0/centos/7/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/centos/7/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_debian-10.yaml
+++ b/provisioner/docker/config_debian-10.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-debian-10"
 
-repo: "http://repos.bigtop.apache.org/releases/3.0.0/debian/10/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/debian/10/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_debian-11.yaml
+++ b/provisioner/docker/config_debian-11.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-debian-11"
 
-repo: "http://repos.bigtop.apache.org/releases/3.0.0/debian/11/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/debian/11/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_rockylinux-8.yaml
+++ b/provisioner/docker/config_rockylinux-8.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-rockylinux-8"
 
-repo: "http://repos.bigtop.apache.org/releases/3.0.0/centos/8/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/centos/8/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_ubuntu-18.04.yaml
+++ b/provisioner/docker/config_ubuntu-18.04.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image:  "bigtop/puppet:trunk-ubuntu-18.04"
 
-repo: "http://repos.bigtop.apache.org/releases/3.0.0/ubuntu/18.04/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/ubuntu/18.04/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_ubuntu-20.04.yaml
+++ b/provisioner/docker/config_ubuntu-20.04.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image:  "bigtop/puppet:trunk-ubuntu-20.04"
 
-repo: "http://repos.bigtop.apache.org/releases/3.0.0/ubuntu/20.04/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/ubuntu/20.04/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false


### PR DESCRIPTION
Update the latest repo url of 3.1.0 release for provisioner docker Distros yamls.