### PR TITLE
BIGTOP-3801: Add maven cache volume for docker provisioner

### DIFF
--- a/packages.gradle
+++ b/packages.gradle
@@ -651,7 +651,8 @@ def genTasks = { target ->
           description: "Invoking a native binary packaging for $target in Docker. Usage: \$ ./gradlew " +
                   "-POS=[centos-7|fedora-35|debian-10|ubuntu-18.04] " +
                   "-Pprefix=[trunk|1.4.0|1.3.0|1.2.1|...] $target-pkg-ind " +
-                  "-Pnexus=[true|false]",
+                  "-Pnexus=[true|false]" +
+                  "[-Pmvn-cache-volume=[true|false]]",
           group: PACKAGES_GROUP) doLast {
     def _prefix = project.hasProperty("prefix") ? prefix : "trunk"
     def _OS = project.hasProperty("OS") ? OS : "centos-7"
@@ -659,6 +660,7 @@ def genTasks = { target ->
       logger.warn(_OS + ' requires privileged mode, pass `-Pdocker-run-option="--privileged"` to gradle option')
     }
     def _target_pkg = "$target-pkg"
+    def _mvn_cache_volume = project.hasProperty("mvn-cache-volume") ? this.'mvn-cache-volume' : ""
     def _docker_run_option = project.hasProperty("docker-run-option") ? this.'docker-run-option' : ""
     def additionalConfigKeys = ['git_repo', 'git_ref', 'git_dir', 'git_commit_hash', 'base_version']
     additionalConfigKeys.each { key ->
@@ -676,6 +678,10 @@ def genTasks = { target ->
     ]
     if ( project.hasProperty("nexus") ) {
       command.add('--nexus')
+    }
+    if ( project.hasProperty("mvn-cache-volume") ) {
+      command.add('--mvn-cache-volume')
+      command.add(_mvn_cache_volume)
     }
 
     println "Building $_prefix $_target_pkg on $_OS in Docker...\n"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
This PR adds an option that adds a docker volume  and mounts `.m2` during the build.
Adding this option, users could reduce the build time by skipping some download processes.

#### Detail

```sh
./gradlew target-ind -POS=ubuntu-20.04 -Pmvn-cache-volume=true
```
or
```sh
cd bigtop-ci; bash -xe ./build.sh --prefix trunk --os ubuntu-20.04 --target zookeeper-pkg --mvn-cache true
```
With this option, bigtop create docker volume that named `bigtop-mvn-cache-$OS` if not exists and mount it on `/var/lib/jenkins/.m2` in the provisioner container. If the volume has already existed, bigtop reuse it.

If users set the option `false`, bigtop try to remove the volume and build without the cache.
If users does not set any option for this, bigtop do nothing for mounting the volume (Same behavior with before).

### How was this patch tested?
I checked on Ubuntu 22.04/x86 host machine.

1st build with the cache option.
```sh
$ nohup ./gradlew zookeeper-clean zookeeper-pkg-ind -POS=ubuntu-20.04 -Pmvn-cache-volume=true > nohup-true-1.out 2>&1 < /dev/null
...
BUILD SUCCESSFUL in 6m 10s
```

Check the volume.
```sh
$ docker volume ls
DRIVER    VOLUME NAME
local     bigtop-mvn-cache-ubuntu-20.04

$ docker run -it --rm -v bigtop-mvn-cache-ubuntu-20.04:/root/.m2 ubuntu:20.04 ls -l /root/.m2/
total 4
drwxr-xr-x 46 1000 1000 4096 Sep  2 06:40 repository
```

2nd build with the cache option
```sh
$ nohup ./gradlew zookeeper-clean zookeeper-pkg-ind -POS=ubuntu-20.04 -Pmvn-cache-volume=true > nohup-true-2.out 2>&1 < /dev/null
...
BUILD SUCCESSFUL in 1m 40s
```

Set the option false
```sh
$ nohup ./gradlew zookeeper-clean zookeeper-pkg-ind -POS=ubuntu-20.04 -Pmvn-cache-volume=false > nohup-false.out 2>&1 < /dev/null &
...
BUILD SUCCESSFUL in 6m 14s
```

Check the deletion 
```sh
$ docker volume ls
DRIVER    VOLUME NAME
```

Set no option
```sh
$ nohup ./gradlew zookeeper-clean zookeeper-pkg-ind -POS=ubuntu-20.04 > nohup-no.out 2>&1 < /dev/null &
...
BUILD SUCCESSFUL in 6m 10s
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/