### PR TITLE
BIGTOP-3747. zeppelin includes plugins directory

### DIFF
--- a/bigtop-packages/src/common/zeppelin/install_zeppelin.sh
+++ b/bigtop-packages/src/common/zeppelin/install_zeppelin.sh
@@ -106,6 +106,7 @@ CONF_DIR=${CONF_DIR:-/etc/zeppelin/conf.dist}
 install -d -m 0755 $PREFIX/$LIB_DIR
 install -d -m 0755 $PREFIX/$LIB_DIR/bin
 install -d -m 0755 $PREFIX/$LIB_DIR/lib
+install -d -m 0755 $PREFIX/$LIB_DIR/plugins
 install -d -m 0755 $PREFIX/$CONF_DIR
 install -d -m 0755 $PREFIX/$DOC_DIR
 

--- a/bigtop-packages/src/common/zeppelin/install_zeppelin.sh
+++ b/bigtop-packages/src/common/zeppelin/install_zeppelin.sh
@@ -116,7 +116,7 @@ install -d -m 0755 $PREFIX/var/log/zeppelin/
 install -d -m 0755 $PREFIX/var/run/zeppelin/
 install -d -m 0755 $PREFIX/var/run/zeppelin/webapps
 
-cp -a ${BUILD_DIR}/build/dist/{bin,interpreter,lib,zeppelin-web-${ZEPPELIN_VERSION}.war} $PREFIX/$LIB_DIR/
+cp -a ${BUILD_DIR}/build/dist/{bin,interpreter,lib,plugins,zeppelin-web-${ZEPPELIN_VERSION}.war} $PREFIX/$LIB_DIR/
 cp -a ${BUILD_DIR}/build/dist/{LICENSE,NOTICE,README.md,licenses} $PREFIX/$DOC_DIR
 cp -a ${BUILD_DIR}/build/dist/conf/* $PREFIX/$CONF_DIR
 cp -a ${BUILD_DIR}/build/dist/notebook $PREFIX/var/lib/zeppelin/

--- a/bigtop-packages/src/rpm/zeppelin/SPECS/zeppelin.spec
+++ b/bigtop-packages/src/rpm/zeppelin/SPECS/zeppelin.spec
@@ -126,6 +126,7 @@ chkconfig --del %{name}
 %doc %{doc_zeppelin}
 %{lib_zeppelin}/*.war
 %{lib_zeppelin}/bin
+%{lib_zeppelin}/plugins
 %{lib_zeppelin}/conf
 %{lib_zeppelin}/interpreter
 %{lib_zeppelin}/lib


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Zeppelin home directory should include plugins directory. Current Bigtop zeppelin spec file and install_zeppelin.sh file does not specify plugins directory 

Build will be successful and rpm file will be generated without any error even if there is no specification about plugins directory.

However when you install rpm and run zeppelin notebook, you will see Logs Like below

```java
...
 WARN [2022-07-18 10:29:36,366] ({ImmediateThread-1658107775074} PluginManager.java[getPluginClassLoader]:192) - PluginFolder /usr/nch/current/zeppelin-server/plugins/NotebookRepo/FileSystemNotebookRepo doesn't exist or is not a directory
...
ERROR [2022-07-18 10:29:38,364] ({main} ZeppelinServer.java[main]:262) - Error while running jettyServer
java.lang.Exception: A MultiException has 2 exceptions.  They are:
1. java.lang.NullPointerException
2. java.lang.IllegalStateException: Unable to perform operation: create on org.apache.zeppelin.notebook.repo.NotebookRepoSync

        at org.apache.zeppelin.server.ZeppelinServer.main(ZeppelinServer.java:256)
Caused by: A MultiException has 2 exceptions.  They are:
1. java.lang.NullPointerException
2. java.lang.IllegalStateException: Unable to perform operation: create on org.apache.zeppelin.notebook.repo.NotebookRepoSync

        at org.jvnet.hk2.internal.ClazzCreator.create(ClazzCreator.java:368)
        at org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:463)
        at org.glassfish.hk2.utilities.ImmediateContext.findOrCreate(ImmediateContext.java:111)
        at org.jvnet.hk2.internal.Utilities.createService(Utilities.java:2102)
        at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:93)
        at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:67)
        at org.glassfish.hk2.utilities.ImmediateContext.doWork(ImmediateContext.java:290)
        at org.glassfish.hk2.internal.ImmediateHelper.run(ImmediateHelper.java:233)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
        at org.apache.zeppelin.notebook.repo.NotebookRepoSync.init(NotebookRepoSync.java:84)
        at org.apache.zeppelin.notebook.repo.NotebookRepoSync.<init>(NotebookRepoSync.java:63)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.glassfish.hk2.utilities.reflection.ReflectionHelper.makeMe(ReflectionHelper.java:1356)
        at org.jvnet.hk2.internal.ClazzCreator.createMe(ClazzCreator.java:248)
        at org.jvnet.hk2.internal.ClazzCreator.create(ClazzCreator.java:342)
        ... 10 more
...
```

So I put specification of plugins dir to spec file and install_zeppelin.sh

### How was this patch tested?
1. modify spec file and install_zeppelin.sh (install plugins dir and specifying location of plugins dir) 
2. run gradle task
```bash
./gradlew zeppelin-clean zeppelin-pkg
```
3. Check "BUILD SUCCESSFULL" message
<img width="203" alt="image" src="https://user-images.githubusercontent.com/53476980/179494798-1f734898-ad04-4cf2-aa77-5e11d4cd927c.png">

4. Check RPM file list 
```bash
rpm -qlp <ZEPPELIN_RPM> | grep plugins

...
/usr/lib/zeppelin/plugins/NotebookRepo
/usr/lib/zeppelin/plugins/NotebookRepo/AzureNotebookRepo
/usr/lib/zeppelin/plugins/NotebookRepo/AzureNotebookRepo/azure-data-lake-store-sdk-2.1.4.jar
/usr/lib/zeppelin/plugins/NotebookRepo/AzureNotebookRepo/azure-storage-4.0.0.jar
/usr/lib/zeppelin/plugins/NotebookRepo/AzureNotebookRepo/jackson-core-2.7.4.jar
/usr/lib/zeppelin/plugins/NotebookRepo/AzureNotebookRepo/notebookrepo-azure-0.10.0.jar
/usr/lib/zeppelin/plugins/NotebookRepo/AzureNotebookRepo/slf4j-api-1.7.30.jar
/usr/lib/zeppelin/plugins/NotebookRepo/FileSystemNotebookRepo
/usr/lib/zeppelin/plugins/NotebookRepo/FileSystemNotebookRepo/notebookrepo-filesystem-0.10.0.jar
...
```
5. Install rpm and run zeppelin, then check zeppelin log -> checked no error like above

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/