### PR TITLE
BIGTOP-3805: Support parent directory configuration for Spark rpm build script

### DIFF
--- a/bigtop-packages/src/common/spark/install_spark.sh
+++ b/bigtop-packages/src/common/spark/install_spark.sh
@@ -32,7 +32,7 @@ usage: $0 <options>
      --bin-dir=DIR               path to install bins [/usr/bin]
      --man-dir=DIR               path to install mans [/usr/share/man]
      --etc-default=DIR           path to bigtop default dir [/etc/default]
-     --etc-spark=DIR             path to install hive conf [/etc/spark]
+     --etc-spark=DIR             path to install spark conf [/etc/spark]
      ... [ see source for more similar options ]
   "
   exit 1


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR


### How was this patch tested?
diff result:
```
467490 blocks
467490 blocks
8386 blocks
8386 blocks
69792 blocks
69792 blocks
10 blocks
10 blocks
10 blocks
10 blocks
25856 blocks
25856 blocks
13786 blocks
13790 blocks
10 blocks
10 blocks
10 blocks
10 blocks
26599 blocks
26599 blocks
```


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/