### PR TITLE
BIGTOP-3829 The Phoenix component should have python3 as its dependency

### DIFF
--- a/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
+++ b/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
@@ -92,7 +92,7 @@ Requires: bsh-utils
 Requires: coreutils
 %endif
 
-%if  0%{?rocky} >= 8
+%if  0%{?rhel} >= 8
 Requires: python3
 %else
 Requires: python

--- a/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
+++ b/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
@@ -92,6 +92,12 @@ Requires: bsh-utils
 Requires: coreutils
 %endif
 
+%if  0%{?rocky} >= 8
+Requires: python3
+%else
+Requires: python
+%endif
+
 %description
 Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
 The Phoenix query engine transforms an SQL query into one or more HBase scans,


### PR DESCRIPTION
I added  python3 dependency only for rockylinux8 in spec file.
I can find python3 requirement in rpm file that  by build with rockylinux8.
```
$ ./gradlew -POS=rockylinux-8 phoenix-pkg-ind
...snip...

$ rpm -qRp output/phoenix/noarch/phoenix-5.1.2-1.el8.noarch.rpm
/bin/sh
/bin/sh
/bin/sh
/usr/bin/env
bigtop-utils >= 0.7
coreutils
python3
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
```

In docker provisionar, I have confirmed that the following steps will run sqlline.py in phoenix.

```
$  ./docker-hadoop.sh -d -C config_rockylinux-8.yaml -r file:///bigtop-home/output -G -k zookeeper,hdfs,hbase,phoenix -c 3
...snip...

$ ./docker-hadoop.sh -e 1 python3 /usr/lib/phoenix/bin/sqlline.py
Setting property: [incremental, false]
Setting property: [isolation, TRANSACTION_READ_COMMITTED]
issuing: !connect -p driver org.apache.phoenix.jdbc.PhoenixDriver -p user "none" -p password "none" "jdbc:phoenix:"
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/lib/phoenix/phoenix-client-hbase-2.4-5.1.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/lib/hadoop/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Reload4jLoggerFactory]
Connecting to jdbc:phoenix:
22/10/25 14:14:13 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable

Connected to: Phoenix (version 5.1)
Driver: PhoenixEmbeddedDriver (version 5.1)
Autocommit status: true
Transaction isolation: TRANSACTION_READ_COMMITTED
sqlline version 1.9.0
0: jdbc:phoenix:>
```
