### PR TITLE
BIGTOP-3763: Fix Hive build issues about protobuf 2.5.0 on Arm64 and PPC64le

### DIFF
--- a/bigtop-packages/src/common/hive/do-component-build
+++ b/bigtop-packages/src/common/hive/do-component-build
@@ -36,12 +36,12 @@ HIVE_MAVEN_OPTS=" -Dhbase.version=$HBASE_VERSION \
 # for non-x86 platforms
 if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
-    -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/bin/protoc
+    -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-2.5.0/bin/protoc
 elif [ $HOSTTYPE = "aarch64" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
-    -Dclassifier=linux-aarch_64 -Dpackaging=exe -Dfile=/usr/local/bin/protoc
+    -Dclassifier=linux-aarch_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-2.5.0/bin/protoc
 fi
-export MAVEN_OPTS="${MAVEN_OPTS} -Xmx1500m -Xms1500m"
+export MAVEN_OPTS="${MAVEN_OPTS} -Xmx2500m -Xms2500m"
 mvn ${HIVE_MAVEN_OPTS} clean install ${EXTRA_GOALS} -Pdist "$@"
 
 mkdir -p build/dist

--- a/bigtop-packages/src/common/hive/do-component-build
+++ b/bigtop-packages/src/common/hive/do-component-build
@@ -41,7 +41,6 @@ elif [ $HOSTTYPE = "aarch64" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
     -Dclassifier=linux-aarch_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-2.5.0/bin/protoc
 fi
-export MAVEN_OPTS="${MAVEN_OPTS} -Xmx2500m -Xms2500m"
 mvn ${HIVE_MAVEN_OPTS} clean install ${EXTRA_GOALS} -Pdist "$@"
 
 mkdir -p build/dist


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

1.Fix Hive build issues about protobuf 2.5.0 on Arm64 and
PPC64le when upgrading hadoop to 3.3.3/3.3.4,
2.Expand Java heap size.
### How was this patch tested?


### For code changes:
Build Hive and run smoke tests


- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/