### PR TITLE
BIGTOP-3717: Update MapReduce service configuration in Mpack

### DIFF
--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/configuration-mapred/mapred-env.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/configuration-mapred/mapred-env.xml
@@ -90,18 +90,18 @@
     <display-name>mapred-env template</display-name>
     <description>This is the jinja template for mapred-env.sh file</description>
     <value>
-# export JAVA_HOME=/home/y/libexec/jdk1.6.0/
 
 export HADOOP_JOB_HISTORYSERVER_HEAPSIZE={{jobhistory_heapsize}}
 
-export HADOOP_MAPRED_ROOT_LOGGER=INFO,RFA
+export HADOOP_ROOT_LOGGER=INFO,RFA
 
-#export HADOOP_JOB_HISTORYSERVER_OPTS=
-#export HADOOP_MAPRED_LOG_DIR="" # Where log files are stored.  $HADOOP_MAPRED_HOME/logs by default.
+# Could be enabled from deployment option if necessary
+#export MAPRED_HISTORYSERVER_OPTS=
+#export HADOOP_LOG_DIR="" # Where log files are stored.  $HADOOP_MAPRED_HOME/logs by default.
 #export HADOOP_JHS_LOGGER=INFO,RFA # Hadoop JobSummary logger.
-#export HADOOP_MAPRED_PID_DIR= # The pid files are stored. /tmp by default.
-#export HADOOP_MAPRED_IDENT_STRING= #A string representing this instance of hadoop. $USER by default
-#export HADOOP_MAPRED_NICENESS= #The scheduling priority for daemons. Defaults to 0.
+#export HADOOP_PID_DIR= # The pid files are stored. /tmp by default.
+#export HADOOP_IDENT_STRING= #A string representing this instance of hadoop. $USER by default
+#export HADOOP_NICENESS= #The scheduling priority for daemons. Defaults to 0.
     </value>
     <value-attributes>
       <type>content</type>


### PR DESCRIPTION
Mapred configuration macros are deprected (HADOOP_MAPRED_ROOT_LOGGER,
HADOOP_JOB_HISTORYSERVER_OPTS, HADOOP_MAPRED_NICENESS, etc.).

Update them in Mpack aligned to
https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/bin/mapred-config.sh#L38-L54

