### PR TITLE
BIGTOP-3872: Adjust Ambari-2.7.5 dependency to fix the deployment issues of Ambari metrics

### DIFF
--- a/bigtop-packages/src/common/ambari/patch12-fix-ambari-metrics-grafana-service-issues.diff
+++ b/bigtop-packages/src/common/ambari/patch12-fix-ambari-metrics-grafana-service-issues.diff
@@ -1,0 +1,44 @@
+diff --git a/ambari-metrics/ambari-metrics-grafana/conf/unix/ambari-metrics-grafana b/ambari-metrics/ambari-metrics-grafana/conf/unix/ambari-metrics-grafana
+index dba2f5ff55..edd3ec1a09 100644
+--- a/ambari-metrics/ambari-metrics-grafana/conf/unix/ambari-metrics-grafana
++++ b/ambari-metrics/ambari-metrics-grafana/conf/unix/ambari-metrics-grafana
+@@ -118,7 +118,7 @@ case "$1" in
+     then
+       for i in {1..10}
+       do
+-        sleep 2
++        sleep 12
+         # check if pid file has been written to
+         if [ -s $PID_FILE ]; then
+           echo " $(date) pid_file has been written to" >> $LOG_FILE
+@@ -131,18 +131,19 @@ case "$1" in
+         echo " $(date) Start FAILED because daemon did not write pid in pid_file after 20 seconds" >> $LOG_FILE
+         exit 1
+       fi
+-      i=0
+-      timeout=60
++      #i=0
++      #timeout=60
+       # Wait for the process to be properly started before exiting
+-      until { cat "$PID_FILE" | xargs kill -0; } >/dev/null 2>&1
+-      do
+-        sleep 1
+-        i=$(($i + 1))
+-        if [ $i -gt $timeout ]; then
+-          echo "FAILED"
+-          exit 1
+-        fi
+-      done
++      sleep 120
++      #until { cat "$PID_FILE" | xargs kill -0; } >/dev/null 2>&1
++      #do
++      #  sleep 1
++      #  i=$(($i + 1))
++      #  if [ $i -gt $timeout ]; then
++      #    echo "FAILED"
++      #    exit 1
++      #  fi
++      #done
+     fi
+ 
+     echo "OK" >> $LOG_FILE

--- a/bigtop-packages/src/common/ambari/patch5-refine-AMBARI-25599-for-Hadoop-3.4.diff
+++ b/bigtop-packages/src/common/ambari/patch5-refine-AMBARI-25599-for-Hadoop-3.4.diff
@@ -43,7 +43,7 @@ index f8423b3806..e37072e9f8 100644
                    </target>
                  </configuration>
 diff --git a/ambari-metrics/pom.xml b/ambari-metrics/pom.xml
-index a0a11b8e6e..6770d86080 100644
+index a0a11b8e6e..909a297c1c 100644
 --- a/ambari-metrics/pom.xml
 +++ b/ambari-metrics/pom.xml
 @@ -40,14 +40,14 @@
@@ -58,13 +58,13 @@ index a0a11b8e6e..6770d86080 100644
 -    <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.4.2.linux-amd64.tar.gz</grafana.tar>
 -    <phoenix.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/phoenix/phoenix-5.0.0.3.1.4.0-315.tar.gz</phoenix.tar>
 -    <phoenix.folder>phoenix-5.0.0.3.1.4.0-315</phoenix.folder>
-+    <hbase.tar>http://10.169.206.131/yum-bigtop/centos/7/x86_64/hbase-2.4.13-bin.tar.gz</hbase.tar>
++    <hbase.tar>http://bigtop-snapshot.s3.amazonaws.com/centos-7/x86_64/bigtop-stack-binary/hbase-2.4.13-bin.tar.gz</hbase.tar>
 +    <hbase.folder>hbase-2.4.13</hbase.folder>
-+    <hadoop.tar>http://10.169.206.131/yum-bigtop/centos/7/x86_64/hadoop-3.3.4.tar.gz</hadoop.tar>
++    <hadoop.tar>http://bigtop-snapshot.s3.amazonaws.com/centos-7/x86_64/bigtop-stack-binary/hadoop-3.3.4.tar.gz</hadoop.tar>
 +    <hadoop.folder>hadoop-3.3.4</hadoop.folder>
 +    <grafana.folder>grafana-9.1.2</grafana.folder>
 +    <grafana.tar>https://dl.grafana.com/enterprise/release/grafana-enterprise-9.1.2.linux-amd64.tar.gz</grafana.tar>
-+    <phoenix.tar>http://10.169.206.131/yum-bigtop/centos/7/x86_64/phoenix-hbase-2.4-5.1.2-bin.tar.gz</phoenix.tar>
++    <phoenix.tar>http://bigtop-snapshot.s3.amazonaws.com/centos-7/x86_64/bigtop-stack-binary/phoenix-hbase-2.4-5.1.2-bin.tar.gz</phoenix.tar>
 +    <phoenix.folder>phoenix-hbase-2.4-5.1.2-bin</phoenix.folder>
      <resmonitor.install.dir>/usr/lib/python2.6/site-packages/resource_monitoring</resmonitor.install.dir>
      <powermock.version>1.6.2</powermock.version>

--- a/bigtop-packages/src/common/ambari/patch5-refine-AMBARI-25599-for-Hadoop-3.4.diff
+++ b/bigtop-packages/src/common/ambari/patch5-refine-AMBARI-25599-for-Hadoop-3.4.diff
@@ -29,7 +29,7 @@ index 5551b3966f..66d5e8ebc9 100644
  
  </project>
 diff --git a/ambari-metrics/ambari-metrics-timelineservice/pom.xml b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
-index f8423b3806..b20fc15dbb 100644
+index f8423b3806..c8da1a469c 100644
 --- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
 +++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
 @@ -33,10 +33,10 @@
@@ -47,9 +47,11 @@ index f8423b3806..b20fc15dbb 100644
    </properties>
  
    <build>
-@@ -372,9 +372,15 @@
+@@ -371,10 +371,18 @@
+       </exclusions>
      </dependency>
  
++<!--
      <dependency>
 -      <groupId>commons-lang</groupId>
 -      <artifactId>commons-lang</artifactId>
@@ -58,6 +60,7 @@ index f8423b3806..b20fc15dbb 100644
 +      <artifactId>phoenix-hbase-compat-2.4.1</artifactId>
 +      <version>5.1.2</version>
 +    </dependency>
++-->
 +
 +    <dependency>
 +      <groupId>org.apache.commons</groupId>
@@ -66,7 +69,7 @@ index f8423b3806..b20fc15dbb 100644
      </dependency>
  
      <dependency>
-@@ -926,8 +932,8 @@
+@@ -926,8 +934,8 @@
                          compression="gzip"
                      />
                      <move
@@ -78,7 +81,7 @@ index f8423b3806..b20fc15dbb 100644
                    </target>
                  </configuration>
 diff --git a/ambari-metrics/pom.xml b/ambari-metrics/pom.xml
-index a0a11b8e6e..f33479844a 100644
+index a0a11b8e6e..6770d86080 100644
 --- a/ambari-metrics/pom.xml
 +++ b/ambari-metrics/pom.xml
 @@ -40,14 +40,14 @@
@@ -93,13 +96,13 @@ index a0a11b8e6e..f33479844a 100644
 -    <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.4.2.linux-amd64.tar.gz</grafana.tar>
 -    <phoenix.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/phoenix/phoenix-5.0.0.3.1.4.0-315.tar.gz</phoenix.tar>
 -    <phoenix.folder>phoenix-5.0.0.3.1.4.0-315</phoenix.folder>
-+    <hbase.tar>https://archive.apache.org/dist/hbase/2.4.13/hbase-2.4.13-bin.tar.gz</hbase.tar>
++    <hbase.tar>http://10.169.206.131/yum-bigtop/centos/7/x86_64/hbase-2.4.13-bin.tar.gz</hbase.tar>
 +    <hbase.folder>hbase-2.4.13</hbase.folder>
-+    <hadoop.tar>https://archive.apache.org/dist/hadoop/common/hadoop-3.3.4/hadoop-3.3.4.tar.gz</hadoop.tar>
++    <hadoop.tar>http://10.169.206.131/yum-bigtop/centos/7/x86_64/hadoop-3.3.4.tar.gz</hadoop.tar>
 +    <hadoop.folder>hadoop-3.3.4</hadoop.folder>
 +    <grafana.folder>grafana-9.1.2</grafana.folder>
 +    <grafana.tar>https://dl.grafana.com/enterprise/release/grafana-enterprise-9.1.2.linux-amd64.tar.gz</grafana.tar>
-+    <phoenix.tar>https://archive.apache.org/dist/phoenix/phoenix-5.1.2/phoenix-hbase-2.4-5.1.2-bin.tar.gz</phoenix.tar>
++    <phoenix.tar>http://10.169.206.131/yum-bigtop/centos/7/x86_64/phoenix-hbase-2.4-5.1.2-bin.tar.gz</phoenix.tar>
 +    <phoenix.folder>phoenix-hbase-2.4-5.1.2-bin</phoenix.folder>
      <resmonitor.install.dir>/usr/lib/python2.6/site-packages/resource_monitoring</resmonitor.install.dir>
      <powermock.version>1.6.2</powermock.version>

--- a/bigtop-packages/src/common/ambari/patch5-refine-AMBARI-25599-for-Hadoop-3.4.diff
+++ b/bigtop-packages/src/common/ambari/patch5-refine-AMBARI-25599-for-Hadoop-3.4.diff
@@ -12,24 +12,8 @@ index 65a630069e..ef4a062960 100644
      <solr.mapping.path>${mapping.base.path}/ambari-infra-solr</solr.mapping.path>
      <solr.package.name>ambari-infra-solr</solr.package.name>
      <solr.client.package.name>ambari-infra-solr-client</solr.client.package.name>
-diff --git a/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml b/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
-index 5551b3966f..66d5e8ebc9 100644
---- a/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
-+++ b/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
-@@ -199,6 +199,11 @@ limitations under the License.
-       <artifactId>powermock-module-junit4</artifactId>
-       <scope>test</scope>
-     </dependency>
-+    <dependency>
-+      <groupId>org.apache.commons</groupId>
-+      <artifactId>commons-lang3</artifactId>
-+      <version>3.12.0</version>
-+    </dependency>
-   </dependencies>
- 
- </project>
 diff --git a/ambari-metrics/ambari-metrics-timelineservice/pom.xml b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
-index f8423b3806..c8da1a469c 100644
+index f8423b3806..e37072e9f8 100644
 --- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
 +++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
 @@ -33,10 +33,10 @@
@@ -47,29 +31,7 @@ index f8423b3806..c8da1a469c 100644
    </properties>
  
    <build>
-@@ -371,10 +371,18 @@
-       </exclusions>
-     </dependency>
- 
-+<!--
-     <dependency>
--      <groupId>commons-lang</groupId>
--      <artifactId>commons-lang</artifactId>
--      <version>2.6</version>
-+      <groupId>org.apache.phoenix</groupId>
-+      <artifactId>phoenix-hbase-compat-2.4.1</artifactId>
-+      <version>5.1.2</version>
-+    </dependency>
-+-->
-+
-+    <dependency>
-+      <groupId>org.apache.commons</groupId>
-+      <artifactId>commons-lang3</artifactId>
-+      <version>3.12.0</version>
-     </dependency>
- 
-     <dependency>
-@@ -926,8 +934,8 @@
+@@ -926,8 +926,8 @@
                          compression="gzip"
                      />
                      <move


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3872

Adjust Ambari-2.7.5 dependency to fix the deployment issues of Ambari metrics. When users deploy Hadoop components with Bigtop stack,  Ambari mertrics dependency should be updated to fix the related issues.

