### PR TITLE
BIGTOP-3804: Add quicklinks for HDFS/YARN/MapReduce

### DIFF
--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HDFS/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HDFS/metainfo.xml
@@ -362,6 +362,13 @@
       </configuration-dependencies>
       <restartRequiredAfterRackChange>true</restartRequiredAfterRackChange>
 
+      <quickLinksConfigurations>
+        <quickLinksConfiguration>
+          <fileName>quicklinks.json</fileName>
+          <default>true</default>
+        </quickLinksConfiguration>
+      </quickLinksConfigurations>
+
       <themes>
         <theme>
           <fileName>directories.json</fileName>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HDFS/quicklinks/quicklinks.json
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HDFS/quicklinks/quicklinks.json
@@ -1,0 +1,80 @@
+{
+  "name": "default",
+  "description": "default quick links configuration",
+  "configuration": {
+    "protocol":
+    {
+      "type":"https",
+      "checks":[
+        {
+          "property":"dfs.http.policy",
+          "desired":"HTTPS_ONLY",
+          "site":"hdfs-site"
+        }
+      ]
+    },
+
+    "links": [
+      {
+        "name": "namenode_ui",
+        "label": "NameNode UI",
+        "component_name": "NAMENODE",
+        "url":"%@://%@:%@",
+        "requires_user_name": "false",
+        "port":{
+          "http_property": "dfs.namenode.http-address",
+          "http_default_port": "50070",
+          "https_property": "dfs.namenode.https-address",
+          "https_default_port": "50470",
+          "regex": "\\w*:(\\d+)",
+          "site": "hdfs-site"
+        }
+      },
+      {
+        "name": "namenode_logs",
+        "label": "NameNode Logs",
+        "component_name": "NAMENODE",
+        "url":"%@://%@:%@/logs",
+        "requires_user_name": "false",
+        "port":{
+          "http_property": "dfs.namenode.http-address",
+          "http_default_port": "50070",
+          "https_property": "dfs.namenode.https-address",
+          "https_default_port": "50470",
+          "regex": "\\w*:(\\d+)",
+          "site": "hdfs-site"
+        }
+      },
+      {
+        "name": "namenode_jmx",
+        "label": "NameNode JMX",
+        "component_name": "NAMENODE",
+        "url":"%@://%@:%@/jmx",
+        "requires_user_name": "false",
+        "port":{
+          "http_property": "dfs.namenode.http-address",
+          "http_default_port": "50070",
+          "https_property": "dfs.namenode.https-address",
+          "https_default_port": "50470",
+          "regex": "\\w*:(\\d+)",
+          "site": "hdfs-site"
+        }
+      },
+      {
+        "name": "Thread Stacks",
+        "label": "Thread Stacks",
+        "component_name": "NAMENODE",
+        "url":"%@://%@:%@/stacks",
+        "requires_user_name": "false",
+        "port":{
+          "http_property": "dfs.namenode.http-address",
+          "http_default_port": "50070",
+          "https_property": "dfs.namenode.https-address",
+          "https_default_port": "50470",
+          "regex": "\\w*:(\\d+)",
+          "site": "hdfs-site"
+        }
+      }
+    ]
+  }
+}

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/configuration-mapred/mapred-env.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/configuration-mapred/mapred-env.xml
@@ -96,8 +96,8 @@ export HADOOP_JOB_HISTORYSERVER_HEAPSIZE={{jobhistory_heapsize}}
 export HADOOP_ROOT_LOGGER=INFO,RFA
 
 # Could be enabled from deployment option if necessary
-#export MAPRED_HISTORYSERVER_OPTS=
-#export HADOOP_LOG_DIR="" # Where log files are stored.  $HADOOP_MAPRED_HOME/logs by default.
+export HADOOP_LOG_DIR={{mapred_log_dir_prefix}}/$USER  # Where log files are stored.  $HADOOP_MAPRED_HOME/logs by default.
+export MAPRED_HISTORYSERVER_OPTS="$MAPRED_HISTORYSERVER_OPTS -Dhadoop.log.dir=$HADOOP_LOG_DIR"
 #export HADOOP_JHS_LOGGER=INFO,RFA # Hadoop JobSummary logger.
 #export HADOOP_PID_DIR= # The pid files are stored. /tmp by default.
 #export HADOOP_IDENT_STRING= #A string representing this instance of hadoop. $USER by default

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/metainfo.xml
@@ -168,6 +168,13 @@
         <service>ZOOKEEPER</service>
       </requiredServices>
 
+      <quickLinksConfigurations>
+        <quickLinksConfiguration>
+          <fileName>quicklinks.json</fileName>
+          <default>true</default>
+        </quickLinksConfiguration>
+      </quickLinksConfigurations>
+
       <configuration-dependencies>
         <config-type>yarn-site</config-type>
         <config-type>yarn-env</config-type>
@@ -295,6 +302,14 @@
       <requiredServices>
         <service>YARN</service>
       </requiredServices>
+
+      <quickLinksConfigurations-dir>quicklinks-mapred</quickLinksConfigurations-dir>
+      <quickLinksConfigurations>
+        <quickLinksConfiguration>
+          <fileName>quicklinks.json</fileName>
+          <default>true</default>
+        </quickLinksConfiguration>
+      </quickLinksConfigurations>
 
       <configuration-dir>configuration-mapred</configuration-dir>
 

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/quicklinks-mapred/quicklinks.json
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/quicklinks-mapred/quicklinks.json
@@ -1,0 +1,80 @@
+{
+  "name": "default",
+  "description": "default quick links configuration",
+  "configuration": {
+    "protocol":
+    {
+      "type":"https",
+      "checks":[
+        {
+          "property":"mapreduce.jobhistory.http.policy",
+          "desired":"HTTPS_ONLY",
+          "site":"mapred-site"
+        }
+      ]
+    },
+
+    "links": [
+      {
+        "name": "jobhistory_ui",
+        "label": "JobHistory UI",
+        "requires_user_name": "false",
+        "component_name": "HISTORYSERVER",
+        "url": "%@://%@:%@",
+        "port":{
+          "http_property": "mapreduce.jobhistory.webapp.address",
+          "http_default_port": "19888",
+          "https_property": "mapreduce.jobhistory.webapp.https.address",
+          "https_default_port": "8090",
+          "regex": "\\w*:(\\d+)",
+          "site": "mapred-site"
+        }
+      },
+      {
+        "name": "jobhistory_logs",
+        "label": "JobHistory logs",
+        "requires_user_name": "false",
+        "component_name": "HISTORYSERVER",
+        "url": "%@://%@:%@/logs",
+        "port":{
+          "http_property": "mapreduce.jobhistory.webapp.address",
+          "http_default_port": "19888",
+          "https_property": "mapreduce.jobhistory.webapp.https.address",
+          "https_default_port": "8090",
+          "regex": "\\w*:(\\d+)",
+          "site": "mapred-site"
+        }
+      },
+      {
+        "name":"jobhistory_jmx",
+        "label":"JobHistory JMX",
+        "requires_user_name":"false",
+        "component_name": "HISTORYSERVER",
+        "url":"%@://%@:%@/jmx",
+        "port":{
+          "http_property": "mapreduce.jobhistory.webapp.address",
+          "http_default_port": "19888",
+          "https_property": "mapreduce.jobhistory.webapp.https.address",
+          "https_default_port": "8090",
+          "regex": "\\w*:(\\d+)",
+          "site": "mapred-site"
+        }
+      },
+      {
+        "name":"thread_stacks",
+        "label":"Thread Stacks",
+        "requires_user_name": "false",
+        "component_name": "HISTORYSERVER",
+        "url":"%@://%@:%@/stacks",
+        "port":{
+          "http_property": "mapreduce.jobhistory.webapp.address",
+          "http_default_port": "19888",
+          "https_property": "mapreduce.jobhistory.webapp.https.address",
+          "https_default_port": "8090",
+          "regex": "\\w*:(\\d+)",
+          "site": "mapred-site"
+        }
+      }
+    ]
+  }
+}

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/quicklinks-mapred/quicklinks.json
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/quicklinks-mapred/quicklinks.json
@@ -32,7 +32,7 @@
       },
       {
         "name": "jobhistory_logs",
-        "label": "JobHistory logs",
+        "label": "JobHistory Logs",
         "requires_user_name": "false",
         "component_name": "HISTORYSERVER",
         "url": "%@://%@:%@/logs",

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/quicklinks/quicklinks.json
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/quicklinks/quicklinks.json
@@ -1,0 +1,80 @@
+{
+  "name": "default",
+  "description": "default quick links configuration",
+  "configuration": {
+    "protocol":
+    {
+      "type":"https",
+      "checks":[
+        {
+          "property":"yarn.http.policy",
+          "desired":"HTTPS_ONLY",
+          "site":"yarn-site"
+        }
+      ]
+    },
+
+    "links": [
+      {
+        "name": "resourcemanager_ui",
+        "label": "ResourceManager UI",
+        "requires_user_name": "false",
+        "component_name": "RESOURCEMANAGER",
+        "url": "%@://%@:%@",
+        "port":{
+          "http_property": "yarn.resourcemanager.webapp.address",
+          "http_default_port": "8088",
+          "https_property": "yarn.resourcemanager.webapp.https.address",
+          "https_default_port": "8090",
+          "regex": "\\w*:(\\d+)",
+          "site": "yarn-site"
+        }
+      },
+      {
+        "name": "resourcemanager_logs",
+        "label": "ResourceManager logs",
+        "requires_user_name": "false",
+        "component_name": "RESOURCEMANAGER",
+        "url": "%@://%@:%@/logs",
+        "port":{
+          "http_property": "yarn.resourcemanager.webapp.address",
+          "http_default_port": "8088",
+          "https_property": "yarn.resourcemanager.webapp.https.address",
+          "https_default_port": "8090",
+          "regex": "\\w*:(\\d+)",
+          "site": "yarn-site"
+        }
+      },
+      {
+        "name": "resourcemanager_jmx",
+        "label":"ResourceManager JMX",
+        "requires_user_name": "false",
+        "component_name": "RESOURCEMANAGER",
+        "url":"%@://%@:%@/jmx",
+        "port":{
+          "http_property": "yarn.resourcemanager.webapp.address",
+          "http_default_port": "8088",
+          "https_property": "yarn.resourcemanager.webapp.https.address",
+          "https_default_port": "8090",
+          "regex": "\\w*:(\\d+)",
+          "site": "yarn-site"
+        }
+      },
+      {
+        "name": "thread_stacks",
+        "label":"Thread Stacks",
+        "requires_user_name": "false",
+        "component_name": "RESOURCEMANAGER",
+        "url":"%@://%@:%@/stacks",
+        "port":{
+          "http_property": "yarn.resourcemanager.webapp.address",
+          "http_default_port": "8088",
+          "https_property": "yarn.resourcemanager.webapp.https.address",
+          "https_default_port": "8090",
+          "regex": "\\w*:(\\d+)",
+          "site": "yarn-site"
+        }
+      }
+    ]
+  }
+}

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/quicklinks/quicklinks.json
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/quicklinks/quicklinks.json
@@ -32,7 +32,7 @@
       },
       {
         "name": "resourcemanager_logs",
-        "label": "ResourceManager logs",
+        "label": "ResourceManager Logs",
         "requires_user_name": "false",
         "component_name": "RESOURCEMANAGER",
         "url": "%@://%@:%@/logs",


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
1 add quicklinks for HDFS/YARN/MapReduce
2 fix the bug that cann't access to http://mr-historyserver-host:19888/logs

### How was this patch tested?
Tested in local vm cluster, including kerberos authentication

hdfs quicklink
![ed0282e8366a640a13110e8db941ba1](https://user-images.githubusercontent.com/13212217/190347037-b529f4cd-1db6-40e0-b71f-5a721a2b1401.jpg)

yarn quicklink
![887a9794d310e2598fb8247025aa9fc](https://user-images.githubusercontent.com/13212217/190347142-d0b860ba-16d2-4156-afb5-4b5ad675b210.jpg)

mr quicklink

![58142fe210fa16130eef08b4ecfd137](https://user-images.githubusercontent.com/13212217/190347220-099d1938-cf36-49ce-bc30-e026fc35de10.jpg)

mr logs ui
![cd3fa4175fd8036d3c4c87e2f73e52d](https://user-images.githubusercontent.com/13212217/190347219-c9da2e0b-7f35-490c-99aa-a9bc857802a9.jpg)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/