### PR TITLE
BIGTOP-3767. Add Spark Thrift Server Puppet Deploy Code

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -148,6 +148,8 @@ hcatalog::webhcat::server::kerberos_realm: "%{hiera('kerberos::site::realm')}"
 
 # spark
 spark::common::master_host: "%{hiera('bigtop::hadoop_head_node')}"
+spark::common::spark_sql_warehouse_dir: "/user/spark/spark-warehouse"
+spark::common::spark_hive_server2_thrift_port: 12000
 # to enable spark HA, ensure zookeeper is available and uncomment the line below
 #spark::common::zookeeper_connection_string: "%{hiera('hadoop::zk')}"
 

--- a/bigtop-deploy/puppet/manifests/cluster.pp
+++ b/bigtop-deploy/puppet/manifests/cluster.pp
@@ -69,6 +69,7 @@ $roles_map = {
     worker => ["spark-on-yarn"],
     client => ["spark-client"],
     library => ["spark-yarn-slave"],
+    gateway_server => ["spark-thriftserver"],
   },
   spark-standalone => {
     master => ["spark-master"],

--- a/bigtop-deploy/puppet/modules/spark/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/spark/manifests/init.pp
@@ -39,6 +39,31 @@ class spark {
     if ('spark-history-server' in $roles) {
       include spark::history_server
     }
+
+    if ('spark-thriftserver' in $roles) {
+      include spark::spark_thriftserver
+    }
+    
+  }
+
+  class spark_thriftserver {
+    include spark::common
+    
+    package { 'spark-thriftserver': 
+      ensure => latest,
+    }
+
+    service { 'spark-thriftserver':
+      ensure     => running,
+      subscribe  => [
+        Package['spark-thriftserver'],
+        File['/etc/spark/conf/spark-env.sh'],
+        File['/etc/spark/conf/spark-defaults.conf'],
+      ],
+      hasrestart => true,
+      hasstatus  => true,
+    }
+    
   }
 
   class client {
@@ -182,6 +207,8 @@ class spark {
   }
 
   class common(
+      $spark_hive_server2_thrift_port = undef,
+      $spark_sql_warehouse_dir = undef,
       $master_url = undef,
       $master_host = $fqdn,
       $zookeeper_connection_string = undef,

--- a/bigtop-deploy/puppet/modules/spark/templates/spark-defaults.conf
+++ b/bigtop-deploy/puppet/modules/spark/templates/spark-defaults.conf
@@ -16,7 +16,7 @@
 <% if @master_url -%>
 spark.master <%= @master_url %>
 <% else -%>
-<% if (scope['deploy::roles'] & ['spark-master', 'spark-worker']) != [] -%>
+<% if (scope['spark::deploy::roles'] & ['spark-master', 'spark-worker']) != [] -%>
 spark.master spark://<%= @master_host %>:<%= @master_port %>
 <% else -%>
 spark.master yarn
@@ -36,3 +36,9 @@ spark.executor.extraLibraryPath <%= @extra_lib_dirs %>
 <% end -%>
 spark.driver.memory <%= @driver_mem %>
 spark.executor.memory <%= @executor_mem %>
+<% if @spark_sql_warehouse_dir -%>
+spark.sql.warehouse.dir <%= @spark_sql_warehouse_dir %>
+<% end -%>
+<% if @spark_hive_server2_thrift_port -%>
+spark.hive.server2.thrift.port <%= @spark_hive_server2_thrift_port %>
+<% end -%>

--- a/bigtop-deploy/puppet/modules/spark/templates/spark-env.sh
+++ b/bigtop-deploy/puppet/modules/spark/templates/spark-env.sh
@@ -27,7 +27,7 @@ export SPARK_MASTER_IP=$STANDALONE_SPARK_MASTER_HOST
 <% if @master_url -%>
 export SPARK_MASTER_URL=<%= @master_url %>
 <% else -%>
-<% if (scope['deploy::roles'] & ['spark-master', 'spark-worker']) != [] -%>
+<% if (scope['spark::deploy::roles'] & ['spark-master', 'spark-worker']) != [] -%>
 export SPARK_MASTER_URL=spark://<%= @master_host %>:<%= @master_port %>
 <% else -%>
 export SPARK_MASTER_URL=yarn


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Add Spark Thrift Server Puppet Deploy Code

### How was this patch tested?
1. #972 first should resolve the pr
2. edit the docker-hadoop.sh 
```yaml
bigtop::hadoop_head_node: $1

hadoop::hadoop_storage_dirs:
- /data/1
bigtop::roles_enabled: true
bigtop::roles: 
- namenode
- resourcemanager
- hive-client
- hive-metastore
- datanode
- nodemanager
- mapred-app
- spark-on-yarn
- spark-thriftserver
bigtop::bigtop_repo_uri: ["file:///bigtop-home/output"]
hadoop_hive::common_config::hive_execution_engine: "tez"
hadoop::common::use_tez: true
hadoop::common_yarn::yarn_resourcemanager_scheduler_class: org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler
hadoop::common_yarn::yarn_scheduler_capacity_maximum_am_resource_percent: 0.5
hadoop_hive::common_config::hive_tez_container_size: 1024
hadoop_hive::common_config::hive_tez_cpu_vcores: 1
hadoop_hive::common_config::hive_server2_enable_doAs: false
```
3. create a docker containner
```
./docker-hadoop.sh -d -c 1
```
4. now you can use beeline to test the Thrift JDBC/ODBC server:

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/