### PR TITLE
BIGTOP-3744. Puppet Deploy Hive on Tez add Resource Resizing Configs

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -180,6 +180,8 @@ hadoop::common::tez_jars: "/usr/lib/tez"
 
 # to enable tez in hive, uncomment the lines below
 # hadoop_hive::common_config::hive_execution_engine: "tez"
+# hadoop_hive::common_config::hive_tez_container_size: 1024
+# hadoop_hive::common_config::hive_tez_cpu_vcores: 1
 
 #kafka
 kafka::server::port: "9092"

--- a/bigtop-deploy/puppet/modules/hadoop_hive/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop_hive/manifests/init.pp
@@ -45,7 +45,9 @@ class hadoop_hive {
     } 
   }
 
-  class common_config ($hbase_master = "",
+  class common_config ($hive_tez_container_size = undef,
+                       $hive_tez_cpu_vcores = undef,
+                       $hbase_master = "",
                        $hbase_zookeeper_quorum = "",
                        $hive_zookeeper_quorum = "",
                        $hive_support_concurrency = false,

--- a/bigtop-deploy/puppet/modules/hadoop_hive/templates/hive-site.xml
+++ b/bigtop-deploy/puppet/modules/hadoop_hive/templates/hive-site.xml
@@ -26,6 +26,20 @@
 
 <!-- Hive Execution Parameters -->
 
+<% if @hive_tez_container_size %>
+<property>
+  <name>hive.tez.container.size</name>
+  <value><%= @hive_tez_container_size %></value>
+</property>
+<% end %>
+
+<% if @hive_tez_cpu_vcores %>
+<property>
+  <name>hive.tez.cpu.vcores</name>
+  <value><%= @hive_tez_cpu_vcores %></value>
+</property>
+<% end %>
+
 <% if @hbase_master != "" %>
 <property>
   <name>hbase.master</name>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
the default hive-on-tez mode config will cause the hive query hang up for a long time. 
![image](https://user-images.githubusercontent.com/49220700/179349829-be86b892-1a68-489e-8fdc-64cff8c0ed14.png)
so I commit the patch to add **hive config hive.tez.cpu.vcores** and **hive.tez.container.size** configurations for hive on tez mode.

### How was this patch tested?
1. enter the $BIGTOP_HOME/provisioner/docker dir, and edit the docker-hadoop.sh, add following config
```shell
hadoop_hive::common_config::hive_execution_engine: "tez"
hadoop::common::use_tez: true
hadoop_hive::common_config::hive_tez_container_size: 1024
hadoop_hive::common_config::hive_tez_cpu_vcores: 1
```
2. edit the config.yaml
```yaml
docker:
        memory_limit: "4g"
        image: "bigtop/puppet:trunk-centos-7"

repo: "http://repos.bigtop.apache.org/releases/3.1.0/centos/7/$basearch"
distro: centos
components: [hdfs, yarn, mapreduce,hive, tez]
enable_local_repo: false
smoke_test_components: [hdfs, yarn, mapreduce, hive]
```
3. create bigtop hadoop containner
```shell
./docker-hadoop.sh -d -c 1
./docker-hadoop.sh --exec 1 /bin/bash
```
4. create some hive table for test.
```sql
create database tmp;
create table tmp.students(id string, name string);
insert overwrite table tmp.students select '001', 'vivostar'
```
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/