### PR TITLE
BIGTOP-3845: Add the command to create the /usr/bigtop folder in the bigtop-select rpm package

### DIFF
--- a/bigtop-packages/src/common/bigtop-select/install_select.sh
+++ b/bigtop-packages/src/common/bigtop-select/install_select.sh
@@ -67,10 +67,12 @@ LIB_DIR=${LIB_DIR:-/usr/lib/bigtop-select}
 BIN_DIR=${BIN_DIR:-/usr/bin}
 CONF_DIR=${CONF_DIR:-/etc/bigtop-select/conf.dist}
 
+STACK_ROOT_DIR=/usr/bigtop
 STACK_SELECTOR=distro-select
 CONF_SELECTOR=conf-select
 
 # Install packages
 install -d -p -m 755 $PREFIX${LIB_DIR}/
+install -d -p -m 755 $PREFIX${STACK_ROOT_DIR}/
 install -p -m 755 ${DISTRO_DIR}/${STACK_SELECTOR} $PREFIX${LIB_DIR}/
 install -p -m 755 ${DISTRO_DIR}/${CONF_SELECTOR} $PREFIX${LIB_DIR}/

--- a/bigtop-packages/src/rpm/bigtop-select/SPECS/bigtop-select.spec
+++ b/bigtop-packages/src/rpm/bigtop-select/SPECS/bigtop-select.spec
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-%define lib_dir /usr/lib/bigtop-select
-%define bin_dir /usr/bin
+%define lib_dir        /usr/lib/bigtop-select
+%define bin_dir        /usr/bin
+%define stack_root_dir /usr/bigtop
 
 Name: bigtop-select
 Version: %{bigtop_select_version}
@@ -69,7 +70,7 @@ rm -rf $RPM_BUILD_ROOT
 %doc LICENSE
 
 %{lib_dir}
-#%{bin_dir}
+%{stack_root_dir}
 
 %changelog
 


### PR DESCRIPTION
BIGTOP-3845: Add the command to create the /usr/bigtop folder in the bigtop-select rpm package

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/