### PR TITLE
BIGTOP-3733. Building Logstash fails on Rocky 8

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -53,7 +53,7 @@ case ${ID}-${VERSION_ID} in
     rocky-8*)
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         dnf -y check-update
-        dnf -y install glibc-langpack-en hostname diffutils curl sudo unzip wget puppet 'dnf-command(config-manager)'
+        dnf -y install glibc-langpack-en hostname diffutils curl sudo unzip wget puppet procps-ng 'dnf-command(config-manager)'
         # Install the module in the same way as Fedora 31 and CentOS 7 for compatibility issues.
         puppet module install puppetlabs-stdlib --version 4.12.0
         # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.


### PR DESCRIPTION

Building Logstash fails on Rocky 8.

I add procps-ng package in puppetize.sh for install rvm command.

I tested two steps in my environment as follows...
1. Build docker images in local environment  both bigtop/slaves and bigtop/puppet.
2. Exec Logstash build task.
`./gradlew allclean logstash-pkg-ind -POS=rockylinux-8 -Pprefix=3.1.1`
3. Confirm job completon with "BUILD SUCCESSFUL" message.

