### PR TITLE
BIGTOP-3765: Remove cmake conditional for Hadoop rpm spec

### DIFF
--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -176,11 +176,6 @@ Source31: kms.default
 #BIGTOP_PATCH_FILES
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id} -u -n)
 BuildRequires: fuse-devel, fuse
-%if %{?el7}0
-BuildRequires: cmake3
-%else
-BuildRequires: cmake
-%endif
 Requires: coreutils, /usr/sbin/useradd, /usr/sbin/usermod, /sbin/chkconfig, /sbin/service, bigtop-utils >= 0.7, zookeeper >= 3.4.0
 Requires: psmisc, %{netcat_package}
 Requires: openssl-devel


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
The cmake3 would be always installed on centos-7:
https://github.com/apache/bigtop/blob/master/bigtop_toolchain/manifests/packages.pp#L69-#L73

We can remove the cmake conditional for cmake3 was always provided in CentOS 7.

### How was this patch tested?
Builf Hadoop against on Centos-7.
Run smoke tests.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/