### PR TITLE
BIGTOP-3758. Fix build failure of Tez against Hadoop 3.3.

### DIFF
--- a/bigtop-packages/src/common/tez/do-component-build
+++ b/bigtop-packages/src/common/tez/do-component-build
@@ -18,6 +18,16 @@ set -xe
 
 . `dirname $0`/bigtop.bom
 
+if [ $HOSTTYPE = "powerpc64le" ] ; then
+  mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
+      -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-2.5.0/bin/protoc
+fi
+
+if [ $HOSTTYPE = "aarch64" ] ; then
+  mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
+      -Dclassifier=linux-aarch_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-2.5.0/bin/protoc
+fi
+
 BUILD_TEZ_OPTS="clean package \
 -Dtar -Dhadoop.version=${HADOOP_VERSION} \
 -Phadoop28 \

--- a/bigtop-packages/src/common/tez/patch4-TEZ-4300-and-TEZ-4428.diff
+++ b/bigtop-packages/src/common/tez/patch4-TEZ-4300-and-TEZ-4428.diff
@@ -1,0 +1,425 @@
+diff --git a/.travis.yml b/.travis.yml
+index 3637a0def..65eaf7778 100644
+--- a/.travis.yml
++++ b/.travis.yml
+@@ -22,9 +22,6 @@ sudo: required
+ 
+ env: MAVEN_OPTS="-Xmx2G -XX:MaxPermSize=512M"
+ 
+-before_install:
+-  - ./build-tools/install-protobuf.sh
+-
+ script:
+   - jdk_switcher use oraclejdk8
+   - mvn -B clean install package -DskipTests=true -Dmaven.javadoc.skip=true
+diff --git a/BUILDING.txt b/BUILDING.txt
+index 875bf3e09..8b89a559d 100644
+--- a/BUILDING.txt
++++ b/BUILDING.txt
+@@ -117,13 +117,16 @@ It's important to note that maven will still include tez-ui project, but all of
+ ----------------------------------------------------------------------------------
+ Protocol Buffer compiler:
+ 
+-The version of Protocol Buffer compiler, protoc, must be 2.5.0 and match the
+-version of the protobuf JAR.
++The version of Protocol Buffer compiler, protoc, can be defined on-the-fly as:
++ $ mvn clean install -DskipTests -pl ./tez-api -Dprotobuf.version=3.7.1
+ 
+-If you have multiple versions of protoc in your system, you can set in your 
+-build shell the PROTOC_PATH environment variable to point to the one you 
+-want to use for the Tez build. If you don't define this environment variable,
+-protoc is looked up in the PATH.
++The default version is defined in the root pom.xml.
++
++If you have multiple versions of protoc in your system, you can set in your
++build shell the PROTOC_PATH environment variable to point to the one you
++want to use for the Tez build. If you don't define this environment variable then the
++embedded protoc compiler will be used with the version defined in ${protobuf.version}.
++It detects the platform and executes the corresponding protoc binary at build time.
+ 
+ You can also specify the path to protoc while building using -Dprotoc.path
+ 
+diff --git a/build-tools/.gitignore b/build-tools/.gitignore
+new file mode 100644
+index 000000000..adfc42ea4
+--- /dev/null
++++ b/build-tools/.gitignore
+@@ -0,0 +1,2 @@
++protobuf
++
+diff --git a/build-tools/install-protobuf.sh b/build-tools/install-protobuf.sh
+deleted file mode 100755
+index 902049dab..000000000
+--- a/build-tools/install-protobuf.sh
++++ /dev/null
+@@ -1,22 +0,0 @@
+-#!/bin/sh
+-
+-# Licensed to the Apache Software Foundation (ASF) under one
+-# or more contributor license agreements.  See the NOTICE file
+-# distributed with this work for additional information
+-# regarding copyright ownership.  The ASF licenses this file
+-# to you under the Apache License, Version 2.0 (the
+-# "License"); you may not use this file except in compliance
+-# with the License.  You may obtain a copy of the License at
+-#
+-# http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-set -ex
+-wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz
+-tar -xzvf protobuf-2.5.0.tar.gz
+-cd protobuf-2.5.0 && ./configure --prefix=/usr && make && sudo make install
+diff --git a/tez-api/pom.xml b/tez-api/pom.xml
+index 71a692351..ef682bcf1 100644
+--- a/tez-api/pom.xml
++++ b/tez-api/pom.xml
+@@ -150,30 +150,27 @@
+         <artifactId>apache-rat-plugin</artifactId>
+       </plugin>
+       <plugin>
+-        <groupId>org.apache.hadoop</groupId>
+-        <artifactId>hadoop-maven-plugins</artifactId>
++        <groupId>com.github.os72</groupId>
++        <artifactId>protoc-jar-maven-plugin</artifactId>
++        <version>3.11.4</version>
+         <executions>
+           <execution>
+-            <id>compile-protoc</id>
+             <phase>generate-sources</phase>
+             <goals>
+-              <goal>protoc</goal>
++              <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocVersion>${protobuf.version}</protocVersion>
++              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+               <protocCommand>${protoc.path}</protocCommand>
+-              <imports>
+-                <param>${basedir}/src/main/proto</param>
+-              </imports>
+-              <source>
+-                <directory>${basedir}/src/main/proto</directory>
+-                <includes>
+-                  <include>DAGApiRecords.proto</include>
+-                  <include>DAGClientAMProtocol.proto</include>
+-                  <include>Events.proto</include>
+-                </includes>
+-              </source>
+-              <output>${project.build.directory}/generated-sources/java</output>
++              <addSources>none</addSources>
++              <inputDirectories>
++                <include>${basedir}/src/main/proto</include>
++              </inputDirectories>
++              <outputTargets>
++                <outputTarget>
++                  <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
++                </outputTarget>
++              </outputTargets>
+             </configuration>
+           </execution>
+         </executions>
+diff --git a/tez-dag/pom.xml b/tez-dag/pom.xml
+index a052b320a..83fe50edd 100644
+--- a/tez-dag/pom.xml
++++ b/tez-dag/pom.xml
+@@ -207,30 +207,31 @@
+         </configuration>
+       </plugin>
+       <plugin>
+-        <groupId>org.apache.hadoop</groupId>
+-        <artifactId>hadoop-maven-plugins</artifactId>
++        <groupId>com.github.os72</groupId>
++        <artifactId>protoc-jar-maven-plugin</artifactId>
++        <version>3.11.4</version>
+         <executions>
+           <execution>
+-            <id>compile-protoc</id>
+             <phase>generate-sources</phase>
+             <goals>
+-              <goal>protoc</goal>
++              <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocVersion>${protobuf.version}</protocVersion>
++              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+               <protocCommand>${protoc.path}</protocCommand>
+-              <imports>
+-                <param>${basedir}/src/main/proto</param>
+-                <param>${basedir}/../tez-api/src/main/proto</param>
+-                <param>${basedir}/../tez-runtime-internals/src/main/proto</param>
+-              </imports>
+-              <source>
+-                <directory>${basedir}/src/main/proto</directory>
+-                <includes>
+-                  <include>HistoryEvents.proto</include>
+-                </includes>
+-              </source>
+-              <output>${project.build.directory}/generated-sources/java</output>
++              <addSources>none</addSources>
++              <includeDirectories>
++                <include>${basedir}/../tez-api/src/main/proto</include>
++                <include>${basedir}/../tez-runtime-internals/src/main/proto</include>
++              </includeDirectories>
++              <inputDirectories>
++                <include>${basedir}/src/main/proto</include>
++              </inputDirectories>
++              <outputTargets>
++                <outputTarget>
++                  <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
++                </outputTarget>
++              </outputTargets>
+             </configuration>
+           </execution>
+         </executions>
+diff --git a/tez-ext-service-tests/pom.xml b/tez-ext-service-tests/pom.xml
+index d98e2343c..c57aec565 100644
+--- a/tez-ext-service-tests/pom.xml
++++ b/tez-ext-service-tests/pom.xml
+@@ -161,29 +161,30 @@
+         <artifactId>apache-rat-plugin</artifactId>
+       </plugin>
+       <plugin>
+-        <groupId>org.apache.hadoop</groupId>
+-        <artifactId>hadoop-maven-plugins</artifactId>
++        <groupId>com.github.os72</groupId>
++        <artifactId>protoc-jar-maven-plugin</artifactId>
++        <version>3.11.4</version>
+         <executions>
+           <execution>
+-            <id>compile-protoc</id>
+             <phase>generate-sources</phase>
+             <goals>
+-              <goal>protoc</goal>
++              <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocVersion>${protobuf.version}</protocVersion>
++              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+               <protocCommand>${protoc.path}</protocCommand>
+-              <imports>
+-                <param>${basedir}/src/test/proto</param>
++              <addSources>none</addSources>
++              <includeDirectories>
+                 <param>${basedir}/../tez-api/src/main/proto</param>
+-              </imports>
+-              <source>
+-                <directory>${basedir}/src/test/proto</directory>
+-                <includes>
+-                  <include>TezDaemonProtocol.proto</include>
+-                </includes>
+-              </source>
+-              <output>${project.build.directory}/generated-test-sources/java</output>
++              </includeDirectories>
++              <inputDirectories>
++                <include>${basedir}/src/test/proto</include>
++              </inputDirectories>
++              <outputTargets>
++                <outputTarget>
++                  <outputDirectory>${project.build.directory}/generated-test-sources/java</outputDirectory>
++                </outputTarget>
++              </outputTargets>
+             </configuration>
+           </execution>
+         </executions>
+diff --git a/tez-mapreduce/pom.xml b/tez-mapreduce/pom.xml
+index 5dc016f9c..8a22afac2 100644
+--- a/tez-mapreduce/pom.xml
++++ b/tez-mapreduce/pom.xml
+@@ -133,28 +133,27 @@
+         <artifactId>apache-rat-plugin</artifactId>
+       </plugin>
+       <plugin>
+-        <groupId>org.apache.hadoop</groupId>
+-        <artifactId>hadoop-maven-plugins</artifactId>
++        <groupId>com.github.os72</groupId>
++        <artifactId>protoc-jar-maven-plugin</artifactId>
++        <version>3.11.4</version>
+         <executions>
+           <execution>
+-            <id>compile-protoc</id>
+             <phase>generate-sources</phase>
+             <goals>
+-              <goal>protoc</goal>
++              <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocVersion>${protobuf.version}</protocVersion>
++              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+               <protocCommand>${protoc.path}</protocCommand>
+-              <imports>
+-                <param>${basedir}/src/main/proto</param>
+-              </imports>
+-              <source>
+-                <directory>${basedir}/src/main/proto</directory>
+-                <includes>
+-                  <include>MRRuntimeProtos.proto</include>
+-                </includes>
+-              </source>
+-              <output>${project.build.directory}/generated-sources/java</output>
++              <addSources>none</addSources>
++              <inputDirectories>
++                <include>${basedir}/src/main/proto</include>
++              </inputDirectories>
++              <outputTargets>
++                <outputTarget>
++                  <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
++                </outputTarget>
++              </outputTargets>
+             </configuration>
+           </execution>
+         </executions>
+diff --git a/tez-plugins/tez-protobuf-history-plugin/pom.xml b/tez-plugins/tez-protobuf-history-plugin/pom.xml
+index e11767f54..829597d02 100644
+--- a/tez-plugins/tez-protobuf-history-plugin/pom.xml
++++ b/tez-plugins/tez-protobuf-history-plugin/pom.xml
+@@ -59,34 +59,31 @@
+         <artifactId>apache-rat-plugin</artifactId>
+       </plugin>
+       <plugin>
+-        <groupId>org.apache.hadoop</groupId>
+-        <artifactId>hadoop-maven-plugins</artifactId>
++        <groupId>com.github.os72</groupId>
++        <artifactId>protoc-jar-maven-plugin</artifactId>
++        <version>3.11.4</version>
+         <executions>
+           <execution>
+-            <id>compile-protoc</id>
+             <phase>generate-sources</phase>
+             <goals>
+-              <goal>protoc</goal>
++              <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocVersion>${protobuf.version}</protocVersion>
++              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+               <protocCommand>${protoc.path}</protocCommand>
+-              <imports>
+-                <param>${basedir}/src/main/proto</param>
+-              </imports>
+-              <source>
+-                <directory>${basedir}/src/main/proto</directory>
+-                <includes>
+-                  <include>HistoryLogger.proto</include>
+-                </includes>
+-              </source>
+-              <output>${project.build.directory}/generated-sources/java</output>
++              <addSources>none</addSources>
++              <inputDirectories>
++                <include>${basedir}/src/main/proto</include>
++              </inputDirectories>
++              <outputTargets>
++                <outputTarget>
++                  <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
++                </outputTarget>
++              </outputTargets>
+             </configuration>
+           </execution>
+         </executions>
+       </plugin>
+-
+     </plugins>
+   </build>
+-
+ </project>
+diff --git a/tez-runtime-internals/pom.xml b/tez-runtime-internals/pom.xml
+index dcfd4ef70..2bea0d093 100644
+--- a/tez-runtime-internals/pom.xml
++++ b/tez-runtime-internals/pom.xml
+@@ -87,28 +87,27 @@
+         <artifactId>apache-rat-plugin</artifactId>
+       </plugin>
+       <plugin>
+-        <groupId>org.apache.hadoop</groupId>
+-        <artifactId>hadoop-maven-plugins</artifactId>
++        <groupId>com.github.os72</groupId>
++        <artifactId>protoc-jar-maven-plugin</artifactId>
++        <version>3.11.4</version>
+         <executions>
+           <execution>
+-            <id>compile-protoc</id>
+             <phase>generate-sources</phase>
+             <goals>
+-              <goal>protoc</goal>
++              <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocVersion>${protobuf.version}</protocVersion>
++              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+               <protocCommand>${protoc.path}</protocCommand>
+-              <imports>
+-                <param>${basedir}/src/main/proto</param>
+-              </imports>
+-              <source>
+-                <directory>${basedir}/src/main/proto</directory>
+-                <includes>
+-                  <include>RuntimeEvents.proto</include>
+-                </includes>
+-              </source>
+-              <output>${project.build.directory}/generated-sources/java</output>
++              <addSources>none</addSources>
++              <inputDirectories>
++                <include>${basedir}/src/main/proto</include>
++              </inputDirectories>
++              <outputTargets>
++                <outputTarget>
++                  <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
++                </outputTarget>
++              </outputTargets>
+             </configuration>
+           </execution>
+         </executions>
+diff --git a/tez-runtime-library/pom.xml b/tez-runtime-library/pom.xml
+index 658417a7b..1e62c0cec 100644
+--- a/tez-runtime-library/pom.xml
++++ b/tez-runtime-library/pom.xml
+@@ -110,30 +110,27 @@
+         <artifactId>apache-rat-plugin</artifactId>
+       </plugin>
+       <plugin>
+-        <groupId>org.apache.hadoop</groupId>
+-        <artifactId>hadoop-maven-plugins</artifactId>
++        <groupId>com.github.os72</groupId>
++        <artifactId>protoc-jar-maven-plugin</artifactId>
++        <version>3.11.4</version>
+         <executions>
+           <execution>
+-            <id>compile-protoc</id>
+             <phase>generate-sources</phase>
+             <goals>
+-              <goal>protoc</goal>
++              <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocVersion>${protobuf.version}</protocVersion>
++              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+               <protocCommand>${protoc.path}</protocCommand>
+-              <imports>
+-                <param>${basedir}/src/main/proto</param>
+-              </imports>
+-              <source>
+-                <directory>${basedir}/src/main/proto</directory>
+-                <includes>
+-                  <include>ShufflePayloads.proto</include>
+-                  <include>CartesianProductPayload.proto</include>
+-                  <include>FairShufflePayloads.proto</include>
+-                </includes>
+-              </source>
+-              <output>${project.build.directory}/generated-sources/java</output>
++              <addSources>none</addSources>
++              <inputDirectories>
++                <include>${basedir}/src/main/proto</include>
++              </inputDirectories>
++              <outputTargets>
++                <outputTarget>
++                  <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
++                </outputTarget>
++              </outputTargets>
+             </configuration>
+           </execution>
+         </executions>

--- a/bigtop-packages/src/common/tez/patch5-TEZ-4298.diff
+++ b/bigtop-packages/src/common/tez/patch5-TEZ-4298.diff
@@ -1,0 +1,41 @@
+diff --git a/tez-plugins/tez-aux-services/findbugs-exclude.xml b/tez-plugins/tez-aux-services/findbugs-exclude.xml
+index 5b11308f6..adfd7041a 100644
+--- a/tez-plugins/tez-aux-services/findbugs-exclude.xml
++++ b/tez-plugins/tez-aux-services/findbugs-exclude.xml
+@@ -12,5 +12,10 @@
+   limitations under the License. See accompanying LICENSE file.
+ -->
+ <FindBugsFilter>
+-
++  <!-- TEZ-4298 -->
++  <Match>
++    <Class name="org.apache.tez.auxservices.ShuffleHandler"/>
++    <Method name="recordJobShuffleInfo"/>
++    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
++  </Match>
+ </FindBugsFilter>
+diff --git a/tez-plugins/tez-aux-services/src/main/java/org/apache/tez/auxservices/ShuffleHandler.java b/tez-plugins/tez-aux-services/src/main/java/org/apache/tez/auxservices/ShuffleHandler.java
+index e73805a1f..fb28a0f4b 100644
+--- a/tez-plugins/tez-aux-services/src/main/java/org/apache/tez/auxservices/ShuffleHandler.java
++++ b/tez-plugins/tez-aux-services/src/main/java/org/apache/tez/auxservices/ShuffleHandler.java
+@@ -153,7 +153,6 @@ import com.google.common.cache.LoadingCache;
+ import com.google.common.cache.RemovalListener;
+ import com.google.common.cache.RemovalNotification;
+ import com.google.common.cache.Weigher;
+-import com.google.protobuf.ByteString;
+ 
+ public class ShuffleHandler extends AuxiliaryService {
+ 
+@@ -796,9 +795,10 @@ public class ShuffleHandler extends AuxiliaryService {
+   private void recordJobShuffleInfo(JobID jobId, String user,
+       Token<JobTokenIdentifier> jobToken) throws IOException {
+     if (stateDb != null) {
++      // Discover type instead of assuming ByteString to allow for shading.
+       TokenProto tokenProto = TokenProto.newBuilder()
+-          .setIdentifier(ByteString.copyFrom(jobToken.getIdentifier()))
+-          .setPassword(ByteString.copyFrom(jobToken.getPassword()))
++          .setIdentifier(TokenProto.getDefaultInstance().getIdentifier().copyFrom(jobToken.getIdentifier()))
++          .setPassword(TokenProto.getDefaultInstance().getPassword().copyFrom(jobToken.getPassword()))
+           .setKind(jobToken.getKind().toString())
+           .setService(jobToken.getService().toString())
+           .build();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3758

* We can leverage protoc-jar-maven-plugin by cherry-picking [TEZ-4300](https://issues.apache.org/jira/browse/TEZ-4300) and [TEZ-4428](https://issues.apache.org/jira/browse/TEZ-4428). (TEZ-4300 is just needed to cleanly apply TEZ-4428)
  * We need to install protoc artifact from locally installed one on aarch64 and ppc64le.
* [TEZ-4298](https://issues.apache.org/jira/browse/TEZ-4298) fixed ShuffleHandler.
