### PR TITLE
BIGTOP-3852: Java 11 to bigtop-toolchain to use it in docker container during packaging

### DIFF
--- a/bigtop-ci/build.sh
+++ b/bigtop-ci/build.sh
@@ -17,7 +17,8 @@
 BIGTOP_HOME=`cd $(dirname $0)/.. && pwd`
 
 usage() {
-    echo "usage build.sh --prefix trunk|1.4.0|1.3.0|... --os debian-10|centos-7|... --target hadoop|tez|... [--nexus] [--mvn-cache-volume true|false] [--docker-run-option ...]"
+    echo "usage build.sh --prefix trunk|1.4.0|1.3.0|... --os debian-10|centos-7|... --target hadoop|tez|..."
+    echo "   [--nexus] [--preferred-java-version 8|11] [--mvn-cache-volume true|false] [--docker-run-option ...]"
     exit 1 # unknown option
 }
 
@@ -44,6 +45,10 @@ case $key in
     -n|--nexus)
     NEXUS="--net=container:nexus"
     CONFIGURE_NEXUS="configure-nexus"
+    shift
+    ;;
+    --preferred-java-version)
+    BIGTOP_PREFERRED_JAVA_VERSION="$2"
     shift
     ;;
     --mvn-cache-volume)
@@ -77,6 +82,13 @@ IMAGE_NAME=bigtop/slaves:$PREFIX-$OS
 ARCH=$(uname -m)
 if [ "x86_64" != $ARCH ]; then
     IMAGE_NAME=$IMAGE_NAME-$ARCH
+fi
+
+if [ -n "${BIGTOP_PREFERRED_JAVA_VERSION}" ]; then
+  if [ "${BIGTOP_PREFERRED_JAVA_VERSION}" == "8" ]; then
+    BIGTOP_PREFERRED_JAVA_VERSION="1.8.0"
+  fi
+  DOCKER_RUN_OPTION="${DOCKER_RUN_OPTION} -e BIGTOP_PREFERRED_JAVA_VERSION=${BIGTOP_PREFERRED_JAVA_VERSION}"
 fi
 
 # Add / Delete named volume for maven cache

--- a/bigtop-packages/src/common/kafka/do-component-build
+++ b/bigtop-packages/src/common/kafka/do-component-build
@@ -23,6 +23,12 @@ BUILD_OPTS="-Divy.home=${HOME}/.ivy2 -Dsbt.ivy.home=${HOME}/.ivy2 -Duser.home=${
             -Dreactor.repo=file://${HOME}/.m2/repository \
             -DskipTests -DrecompileMode=all"
 
+# if BIGTOP_PREFERRED_JAVA_VERSION is set, switch java version for the build
+if [ -n "${BIGTOP_PREFERRED_JAVA_VERSION}" ]; then
+  export JAVA_HOME="/usr/lib/jvm/java-${BIGTOP_PREFERRED_JAVA_VERSION}"
+  export PATH=$JAVA_HOME/bin:$PATH
+fi
+
 ## this might be an issue at times
 #        http://maven.40175.n5.nabble.com/Not-finding-artifact-in-local-repo-td3727753.html
 export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"

--- a/bigtop_toolchain/manifests/installer.pp
+++ b/bigtop_toolchain/manifests/installer.pp
@@ -37,15 +37,15 @@ class bigtop_toolchain::installer {
     }
     /Ubuntu/: {
       exec { 'ensure java 8 is set as default':
-        command => "update-java-alternatives --set java-1.8.0-openjdk*",
+        command => "update-java-alternatives --set java-1.8.0-openjdk-$(dpkg --print-architecture)",
         path    => ['/usr/sbin', '/usr/bin', '/bin'],
         require => Class['bigtop_toolchain::jdk'],
       }
     }
     /(CentOS|Fedora|RedHat)/: {
       exec { 'ensure java 8 is set as default':
-        command => "update-alternatives --set java $(readlink -f /usr/lib/jvm/jre-1.8.0/bin/java) \
-                    && update-alternatives --set javac $(readlink -f /usr/lib/jvm/java-1.8.0/bin/javac)",
+        command => "update-alternatives --set java java-1.8.0-openjdk.$(uname -m) \
+                    && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)",
         path    => ['/usr/sbin', '/usr/bin', '/bin'],
         require => Class['bigtop_toolchain::jdk'],
       }

--- a/bigtop_toolchain/manifests/installer.pp
+++ b/bigtop_toolchain/manifests/installer.pp
@@ -25,6 +25,32 @@ class bigtop_toolchain::installer {
   include bigtop_toolchain::user
   include bigtop_toolchain::renv
   include bigtop_toolchain::grpc
+  Class['bigtop_toolchain::jdk11']->Class['bigtop_toolchain::jdk']
+
+  case $::operatingsystem {
+    /Debian/: {
+      exec { 'ensure java 8 is set as default':
+        command => "update-java-alternatives --set adoptopenjdk-8*",
+        path    => ['/usr/sbin', '/usr/bin', '/bin'],
+        require => Class['bigtop_toolchain::jdk'],
+      }
+    }
+    /Ubuntu/: {
+      exec { 'ensure java 8 is set as default':
+        command => "update-java-alternatives --set java-1.8.0-openjdk*",
+        path    => ['/usr/sbin', '/usr/bin', '/bin'],
+        require => Class['bigtop_toolchain::jdk'],
+      }
+    }
+    /(CentOS|Fedora|RedHat)/: {
+      exec { 'ensure java 8 is set as default':
+        command => "update-alternatives --set java $(readlink -f /usr/lib/jvm/jre-1.8.0/bin/java) \
+                    && update-alternatives --set javac $(readlink -f /usr/lib/jvm/java-1.8.0/bin/javac)",
+        path    => ['/usr/sbin', '/usr/bin', '/bin'],
+        require => Class['bigtop_toolchain::jdk'],
+      }
+    }
+  }
 
   stage { 'last':
     require => Stage['main'],

--- a/bigtop_toolchain/manifests/jdk11.pp
+++ b/bigtop_toolchain/manifests/jdk11.pp
@@ -13,21 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class bigtop_toolchain::installer {
-  include bigtop_toolchain::jdk11
-  include bigtop_toolchain::jdk
-  include bigtop_toolchain::maven
-  include bigtop_toolchain::ant
-  include bigtop_toolchain::gradle
-  include bigtop_toolchain::protobuf
-  include bigtop_toolchain::packages
-  include bigtop_toolchain::env
-  include bigtop_toolchain::user
-  include bigtop_toolchain::renv
-  include bigtop_toolchain::grpc
+class bigtop_toolchain::jdk11 {
+  case $::operatingsystem {
+    /(Debian|Ubuntu)/: {
+      include apt
 
-  stage { 'last':
-    require => Stage['main'],
+      package { 'openjdk-11-jdk' :
+        ensure  => present,
+      }
+    }
+    /(CentOS|Fedora|RedHat)/: {
+      package { 'java-11-openjdk-devel' :
+        ensure => present
+      }
+    }
   }
-  class { 'bigtop_toolchain::cleanup': stage => 'last' }
 }

--- a/packages.gradle
+++ b/packages.gradle
@@ -652,6 +652,7 @@ def genTasks = { target ->
                   "-POS=[centos-7|fedora-35|debian-10|ubuntu-18.04] " +
                   "-Pprefix=[trunk|1.4.0|1.3.0|1.2.1|...] $target-pkg-ind " +
                   "-Pnexus=[true|false]" +
+                  "[-Ppreferred-java-version=[8|11]]" +
                   "[-Pmvn-cache-volume=[true|false]]",
           group: PACKAGES_GROUP) doLast {
     def _prefix = project.hasProperty("prefix") ? prefix : "trunk"
@@ -660,6 +661,7 @@ def genTasks = { target ->
       logger.warn(_OS + ' requires privileged mode, pass `-Pdocker-run-option="--privileged"` to gradle option')
     }
     def _target_pkg = "$target-pkg"
+    def _preferred_java_version = project.hasProperty("preferred-java-version") ? this.'preferred-java-version' : "8"
     def _mvn_cache_volume = project.hasProperty("mvn-cache-volume") ? this.'mvn-cache-volume' : ""
     def _docker_run_option = project.hasProperty("docker-run-option") ? this.'docker-run-option' : ""
     def additionalConfigKeys = ['git_repo', 'git_ref', 'git_dir', 'git_commit_hash', 'base_version']
@@ -678,6 +680,10 @@ def genTasks = { target ->
     ]
     if ( project.hasProperty("nexus") ) {
       command.add('--nexus')
+    }
+    if ( _preferred_java_version.toInteger() > 8 ) {
+      command.add('--preferred-java-version')
+      command.add( _preferred_java_version)
     }
     if ( project.hasProperty("mvn-cache-volume") ) {
       command.add('--mvn-cache-volume')


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
This PR aims bigtop users can use Java 11 when they package some projects on a docker container.
- The behavior of bigtop is not changed.
- If user set an option, bigtop pass a flag to the docker container by environment variable. If build target project can receive the flag, bigtop switch `JAVA_HOME` to change the Java version.

### How was this patch tested?
#### Installation of JDK 11
I checked below on aarch 64 machine
```sh
# build bigtop/slave
cd docker/bigtop-slaves/
OS_LIST=( ubuntu-18.04 ubuntu-20.04 ubuntu-22.04 debian-10 debian-11 centos-7 rockylinux-8 fedora-35 fedora-36 )
for OS in ${OS_LIST[@]} ; do
  ./build.sh trunk-${OS}
done

# check the installation
for OS in ${OS_LIST[@]} ; do
  echo $OS; 
  docker run -i --rm bigtop/slaves:trunk-$OS-aarch64 ls /usr/lib/jvm;
  echo ""
done
```
The default JAVA_HOME is set to 8 by `/etc/profile.d/bigtop.sh` so installation does not affect on it.

#### Build Kafka 2.8.1 by Java 11
I checked below on aarch 64 machine.
```sh
./gradlew zookeeper-pkg-ind kafka-pkg-ind -Ppreferred-java-version=11 -POS=rockylinux-8
```
I checked Java version by inserting `mvn --version` or `gradle --version` to `do-component-build`.
Zookeeper was build by 8 and Kafka was by 11.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/