### PR TITLE
BIGTOP-3815. Fix failure of installing hadoop-httpfs deb due to change of httpfs home dir.

### DIFF
--- a/bigtop-packages/src/deb/hadoop/hadoop-httpfs.postinst
+++ b/bigtop-packages/src/deb/hadoop/hadoop-httpfs.postinst
@@ -21,6 +21,7 @@ set -e
 
 case "$1" in
     configure)
+        mkdir -p /var/log/hadoop-httpfs /var/run/hadoop-httpfs || :
         chown httpfs:httpfs /var/run/hadoop-httpfs /var/log/hadoop-httpfs /var/lib/hadoop-httpfs
     ;;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3815

This is a follow-up of #1007 causing following error.

```
Setting up hadoop-httpfs (3.3.4-1) ...
chown: cannot access '/var/run/hadoop-httpfs': No such file or directory
dpkg: error processing package hadoop-httpfs (--configure):
```