### PR TITLE
BIGTOP-3828: Docker network resource continues to remain when use doc…

### DIFF
--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -211,10 +211,16 @@ destroy() {
     else
         get_nodes
         docker exec ${NODES[0]} bash -c "umount /etc/hosts; rm -f /etc/hosts"
+        NETWORK_ID=`docker network ls | grep ${PROVISION_ID}_default`
+
         if [ -n "$PROVISION_ID" ]; then
             $DOCKER_COMPOSE_CMD -p $PROVISION_ID stop
             $DOCKER_COMPOSE_CMD -p $PROVISION_ID rm -f
         fi
+
+        if [ -n "$NETWORK_ID" ]; then
+            docker network rm ${PROVISION_ID}_default
+        fi 
         rm -rvf ./config .provision_id .error_msg*
     fi
 }

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -211,7 +211,7 @@ destroy() {
     else
         get_nodes
         docker exec ${NODES[0]} bash -c "umount /etc/hosts; rm -f /etc/hosts"
-        NETWORK_ID=`docker network ls | grep ${PROVISION_ID}_default`
+        NETWORK_ID=`docker network ls --quiet --filter name=${PROVISION_ID}_default`
 
         if [ -n "$PROVISION_ID" ]; then
             $DOCKER_COMPOSE_CMD -p $PROVISION_ID stop


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3828

The option -d or --destroy in docker-hadoop.sh can destroy cluster by provisioner id, but the network resource is remaining after deletion.

Add steps to romeve network resources in -d option if network is exists.
The network is created as "$PROVISION_ID + _default"