### PR TITLE
BIGTOP-3814. Deploying Spark ThriftServer fails because it's launched too early.

### DIFF
--- a/bigtop-deploy/puppet/modules/spark/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/spark/manifests/init.pp
@@ -63,7 +63,8 @@ class spark {
       hasrestart => true,
       hasstatus  => true,
     }
-    
+
+    Exec<| title == "init hdfs" |> -> Service["spark-thriftserver"]
   }
 
   class client {


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

- This PR defers Spark ThriftServer's launch after initializing HDFS so that the launch succeeds.

### How was this patch tested?

- Ran `./docker-hadoop.sh -d -C config_rockylinux-8.yaml -r file:///bigtop-home/output -G -k hdfs,yarn,spark -c 3` locally.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/