### PR TITLE
BIGTOP-3817: HdfsResource didn't chown again when reupload local file in resource_management for Ambari-2.7.5

### DIFF
--- a/bigtop-packages/src/common/ambari/patch12-AMBARI-25731.diff
+++ b/bigtop-packages/src/common/ambari/patch12-AMBARI-25731.diff
@@ -1,0 +1,14 @@
+diff --git a/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py b/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
+index 301f2b8b63..59cab65d6a 100644
+--- a/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
++++ b/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
+@@ -533,6 +533,9 @@ class HdfsResourceWebHDFS:
+ 
+     self.util.run_command(target, 'CREATE', method='PUT', overwrite=True, assertable_result=False, file_to_put=source, **kwargs)
+ 
++    # Get file status again after file reupload
++    self.target_status = self._get_file_status(target)
++
+     if mode and file_status:
+       file_status['permission'] = mode
+ 


### PR DESCRIPTION
BIGTOP-3817:  HdfsResource didn't chown again when reupload local file in resource_management for Ambari-2.7.5

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/