### PR TITLE
BIGTOP-3762: Add JVM options for spark build to avoid StackOverflowError

### DIFF
--- a/bigtop-packages/src/common/spark/do-component-build
+++ b/bigtop-packages/src/common/spark/do-component-build
@@ -30,6 +30,9 @@ BUILD_OPTS="-Divy.home=${HOME}/.ivy2 -Dsbt.ivy.home=${HOME}/.ivy2 -Duser.home=${
             -Dguava.version=27.0-jre \
             $SPARK_BUILD_OPTS"
 
+# BIGTOP-3762
+export MAVEN_OPTS="${MAVEN_OPTS:--Xss64m -Xmx4g -XX:ReservedCodeCacheSize=1g}"
+
 ./dev/make-distribution.sh --mvn mvn --r $BUILD_OPTS -DskipTests
 
 SPARK_SKIP_TESTS=$([ "$SPARK_RUN_TESTS" = "true" ] && echo false || echo true)


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Add JVM options for spark build to avoid StackOverflowError on Bigtop's Jenkins.

### How was this patch tested?
On CentOS 7, arm machine

```sh
$ ./gradlew spark-clean spark-pkg
... 
+ exit 0

BUILD SUCCESSFUL in 58m 35s
7 actionable tasks: 7 executed
```

I also checked that setting larger values worked. 

e.g. 
```
$ export MAVEN_OPTS="--Xss32g -Xmx32g -XX:ReservedCodeCacheSize=1g"
$ ./gradlew spark-clean spark-pkg
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/