### PR TITLE
BIGTOP-3711: Add read/write smoke tests for Kafka

### DIFF
--- a/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
+++ b/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
@@ -18,17 +18,18 @@
 
 package org.apache.bigtop.itest.kafka
 
-import org.junit.BeforeClass
-import org.junit.AfterClass
-import org.apache.bigtop.itest.shell.Shell
-import static org.junit.Assert.assertNotNull
-import static org.junit.Assert.assertTrue
-import org.junit.Test
 import org.apache.bigtop.itest.JarContent
 import org.apache.bigtop.itest.TestUtils
+import org.apache.bigtop.itest.shell.Shell
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.FixMethodOrder
+import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.MethodSorters;
-import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters
+
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
 
 @FixMethodOrder (MethodSorters.NAME_ASCENDING)
 class TestKafkaSmoke {

--- a/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
+++ b/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
@@ -27,12 +27,18 @@ import org.junit.Test
 import org.apache.bigtop.itest.JarContent
 import org.apache.bigtop.itest.TestUtils
 import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters;
+import org.junit.FixMethodOrder;
 
+@FixMethodOrder (MethodSorters.NAME_ASCENDING)
 class TestKafkaSmoke {
   static Shell sh = new Shell("/bin/bash -s");
 
   static final String KAFKA_HOME = "/usr/lib/kafka"
   static final String KAFKA_TOPICS = KAFKA_HOME + "/bin/kafka-topics.sh "
+  static final String KAFKA_PRODUCER = KAFKA_HOME + "/bin/kafka-console-producer.sh"
+  static final String KAFKA_CONSUMER = KAFKA_HOME + "/bin/kafka-console-consumer.sh"
+  static final String TEST_MESSAGE = "Hello Bigtop"
 
   @AfterClass
   public static void deleteKafkaTopics() {
@@ -44,9 +50,27 @@ class TestKafkaSmoke {
   }
 
   @Test
-  public void testCreateTopics() {
+  public void test0CreateTopics() {
     sh.exec(KAFKA_TOPICS + " --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test");
     sh.exec(KAFKA_TOPICS + " --list --zookeeper localhost:2181");
     assertTrue(" Create Kafka topics failed. " + sh.getOut() + " " + sh.getErr(), sh.getRet() == 0);
+  }
+
+  @Test
+  public void test1WriteKafkaTopics() {
+    sh.exec("echo '" + TEST_MESSAGE + "' | " + KAFKA_PRODUCER + " --broker-list localhost:9092 --topic test");
+    assertTrue(
+      " Write Kafka topics failed. " + sh.getOut() + " " + sh.getErr(),
+      sh.getRet() == 0
+    );
+  }
+
+  @Test
+  public void test2ReadKafkaTopics() {
+    sh.exec(KAFKA_CONSUMER + " --bootstrap-server localhost:9092 --topic test --partition 0 --offset 0 --max-messages 1");
+    assertTrue(
+      " Read Kafka topics failed. " + sh.getOut() + " " + sh.getErr(),
+      sh.getOut() == [TEST_MESSAGE]
+    );
   }
 }

--- a/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
+++ b/bigtop-tests/smoke-tests/kafka/TestKafkaSmoke.groovy
@@ -68,7 +68,8 @@ class TestKafkaSmoke {
 
   @Test
   public void test2ReadKafkaTopics() {
-    sh.exec(KAFKA_CONSUMER + " --bootstrap-server localhost:9092 --topic test --partition 0 --offset 0 --max-messages 1");
+    sh.exec(KAFKA_CONSUMER + " --bootstrap-server localhost:9092 --topic test \
+            --partition 0 --offset 0 --max-messages 1 --timeout-ms 10000");
     assertTrue(
       " Read Kafka topics failed. " + sh.getOut() + " " + sh.getErr(),
       sh.getOut() == [TEST_MESSAGE]


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR adds read/write tests for an Kafka topic to improve the test coverage.
- Add a write test using `kafka-console-producer.sh`.
- Add a read test using `kafka-console-consumer.sh`. This test try to read the message written by the write test above.

### How was this patch tested?

```sh
./docker-hadoop.sh -d   -C config_ubuntu-20.04.yaml   --create 3   --memory 8g   --disable-gpg-check   --stack zookeeper,kafka   --smoke-tests kafka
``` 
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/