### PR TITLE
BIGTOP-3712: Fix Kafka smoke test failure with Zookeeper built with maven

### DIFF
--- a/bigtop-packages/src/common/kafka/install_kafka.sh
+++ b/bigtop-packages/src/common/kafka/install_kafka.sh
@@ -89,6 +89,10 @@ for var in PREFIX BUILD_DIR SOURCE_DIR; do
   fi
 done
 
+if [ -f "$SOURCE_DIR/bigtop.bom" ]; then
+  . $SOURCE_DIR/bigtop.bom
+fi
+
 MAN_DIR=${MAN_DIR:-/usr/share/man/man1}
 DOC_DIR=${DOC_DIR:-/usr/share/doc/kafka}
 LIB_DIR=${LIB_DIR:-/usr/lib/kafka}
@@ -163,6 +167,9 @@ ln -s /var/log/kafka ${PREFIX}/$LIB_DIR/logs
 # Removing zookeeper*.jar from under libs and dropping a symlink in place
 rm -f ${PREFIX}/${LIB_DIR}/libs/zookeeper-*.jar
 ln -sf /usr/lib/zookeeper/zookeeper.jar ${PREFIX}/${LIB_DIR}/libs/
+
+# BIGTOP-3712
+ln -s /usr/lib/zookeeper/zookeeper-jute-${ZOOKEEPER_VERSION}.jar ${PREFIX}/${LIB_DIR}/libs/
 
 # Copy in the defaults file
 install -d -m 0755 ${PREFIX}/etc/default


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
As I reported on JIRA(https://issues.apache.org/jira/browse/BIGTOP-3712), building Zookeeper with maven separates `zookeeper-jute` jar file from zookeeper itself.
This PR adds symlink to `zookeeper-jute` when you packages Kafka.

### How was this patch tested?

```sh
./gradlew zookeeper-clean kafka-clean zookeeper-pkg kafka-pkg repo
./docker-hadoop.sh -d   -C config_ubuntu-20.04.yaml   --create 1   --memory 8g   --enable-local-repo   --repo file:///bigtop-home/output/apt   --disable-gpg-check   --stack zookeeper,kafka   --smoke-tests kafka
```
### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/