### PR TITLE
BIGTOP-3775: Failed to build Phoenix on Arm64/powerpc64le

### DIFF
--- a/bigtop-packages/src/common/phoenix/do-component-build
+++ b/bigtop-packages/src/common/phoenix/do-component-build
@@ -25,11 +25,11 @@ MVN_ARGS+="-Dhbase.profile=${HBASE_VERSION%.*} "
 # create com.google.protobuf:protoc artifact with local protoc built by toolchain
 if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
-            -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/bin/protoc
+            -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-2.5.0/bin/protoc
   MVN_ARGS+="-Dprotobuf.group=com.google.protobuf -Dprotoc.version=2.5.0 "
 elif [ $HOSTTYPE = "aarch64" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
-            -Dclassifier=linux-aarch_64 -Dpackaging=exe -Dfile=/usr/local/bin/protoc
+            -Dclassifier=linux-aarch_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-2.5.0/bin/protoc
   MVN_ARGS+="-Dprotobuf.group=com.google.protobuf -Dprotoc.version=2.5.0 "
 fi
 


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-3775

The root cause is same with [BIGTOP-3763](https://issues.apache.org/jira/browse/BIGTOP-3763).
We still need locally installed protobuf-2.5.0 which was brought back by [BIGTOP-3709](https://issues.apache.org/jira/browse/BIGTOP-3709).

### How was this patch tested?
Build Phoenix on Arm64/Powerpc64le

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/