### PR TITLE
BIGTOP-3750: Add Chrony synchronization to fix hostcheck issue in Mpack docker provisioner

### DIFF
--- a/bigtop-packages/src/common/bigtop-ambari-mpack/dev-support/docker/centos7/Dockerfile
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/dev-support/docker/centos7/Dockerfile
@@ -15,7 +15,7 @@
 
 FROM centos:7
 
-RUN yum -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server java-1.8.0-openjdk* net-tools krb5-server krb5-libs krb5-workstation
+RUN yum -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server java-1.8.0-openjdk* net-tools chrony krb5-server krb5-libs krb5-workstation
 RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -O /usr/share/java/mysql-connector-java.jar
 
 RUN /bin/sed -i 's,#   StrictHostKeyChecking ask,StrictHostKeyChecking no,g' /etc/ssh/ssh_config


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Add Chrony synchronization to fix hostcheck issue in Mpack docker provisioner.


![chronyd](https://user-images.githubusercontent.com/20575685/179689917-a931315e-f4b6-4bb0-bbd0-bef9840ed257.png)



Also silence the shellcheck issues: SC2046 and SC2164.

### How was this patch tested?
```
$pwd
bigtop/bigtop-packages/src/common/bigtop-ambari-mpack/dev-support/docker/centos7
```
Build docker images: `./build-image.sh`
Ambari deployment: `./build-containers.sh`

Access Ambari web ui: localhost:8080
### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/