### PR TITLE
BIGTOP-3751. Fix build failure of Zeppelin due to dependency convergence error.

### DIFF
--- a/bigtop-packages/src/common/zeppelin/patch3-exclude-conflicting-dependencies.diff
+++ b/bigtop-packages/src/common/zeppelin/patch3-exclude-conflicting-dependencies.diff
@@ -1,0 +1,109 @@
+diff --git a/zeppelin-interpreter/pom.xml b/zeppelin-interpreter/pom.xml
+index 48ce9aa44..560e7c001 100644
+--- a/zeppelin-interpreter/pom.xml
++++ b/zeppelin-interpreter/pom.xml
+@@ -218,6 +218,14 @@
+           <groupId>org.codehaus.woodstox</groupId>
+           <artifactId>stax2-api</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>org.slf4j</groupId>
++          <artifactId>slf4j-reload4j</artifactId>
++        </exclusion>
++        <exclusion>
++          <groupId>ch.qos.reload4j</groupId>
++          <artifactId>reload4j</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+ 
+diff --git a/zeppelin-plugins/notebookrepo/filesystem/pom.xml b/zeppelin-plugins/notebookrepo/filesystem/pom.xml
+index f5cb1d579..7238bca20 100644
+--- a/zeppelin-plugins/notebookrepo/filesystem/pom.xml
++++ b/zeppelin-plugins/notebookrepo/filesystem/pom.xml
+@@ -47,6 +47,18 @@
+                     <groupId>org.codehaus.woodstox</groupId>
+                     <artifactId>stax2-api</artifactId>
+                 </exclusion>
++                <exclusion>
++                    <groupId>org.slf4j</groupId>
++                    <artifactId>slf4j-reload4j</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>ch.qos.reload4j</groupId>
++                    <artifactId>reload4j</artifactId>
++                </exclusion>
++                <exclusion>
++                    <groupId>org.eclipse.jetty.websocket</groupId>
++                    <artifactId>websocket-client</artifactId>
++                </exclusion>
+             </exclusions>
+         </dependency>
+     </dependencies>
+diff --git a/zeppelin-server/pom.xml b/zeppelin-server/pom.xml
+index f84f3e384..d6fef83e6 100644
+--- a/zeppelin-server/pom.xml
++++ b/zeppelin-server/pom.xml
+@@ -290,6 +290,24 @@
+     <dependency>
+       <groupId>org.apache.hadoop</groupId>
+       <artifactId>hadoop-client</artifactId>
++      <exclusions>
++        <exclusion>
++          <groupId>org.slf4j</groupId>
++          <artifactId>slf4j-reload4j</artifactId>
++        </exclusion>
++        <exclusion>
++          <groupId>ch.qos.reload4j</groupId>
++          <artifactId>reload4j</artifactId>
++        </exclusion>
++        <exclusion>
++          <groupId>javax.ws.rs</groupId>
++          <artifactId>javax.ws.rs-api</artifactId>
++        </exclusion>
++        <exclusion>
++          <groupId>org.eclipse.jetty.websocket</groupId>
++          <artifactId>websocket-client</artifactId>
++        </exclusion>
++      </exclusions>
+     </dependency>
+ 
+     <!--test libraries-->
+@@ -303,6 +321,14 @@
+           <groupId>org.codehaus.woodstox</groupId>
+           <artifactId>stax2-api</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>org.slf4j</groupId>
++          <artifactId>slf4j-reload4j</artifactId>
++        </exclusion>
++        <exclusion>
++          <groupId>ch.qos.reload4j</groupId>
++          <artifactId>reload4j</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+ 
+diff --git a/zeppelin-zengine/pom.xml b/zeppelin-zengine/pom.xml
+index 3e789968a..1ee305c3a 100644
+--- a/zeppelin-zengine/pom.xml
++++ b/zeppelin-zengine/pom.xml
+@@ -223,6 +223,18 @@
+           <groupId>org.codehaus.woodstox</groupId>
+           <artifactId>stax2-api</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>org.slf4j</groupId>
++          <artifactId>slf4j-reload4j</artifactId>
++        </exclusion>
++        <exclusion>
++          <groupId>ch.qos.reload4j</groupId>
++          <artifactId>reload4j</artifactId>
++        </exclusion>
++        <exclusion>
++          <groupId>org.eclipse.jetty.websocket</groupId>
++          <artifactId>websocket-client</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+ 

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -310,7 +310,7 @@ bigtop {
     'zeppelin' {
       name    = 'zeppelin'
       relNotes = 'Apache Zeppelin'
-      version { base = '0.10.0'; pkg = base; release = 1 }
+      version { base = '0.10.0'; pkg = base; release = 2 }
       tarball { source      = "$name-${version.base}.tgz"
                 destination = "$name-${version.base}.tar.gz" }
       url     { download_path = "/$name/$name-${version.base}/"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3751

```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce) @ zeppelin-interpreter ---
[WARNING] 
Dependency convergence error for ch.qos.reload4j:reload4j:1.2.18.3 paths to dependency are:
+-org.apache.zeppelin:zeppelin-interpreter:0.10.0
  +-org.apache.hadoop:hadoop-client:3.3.3
    +-org.apache.hadoop:hadoop-common:3.3.3
      +-ch.qos.reload4j:reload4j:1.2.18.3
and
+-org.apache.zeppelin:zeppelin-interpreter:0.10.0
  +-org.apache.hadoop:hadoop-client:3.3.3
    +-org.apache.hadoop:hadoop-common:3.3.3
      +-org.slf4j:slf4j-reload4j:1.7.36
        +-ch.qos.reload4j:reload4j:1.2.19
and
+-org.apache.zeppelin:zeppelin-interpreter:0.10.0
  +-org.apache.hadoop:hadoop-client:3.3.3
    +-org.apache.hadoop:hadoop-common:3.3.3
      +-org.apache.hadoop:hadoop-auth:3.3.3
        +-ch.qos.reload4j:reload4j:1.2.18.3
and
+-org.apache.zeppelin:zeppelin-interpreter:0.10.0
  +-org.apache.hadoop:hadoop-client:3.3.3
    +-org.apache.hadoop:hadoop-mapreduce-client-core:3.3.3
      +-org.apache.hadoop:hadoop-yarn-common:3.3.3
        +-ch.qos.reload4j:reload4j:1.2.18.3
```