### PR TITLE
BIGTOP-3818. Phoenix Don't Requre Hadoop and Zookeeper Installed

### DIFF
--- a/bigtop-packages/src/deb/phoenix/control
+++ b/bigtop-packages/src/deb/phoenix/control
@@ -23,7 +23,7 @@ Homepage: http://phoenix.apache.org
 
 Package: phoenix
 Architecture: all
-Depends: zookeeper, hadoop, hadoop-mapreduce, hadoop-yarn, hbase, bigtop-utils (>= 0.7)
+Depends: bigtop-utils (>= 0.7)
 Description: Phoenix is a SQL skin over HBase and client-embedded JDBC driver.
  Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
  The Phoenix query engine transforms an SQL query into one or more HBase scans,

--- a/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
+++ b/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
@@ -84,7 +84,7 @@ Source1: do-component-build
 Source2: install_phoenix.sh
 Source3: bigtop.bom
 BuildArch: noarch
-Requires: hadoop, hadoop-mapreduce, hadoop-yarn, hbase, zookeeper
+Requires: bigtop-utils >= 0.7
 
 %if  0%{?mgaversion}
 Requires: bsh-utils


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

When we deploy Phoenix, we just need to move phoenix-server.jar to hbase lib dir.
So I think the package requires is redundant.

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/