### PR TITLE
BIGTOP-3868: Add an error message file check to avoid the error exit

### DIFF
--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -196,7 +196,7 @@ provision() {
         ) &
     done
     wait
-    if [ -f .error_msg_* ]; then
+    if [ `find . -maxdepth 1 -type f -name ".error_msg_*" | wc -l` -gt 0 ]; then
       cat .error_msg_* 2>/dev/null && exit 1
     fi
 }

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -196,7 +196,9 @@ provision() {
         ) &
     done
     wait
-    cat .error_msg_* 2>/dev/null && exit 1
+    if [ -f .error_msg_* ]; then
+      cat .error_msg_* 2>/dev/null && exit 1
+    fi
 }
 
 smoke-tests() {


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
If users use docker provisioner from gradle, it fails. This is because `docker-hadoop.sh` returns 1 even if the provisioning was secceeded.

```sh
$ ./gradlew -Pstack=zookeeper docker-provisioner
...
Notice: Finished catalog run in 74.78 seconds
> Task :docker-provisioner FAILED
```

This PR add an error message check before printing the file, to avoid the error exit.

### How was this patch tested?
```sh
$ ./gradlew -Pstack=zookeeper docker-provisioner
...
Notice: Finished catalog run in 65.20 seconds

BUILD SUCCESSFUL in 1m 29s
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/