### PR TITLE
BIGTOP-3725. Puppet 3 is removed from EPEL for CentOS 7.

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -44,7 +44,8 @@ case ${ID}-${VERSION_ID} in
         # BIGTOP-3088: pin puppetlabs-stdlib to 4.12.0 as the one provided by
         # distro (4.25.0) has conflict with puppet<4. Should be removed once
         # puppet in distro is updated.
-        yum -y install hostname curl sudo unzip wget puppet
+        yum -y install hostname curl sudo unzip wget rubygems
+        gem install --bindir /usr/bin --no-ri --no-rdoc json_pure:2.5.1 puppet:3.6.2
         puppet module install puppetlabs-stdlib --version 4.12.0
         ;;
     centos-8*)


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Puppet RPM for CentOS 7 provided in EPEL was apparently removed. This PR is a workaround for it.
https://issues.apache.org/jira/browse/BIGTOP-3725

### How was this patch tested?

I locally ran `./build.sh trunk-centos-7` in docker/bigtop-puppet and then docker/bigtop-slaves, and confirmed both succeeded.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/