### PR TITLE
BIGTOP-3850: Conflict occurs when installing both ranger-hdfs-plugin …

### DIFF
--- a/bigtop-packages/src/common/ranger/install_ranger.sh
+++ b/bigtop-packages/src/common/ranger/install_ranger.sh
@@ -123,7 +123,7 @@ if [[ "${COMPONENT}" =~ ^(admin|usersync|tagsync|kms)$ ]]; then
 else
   RANGER_COMPONENT=${COMPONENT}
   if [[ "${COMPONENT}" = "hdfs-plugin" || "${COMPONENT}" = "yarn-plugin" ]];then
-    RANGER_COMPONENT="hadoop"
+    RANGER_COMPONENT="hadoop-$(echo $COMPONENT | cut -d '-' -f 1)"
   else
     RANGER_COMPONENT=$(echo $COMPONENT | cut -d '-' -f 1)
   fi

--- a/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
+++ b/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
@@ -21,6 +21,8 @@
 %define np_etc_ranger /etc/%{ranger_name}
 
 %define usr_lib_hadoop %{parent_dir}/usr/lib/hadoop
+%define usr_lib_hdfs %{hadoop_home}-hdfs
+%define usr_lib_yarn %{hadoop_home}-yarn
 %define usr_lib_hive %{parent_dir}/usr/lib/hive
 %define usr_lib_knox %{parent_dir}/usr/lib/knox
 %define usr_lib_storm %{parent_dir}/usr/lib/storm
@@ -536,12 +538,12 @@ fi
 %files hdfs-plugin
 %defattr(-,root,root,755)
 %{usr_lib_ranger}-hdfs-plugin
-%{usr_lib_hadoop}/lib
+%{usr_lib_hdfs}/lib
 
 %files yarn-plugin
 %defattr(-,root,root,755)
 %{usr_lib_ranger}-yarn-plugin
-%{usr_lib_hadoop}/lib
+%{usr_lib_yarn}/lib
 
 %files hive-plugin
 %defattr(-,root,root,755)


### PR DESCRIPTION
…and ranger-yarn-plugin

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

`ranger-hdfs-plugin` and `ranger-yarn-plugin` install jars on the same directory, `/usr/lib/hadoop/lib`. If both NameNode and ResourceManager are installed on the same machine, it could be a problem when installing or upgrading plugins respectively. It should be separated.


### How was this patch tested?

Manually tested on private on-premise hadoop cluster.
NameNode and ResourceManager are located on the same machine.
Try install & upgrade `ranger-hdfs-plugin` and `ranger-yarn-plugin` respectively.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3850. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/