### PR TITLE
BIGTOP-3858 Invalid repository URL is set in rockylinux8 config

### DIFF
--- a/provisioner/docker/config_rockylinux-8.yaml
+++ b/provisioner/docker/config_rockylinux-8.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-rockylinux-8"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/centos/8/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.1.0/rockylinux/8/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
In rockylinux8 config file, the default url is invalid.
Change default url from 'centos' to 'rockylinux'.


### How was this patch tested?
```
$ ./docker-hadoop.sh -d -C  config_rockylinux-8.yaml -c 3
...snip...

$ ./docker-hadoop.sh -e 1 dnf info hadoop-hdfs-namenode
Last metadata expiration check: 0:05:34 ago on Tue Oct 25 15:20:18 2022.
Installed Packages
Name         : hadoop-hdfs-namenode
Version      : 3.2.3
...
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/