### PR TITLE
BIGTOP-3714. Fix error of DataNode httpserver due to conflicting dependency on Netty in branch-3.1.

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch0-exclude-netty-from-zookeeper.diff
+++ b/bigtop-packages/src/common/hadoop/patch0-exclude-netty-from-zookeeper.diff
@@ -1,0 +1,34 @@
+diff --git a/hadoop-project/pom.xml b/hadoop-project/pom.xml
+index ce2a268..d1da396 100644
+--- a/hadoop-project/pom.xml
++++ b/hadoop-project/pom.xml
+@@ -1192,6 +1192,14 @@
+             <groupId>jline</groupId>
+             <artifactId>jline</artifactId>
+           </exclusion>
++          <exclusion>
++            <groupId>io.netty</groupId>
++            <artifactId>netty-handler</artifactId>
++          </exclusion>
++          <exclusion>
++            <groupId>io.netty</groupId>
++            <artifactId>netty-transport-native-epoll</artifactId>
++          </exclusion>
+         </exclusions>
+       </dependency>
+       <dependency>
+@@ -1208,6 +1216,14 @@
+             <groupId>jline</groupId>
+             <artifactId>jline</artifactId>
+           </exclusion>
++          <exclusion>
++            <groupId>io.netty</groupId>
++            <artifactId>netty-handler</artifactId>
++          </exclusion>
++          <exclusion>
++            <groupId>io.netty</groupId>
++            <artifactId>netty-transport-native-epoll</artifactId>
++          </exclusion>
+         </exclusions>
+       </dependency>
+       <dependency>

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -145,7 +145,7 @@ bigtop {
     'hadoop' {
       name    = 'hadoop'
       relNotes = 'Apache Hadoop'
-      version { base = '3.2.3'; pkg = base; release = 1 }
+      version { base = '3.2.3'; pkg = base; release = 2 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/common/$name-${version.base}"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3714

Multiple versions of Netty 4 jars are exists on classpath. This breaks http server of DataNode. Excluding Netty from transitive dependency of ZooKeeper should fix this.