### PR TITLE
BIGTOP-3787. Add docs in Phoenix .deb package

### DIFF
--- a/bigtop-packages/src/deb/phoenix/phoenix.install
+++ b/bigtop-packages/src/deb/phoenix/phoenix.install
@@ -1,2 +1,3 @@
 /etc/phoenix/conf.dist
 /usr/lib/phoenix
+/usr/share/doc/phoenix


### PR DESCRIPTION

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/


I list .rpm and .deb files as below.

- .rpm file.

```
drwxr-xr-x root/root         0 2022-08-22 02:46 ./usr/share/doc/
drwxr-xr-x root/root         0 2022-08-22 02:46 ./usr/share/doc/phoenix/
-rw-r--r-- root/root     33895 2020-01-22 15:10 ./usr/share/doc/phoenix/LICENSE.gz
-rw-r--r-- root/root      3325 2020-01-22 15:10 ./usr/share/doc/phoenix/NOTICE.gz
-rw-r--r-- root/root       129 2022-08-22 02:46 ./usr/share/doc/phoenix/changelog.Debian.gz
-rw-r--r-- root/root     25756 2021-05-30 15:25 ./usr/share/doc/phoenix/changelog.gz
-rw-r--r-- root/root       318 2022-08-22 02:46 ./usr/share/doc/phoenix/copyright
drwxr-xr-x root/root         0 2020-01-22 15:10 ./usr/share/doc/phoenix/examples/
-rw-r--r-- root/root       149 2020-01-22 15:10 ./usr/share/doc/phoenix/examples/STOCK_SYMBOL.csv
-rw-r--r-- root/root       183 2020-01-22 15:10 ./usr/share/doc/phoenix/examples/STOCK_SYMBOL.sql
-rw-r--r-- root/root      2091 2020-01-22 15:10 ./usr/share/doc/phoenix/examples/WEB_STAT.csv
-rw-r--r-- root/root       296 2020-01-22 15:10 ./usr/share/doc/phoenix/examples/WEB_STAT.sql
-rw-r--r-- root/root       563 2020-01-22 15:10 ./usr/share/doc/phoenix/examples/WEB_STAT_QUERIES.sql
```

- .dev files.
```
/usr/share/doc/phoenix-5.1.2
/usr/share/doc/phoenix-5.1.2/LICENSE
/usr/share/doc/phoenix-5.1.2/NOTICE
/usr/share/doc/phoenix-5.1.2/examples
/usr/share/doc/phoenix-5.1.2/examples/STOCK_SYMBOL.csv
/usr/share/doc/phoenix-5.1.2/examples/STOCK_SYMBOL.sql
/usr/share/doc/phoenix-5.1.2/examples/WEB_STAT.csv
/usr/share/doc/phoenix-5.1.2/examples/WEB_STAT.sql
/usr/share/doc/phoenix-5.1.2/examples/WEB_STAT_QUERIES.sql
```

