### PR TITLE
BIGTOP-3848 Rangeradmin does not start with Hadoop 3.3.4

### DIFF
--- a/bigtop-packages/src/common/ranger/patch2-pull-172.diff
+++ b/bigtop-packages/src/common/ranger/patch2-pull-172.diff
@@ -1,0 +1,13 @@
+diff --git a/pom.xml b/pom.xml
+index 8b700d0d3..84e023e7a 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -99,7 +99,7 @@
+         <commons.collections.version>3.2.2</commons.collections.version>
+         <commons.compress.version>1.8.1</commons.compress.version>
+         <commons.configuration1.version>1.10</commons.configuration1.version>
+-        <commons.configuration.version>2.1.1</commons.configuration.version>
++        <commons.configuration.version>2.8.0</commons.configuration.version>
+         <commons.dbcp.version>1.4</commons.dbcp.version>
+         <commons.digester.version>2.1</commons.digester.version>
+         <commons.io.version>2.5</commons.io.version>


### PR DESCRIPTION
### Description of the PR
When starting rangeradmin with Hadoop 3.3.4, Rangeradmin throws a NoClassDefFoundError.
```
Exception in thread "main" java.lang.NoClassDefFoundError: com/ctc/wstx/io/InputBootstrapper
    at org.apache.ranger.credentialapi.CredentialReader.getDecryptedString(CredentialReader.java:39)
    at org.apache.ranger.credentialapi.buildks.createCredential(buildks.java:87)
    at org.apache.ranger.credentialapi.buildks.main(buildks.java:41)
Caused by: java.lang.ClassNotFoundException: com.ctc.wstx.io.InputBootstrapper
    at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
    ... 3 more
```
This is described in https://github.com/apache/ranger/pull/172

### How was this patch tested?

Add patch file to bump commons.configuration.version to 2.8.0

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/