### PR TITLE
BIGTOP-3756: Add Fedora 36 option

### DIFF
--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -20,6 +20,7 @@
 # since Hadoop build system makes it difficult to pass the kind of flags
 # that would make newer RPM debuginfo generation scripts happy.
 %undefine _missing_build_ids_terminate_build
+%undefine _auto_set_build_flags
 
 %define hadoop_name hadoop
 %define etc_hadoop /etc/%{name}

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -21,7 +21,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case ${ID}-${VERSION_ID} in
-    fedora-35)
+    fedora-35|fedora-36)
         dnf -y install yum-utils
         dnf -y check-update
         dnf -y install hostname diffutils findutils curl sudo unzip wget puppet procps-ng libxcrypt-compat systemd

--- a/docker/bigtop-puppet/build.sh
+++ b/docker/bigtop-puppet/build.sh
@@ -51,5 +51,17 @@ ${ENV_PATH}
 RUN bash /tmp/puppetize.sh
 EOF
 
+# modify the Dockerfile according to the OS/version
+case "${OS}-${VERSION}" in
+  fedora-36*)
+    # use java 8 during build if the os's default java version is newer
+    sed -i -e "s|RUN bash /tmp/puppetize.sh|ENV PATH /usr/lib/jvm/java-1.8.0/bin:\$PATH\nRUN bash /tmp/puppetize.sh|" Dockerfile
+    # add initd
+    sed -i -e "s|RUN bash /tmp/puppetize.sh|RUN bash /tmp/puppetize.sh\nRUN dnf install -y initscripts|" Dockerfile
+    ;;
+  *)
+    ;;
+esac
+
 docker build -t bigtop/puppet:${PREFIX}-${OS}-${VERSION}${ARCH} .
 rm -f Dockerfile puppetize.sh

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -88,6 +88,15 @@ fi
 # generate Dockerfile for build
 sed -e "s|PREFIX|${PREFIX}|;s|OS|${OS}|;s|VERSION|${VERSION}|" Dockerfile.template | \
   sed -e "s|PUPPET_MODULES|${PUPPET_MODULES}|;s|UPDATE_SOURCE|${UPDATE_SOURCE}|" > Dockerfile
+  
+# use java 8 during build if the os's default java version is newer
+case "${OS}-${VERSION}" in
+  fedora-36*)
+    sed -i -e "s|COPY . /tmp/bigtop|ENV PATH /usr/lib/jvm/java-1.8.0/bin:\$PATH\nCOPY . /tmp/bigtop|" Dockerfile
+    ;;
+  *)
+    ;;
+esac
 
 docker build ${NETWORK} --rm -t bigtop/slaves:${PREFIX}-${OS}-${VERSION} -f Dockerfile ../..
 rm -f Dockerfile

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -88,15 +88,6 @@ fi
 # generate Dockerfile for build
 sed -e "s|PREFIX|${PREFIX}|;s|OS|${OS}|;s|VERSION|${VERSION}|" Dockerfile.template | \
   sed -e "s|PUPPET_MODULES|${PUPPET_MODULES}|;s|UPDATE_SOURCE|${UPDATE_SOURCE}|" > Dockerfile
-  
-# use java 8 during build if the os's default java version is newer
-case "${OS}-${VERSION}" in
-  fedora-36*)
-    sed -i -e "s|COPY . /tmp/bigtop|ENV PATH /usr/lib/jvm/java-1.8.0/bin:\$PATH\nCOPY . /tmp/bigtop|" Dockerfile
-    ;;
-  *)
-    ;;
-esac
 
 docker build ${NETWORK} --rm -t bigtop/slaves:${PREFIX}-${OS}-${VERSION} -f Dockerfile ../..
 rm -f Dockerfile

--- a/provisioner/docker/config_fedora-36.yaml
+++ b/provisioner/docker/config_fedora-36.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker:
+        memory_limit: "4g"
+        image: "bigtop/puppet:trunk-fedora-36"
+
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/fedora/36/$basearch"
+distro: centos
+components: [hdfs, yarn, mapreduce]
+enable_local_repo: false
+smoke_test_components: [hdfs, yarn, mapreduce]


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
This PR adds a Fedora 36 option to Bigtop.
- use java 8 during build process because on fedora 36 java 17 is also installed and set as default.
- add init-script installations to use init.d
- opt-out from Fedora 36's default `CFLAGS` options.

### How was this patch tested?
I tested on CentOS7/arm and on Ubuntu 22.04/x86.


```sh
# Build images
cd docker/bigtop-puppet/
./build.sh trunk-fedora-36
cd ../bigtop-slaves/
./build.sh trunk-fedora-36

# Build a project
cd ../..
./gradlew -POS=fedora-36 -Pdocker-run-option="--privileged" \
  bigtop-utils-pkg-ind bigtop-jsvc-pkg-ind bigtop-groovy-pkg-ind \
  zookeeper-pkg-ind hadoop-ind repo-ind 

# Smoke test
cd provisioner/docker/
./docker-hadoop.sh -d  -C config_fedora-36.yaml -F docker-compose-cgroupv2.yml  \
  --create 3  --memory 8g  --enable-local-repo  --repo file:///bigtop-home/output  \
  --disable-gpg-check  --stack zookeeper,yarn,hdfs,mapreduce  \
  --smoke-tests yarn,hdfs,mapreduce
```
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/