### PR TITLE
BIGTOP-3724. Increment the release number of ZooKeeper and Kafka.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -130,7 +130,7 @@ bigtop {
       version {
         base  = '3.5.9'
         pkg   = base
-        release = 1
+        release = 2
       }
       tarball {
         source      = "apache-zookeeper-${version.base}.tar.gz"
@@ -291,7 +291,7 @@ bigtop {
     'kafka' {
       name    = 'kafka'
       relNotes = 'Apache Kafka'
-      version { base = '2.8.1'; pkg = base; release = 1 }
+      version { base = '2.8.1'; pkg = base; release = 2 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3712

[BIGTOP-3669](https://issues.apache.org/jira/browse/BIGTOP-3669) and [BIGTOP-3712](https://issues.apache.org/jira/browse/BIGTOP-3712) updated the package contents of ZooKeeper and Kafka within the same version. Release number of them should be incremented.