### PR TITLE
BIGTOP-3754: Add Ubuntu 22.04 option

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -30,7 +30,7 @@ case ${ID}-${VERSION_ID} in
         # So we install that module in the same way as CentOS 7.
         puppet module install puppetlabs-stdlib --version 4.12.0
         ;;
-    ubuntu-18.04|ubuntu-20.04)
+    ubuntu-18.04|ubuntu-20.04|ubuntu-22.04)
         apt-get update
         apt-get -y install wget curl sudo unzip puppet software-properties-common puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv
         ;;

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -211,8 +211,13 @@ class bigtop_toolchain::packages {
         "python3-dev",
         "python2.7-dev"
       ]
-
-      if (($operatingsystem == 'Ubuntu' and 0 <= versioncmp($operatingsystemmajrelease, '20.04')) or ($operatingsystem == 'Debian' and 0 <= versioncmp($operatingsystemmajrelease, '11'))) {
+      if (($operatingsystem == 'Ubuntu' and 0 <= versioncmp($operatingsystemmajrelease, '22.04'))) {
+        file { '/usr/bin/python':
+          ensure => 'link',
+          target => '/usr/bin/python2',
+        }
+        $pkgs = $_pkgs
+      } elsif (($operatingsystem == 'Ubuntu' and 0 <= versioncmp($operatingsystemmajrelease, '20.04')) or ($operatingsystem == 'Debian' and 0 <= versioncmp($operatingsystemmajrelease, '11'))) {
         $pkgs = concat($_pkgs, ["python-is-python2"])
       } else {
         $pkgs = $_pkgs

--- a/packages.gradle
+++ b/packages.gradle
@@ -652,8 +652,8 @@ def genTasks = { target ->
           group: PACKAGES_GROUP) doLast {
     def _prefix = project.hasProperty("prefix") ? prefix : "trunk"
     def _OS = project.hasProperty("OS") ? OS : "centos-7"
-    if (_OS == "fedora-35") {
-      logger.warn('fedora-35 requires privileged mode, pass `-Pdocker-run-option="--privileged"` to gradle option')
+    if (_OS == "fedora-35" || _OS == "ubuntu-22.04") {
+      logger.warn(_OS + ' requires privileged mode, pass `-Pdocker-run-option="--privileged"` to gradle option')
     }
     def _target_pkg = "$target-pkg"
     def _docker_run_option = project.hasProperty("docker-run-option") ? this.'docker-run-option' : ""

--- a/provisioner/docker/config_ubuntu-22.04.yaml
+++ b/provisioner/docker/config_ubuntu-22.04.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker:
+        memory_limit: "4g"
+        image:  "bigtop/puppet:trunk-ubuntu-22.04"
+
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/ubuntu/22.04/$(ARCH)"
+distro: debian
+components: [hdfs, yarn, mapreduce]
+enable_local_repo: false
+smoke_test_components: [hdfs, yarn, mapreduce]


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
This PR adds an Ubuntu 22.04 option to Bigtop
- switch to create symlink to python2 because python-is-python2 cannot be installed to Ubuntu 22.04
- add a warning message to add privileged option for docker smoke test to avoid test failures caused by newer systemd version

### How was this patch tested?
I tested on a ubuntu 22.04 host machine, x86 CPU.

```sh
# Build base docker images
cd docker/bigtop-puppet
./build.sh trunk-ubuntu-22.04
cd ../bigtop-slaves/
./build.sh trunk-ubuntu-22.04
cd ../..

# Build a project
./gradlew -POS=ubuntu-22.04 -Pdocker-run-option="--privileged" zookeeper-pkg-ind

# Test
./gradlew -POS=ubuntu-22.04 -Pdocker-run-option="--privileged" repo-ind
cd provisioner/docker
./docker-hadoop.sh -d  -C config_ubuntu-22.04.yaml -F docker-compose-cgroupv2.yml  \
  --create 1  --memory 8g  --enable-local-repo  --repo file:///bigtop-home/output/apt  \
  --disable-gpg-check  --stack zookeeper  --smoke-tests zookeeper
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/