### PR TITLE
BIGTOP-3810: Fix wrong home configuration for HTTPFS on build scripts

### DIFF
--- a/bigtop-packages/src/deb/hadoop/hadoop-httpfs.preinst
+++ b/bigtop-packages/src/deb/hadoop/hadoop-httpfs.preinst
@@ -37,7 +37,7 @@ case "$1" in
             adduser \
                 --system \
                 --ingroup httpfs \
-                --home /var/run/hadoop-httpfs \
+                --home /var/lib/hadoop-httpfs \
                 --gecos "Hadoop HTTPFS" \
                 --shell /bin/bash \
                 httpfs >/dev/null 2>/dev/null || :

--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -620,7 +620,7 @@ getent passwd hdfs >/dev/null || /usr/sbin/useradd --comment "Hadoop HDFS" --she
 
 %pre httpfs
 getent group httpfs >/dev/null   || groupadd -r httpfs
-getent passwd httpfs >/dev/null || /usr/sbin/useradd --comment "Hadoop HTTPFS" --shell /bin/bash -M -r -g httpfs -G httpfs --home %{run_httpfs} httpfs
+getent passwd httpfs >/dev/null || /usr/sbin/useradd --comment "Hadoop HTTPFS" --shell /bin/bash -M -r -g httpfs -G httpfs --home %{state_httpfs} httpfs
 
 %pre kms
 getent group kms >/dev/null   || groupadd -r kms


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/