### PR TITLE
BIGTOP-3796: Support parent directory configuration for Zookeeper rpm build script

### DIFF
--- a/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
+++ b/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
@@ -149,6 +149,7 @@ install -d -m 0755 $PREFIX/$LIB_DIR/lib
 cp $BUILD_DIR/lib/*.jar $PREFIX/$LIB_DIR/lib
 
 # Copy in the configuration files
+install -d -m 0755 $PREFIX/etc/zookeeper
 install -d -m 0755 $PREFIX/$CONF_DIST_DIR
 cp zoo.cfg $BUILD_DIR/conf/* $PREFIX/$CONF_DIST_DIR/
 ln -s $CONF_DIR $PREFIX/$LIB_DIR/conf

--- a/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
+++ b/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
@@ -28,6 +28,9 @@ usage: $0 <options>
      --doc-dir=DIR               path to install docs into [/usr/share/doc/zookeeper]
      --lib-dir=DIR               path to install zookeeper home [/usr/lib/zookeeper]
      --bin-dir=DIR               path to install bins [/usr/bin]
+     --man-dir=DIR               path to install mans [/usr/share/man]
+     --conf-dist-dir=DIR         path to install conf dist dir [/etc/zookeeper/conf.dist]
+     --etc-default=DIR           path to bigtop default dir [/etc/default]
      --examples-dir=DIR          path to install examples [doc-dir/examples]
      --system-include-dir=DIR    path to install development headers [/usr/include]
      --system-lib-dir=DIR        path to install native libraries [/usr/lib]
@@ -43,6 +46,9 @@ OPTS=$(getopt \
   -l 'doc-dir:' \
   -l 'lib-dir:' \
   -l 'bin-dir:' \
+  -l 'man-dir:' \
+  -l 'conf-dist-dir:' \
+  -l 'etc-default:' \
   -l 'examples-dir:' \
   -l 'system-include-dir:' \
   -l 'system-lib-dir:' \
@@ -69,6 +75,15 @@ while true ; do
         ;;
         --bin-dir)
         BIN_DIR=$2 ; shift 2
+        ;;
+        --man-dir)
+        MAN_DIR=$2 ; shift 2
+        ;;
+        --conf-dist-dir)
+        CONF_DIST_DIR=$2 ; shift 2
+        ;;
+        --etc-default)
+        ETC_DEFAULT=$2 ; shift 2
         ;;
         --examples-dir)
         EXAMPLES_DIR=$2 ; shift 2
@@ -97,14 +112,16 @@ for var in PREFIX BUILD_DIR ; do
   fi
 done
 
-MAN_DIR=/usr/share/man/man1
+MAN_DIR=${MAN_DIR:-/usr/share/man}/man1
 DOC_DIR=${DOC_DIR:-/usr/share/doc/zookeeper}
 LIB_DIR=${LIB_DIR:-/usr/lib/zookeeper}
 BIN_DIR=${BIN_DIR:-/usr/bin}
-CONF_DIR=/etc/zookeeper/conf
-CONF_DIST_DIR=/etc/zookeeper/conf.dist/
+ETC_DEFAULT=${ETC_DEFAULT:-/etc/default}
 SYSTEM_INCLUDE_DIR=${SYSTEM_INCLUDE_DIR:-/usr/include}
 SYSTEM_LIB_DIR=${SYSTEM_LIB_DIR:-/usr/lib}
+
+CONF_DIR=/etc/zookeeper/conf
+CONF_DIST_DIR=${CONF_DIST_DIR:-/etc/zookeeper/conf.dist}
 
 tar -z -x -f zookeeper-assembly/target/apache-zookeeper-*-bin.tar.gz
 install -d -m 0755 $PREFIX/$LIB_DIR/
@@ -144,7 +161,7 @@ for i in zkServer.sh zkEnv.sh zkCli.sh zkCleanup.sh zkServer-initialize.sh
 	chmod 755 $PREFIX/$LIB_DIR/bin/$i
 done
 
-wrapper=$PREFIX/usr/bin/zookeeper-client
+wrapper=$PREFIX/$BIN_DIR/zookeeper-client
 install -d -m 0755 `dirname $wrapper`
 cat > $wrapper <<EOF
 #!/bin/bash
@@ -161,7 +178,7 @@ EOF
 chmod 755 $wrapper
 
 for pairs in zkServer.sh/zookeeper-server zkServer-initialize.sh/zookeeper-server-initialize zkCleanup.sh/zookeeper-server-cleanup ; do
-  wrapper=$PREFIX/usr/bin/`basename $pairs`
+  wrapper=$PREFIX/$BIN_DIR/`basename $pairs`
   upstream_script=`dirname $pairs`
   cat > $wrapper <<EOF
 #!/bin/bash
@@ -188,8 +205,8 @@ install -d -m 0755 $PREFIX/$DOC_DIR
 cp -a $BUILD_DIR/docs/* $PREFIX/$DOC_DIR
 cp $BUILD_DIR/*.txt $PREFIX/$DOC_DIR/
 
-install -d -m 0755 ${PREFIX}/etc/default
-cp zookeeper.default ${PREFIX}/etc/default/zookeeper
+install -d -m 0755 $PREFIX/$ETC_DEFAULT
+cp zookeeper.default $PREFIX/$ETC_DEFAULT/zookeeper
 
 install -d -m 0755 $PREFIX/$MAN_DIR
 gzip -c zookeeper.1 > $PREFIX/$MAN_DIR/zookeeper.1.gz
@@ -212,7 +229,7 @@ for binary in ${PREFIX}/${LIB_DIR}-native/*; do
 
 PREFIX=\$(dirname \$(readlink -f \$0))
 export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:\${PREFIX}/../lib:\${PREFIX}/../lib64
-/usr/lib/zookeeper-native/`basename ${binary}` \$@
+${LIB_DIR}-native/`basename ${binary}` \$@
 
 EOF
 done

--- a/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
+++ b/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
@@ -28,7 +28,7 @@
 # No prefix directory
 %define np_var_log_zookeeper /var/log/%{name}
 %define np_var_run_zookeeper /var/run/%{name}
-%define np_etc_zookeeper_conf /etc/%{name}/conf
+%define np_etc_zookeeper /etc/%{name}
 
 %define svc_zookeeper %{name}-server
 %define svc_zookeeper_rest %{name}-rest
@@ -200,7 +200,7 @@ getent passwd zookeeper > /dev/null || useradd -c "ZooKeeper" -s /sbin/nologin -
 
 # Manage configuration symlink
 %post
-%{alternatives_cmd} --install %{np_etc_zookeeper_conf} %{name}-conf %{etc_zookeeper_conf_dist} 30
+%{alternatives_cmd} --install %{np_etc_zookeeper}/conf %{name}-conf %{etc_zookeeper_conf_dist} 30
 %__install -d -o zookeeper -g zookeeper -m 0755 %{var_lib_zookeeper}
 
 %preun
@@ -243,6 +243,7 @@ fi
 %defattr(-,root,root)
 %config(noreplace) %{etc_zookeeper_conf_dist}
 %config(noreplace) %{etc_default}/%{name}
+%{np_etc_zookeeper}
 %{usr_lib_zookeeper}
 %{bin_dir}/zookeeper-server
 %{bin_dir}/zookeeper-server-initialize


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR


### How was this patch tested?
Tested with #994 
diff result:
```
76706 blocks
76706 blocks
2d1
< ./etc/zookeeper
2960 blocks
2960 blocks
3,5c3,5
< ./usr/lib/debug/.build-id/14
< ./usr/lib/debug/.build-id/14/f894a8d56d3605a32e06dae10414d8fce637a5
< ./usr/lib/debug/.build-id/14/f894a8d56d3605a32e06dae10414d8fce637a5.debug
---
> ./usr/lib/debug/.build-id/49
> ./usr/lib/debug/.build-id/49/62750d18b3c9b7307c7ef7d759e3534ff094b7
> ./usr/lib/debug/.build-id/49/62750d18b3c9b7307c7ef7d759e3534ff094b7.debug
10,12c10,15
< ./usr/lib/debug/.build-id/bc
< ./usr/lib/debug/.build-id/bc/8fb84dd4b8899b6615b39bae1f853f0cf831c1
< ./usr/lib/debug/.build-id/bc/8fb84dd4b8899b6615b39bae1f853f0cf831c1.debug
---
> ./usr/lib/debug/.build-id/a2
> ./usr/lib/debug/.build-id/a2/97a24eec5b2bc42df57041bdbc0a1472a0fe51
> ./usr/lib/debug/.build-id/a2/97a24eec5b2bc42df57041bdbc0a1472a0fe51.debug
> ./usr/lib/debug/.build-id/c5
> ./usr/lib/debug/.build-id/c5/110b9deb0e345be200298c5bf7907cdaaba8c5
> ./usr/lib/debug/.build-id/c5/110b9deb0e345be200298c5bf7907cdaaba8c5.debug
16,18d18
< ./usr/lib/debug/.build-id/ff
< ./usr/lib/debug/.build-id/ff/b1ec76e1483c67eba6c4e7fd85e935572389e7
< ./usr/lib/debug/.build-id/ff/b1ec76e1483c67eba6c4e7fd85e935572389e7.debug
2553 blocks
2553 blocks
10 blocks
10 blocks
11 blocks
11 blocks
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/