### PR TITLE
BIGTOP-3761. Fix bigtop_toolchain to enable EPEL before downloading p…

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -243,7 +243,8 @@ class bigtop_toolchain::packages {
 
   if $operatingsystem == 'CentOS' {
     package { 'epel-release':
-      ensure => installed
+      ensure => installed,
+      notify => Package[$pkgs]
     }
 
     if $operatingsystemmajrelease == 7 {


### PR DESCRIPTION
Add a notify attribute in puppet manifest to ensure install order.
EPEL will be enabled before install packaged. 

```
$ ./gradlew bigtop-slaves
...
Notice: /Stage[main]/Bigtop_toolchain::Jdk/Package[java-1.8.0-openjdk-devel]/ensure: created
Notice: /Stage[main]/Bigtop_toolchain::Gradle/Exec[/usr/bin/wget https://services.gradle.org/distributions/gradle-5.6.4-bin.zip]/returns: executed successfully
Notice: /Stage[main]/Bigtop_toolchain::Gradle/Exec[/usr/bin/unzip -x -o /usr/src/gradle-5.6.4-bin.zip]/returns: executed successfully
Notice: /Stage[main]/Bigtop_toolchain::Gradle/Exec[/usr/bin/unzip -x -o /usr/src/gradle-5.6.4-bin.zip]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Bigtop_toolchain::Packages/Package[libtool]/ensure: created
...
BUILD SUCCESSFUL in 19s
```