### PR TITLE
BIGTOP-3816: Fails to enable NameNode HA

### DIFF
--- a/bigtop-packages/src/common/ambari/patch11-namenode-ha-wizard-error.diff
+++ b/bigtop-packages/src/common/ambari/patch11-namenode-ha-wizard-error.diff
@@ -1,0 +1,18 @@
+diff --git a/ambari-web/app/controllers/main/admin/highAvailability/nameNode/step7_controller.js b/ambari-web/app/controllers/main/admin/highAvailability/nameNode/step7_controller.js
+index 722668cf05..27ea705e48 100644
+--- a/ambari-web/app/controllers/main/admin/highAvailability/nameNode/step7_controller.js
++++ b/ambari-web/app/controllers/main/admin/highAvailability/nameNode/step7_controller.js
+@@ -32,11 +32,11 @@ App.HighAvailabilityWizardStep7Controller = App.HighAvailabilityProgressPageCont
+       tasksToRemove.push('startAmbariInfra');
+     }
+ 
+-    if (App.ClientComponent.getModelByComponentName('RANGER_ADMIN').get('installedCount') === 0) {
++    if (App.ClientComponent.getModelByComponentName('RANGER_ADMIN') == null || App.ClientComponent.getModelByComponentName('RANGER_ADMIN').get('installedCount') === 0) {
+       tasksToRemove.push('startRanger');
+     }
+ 
+-    if (App.ClientComponent.getModelByComponentName('MYSQL_SERVER').get('installedCount') === 0) {
++    if (App.ClientComponent.getModelByComponentName('MYSQL_SERVER') == null || App.ClientComponent.getModelByComponentName('MYSQL_SERVER').get('installedCount') === 0) {
+       tasksToRemove.push('startMysqlServer');
+     }
+ 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
NameNode HA wizard runs into an error.
The reason is that mpack lacks relevant components.

![image](https://user-images.githubusercontent.com/13212217/190561107-ddfab545-6ef5-4eb7-bda5-bec1cff1192a.png)


### How was this patch tested?
Tested in local vm cluster.
NameNode HA now can be enabled step by step smoothly.

![image](https://user-images.githubusercontent.com/13212217/190561243-9e13b993-d324-41ab-98f8-4a126796e4f6.png)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/