### PR TITLE
BIGTOP-3726: Align the version of the components in Mpack

### DIFF
--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/repos/repoinfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/repos/repoinfo.xml
@@ -18,17 +18,9 @@
 <reposinfo>
   <os family="redhat7">
     <repo>
-      <baseurl>http://repos.bigtop.apache.org/releases/1.5.0/centos/7/$basearch</baseurl>
+      <baseurl>http://repos.bigtop.apache.org/releases/3.2.0/centos/7/$basearch</baseurl>
       <repoid>BGTP-1.0</repoid>
       <reponame>BGTP</reponame>
-    </repo>
-  </os>
-  <os family="ubuntu18">
-    <repo>
-      <baseurl>http://repos.bigtop.apache.org/releases/1.5.0/ubuntu/18.04/$(ARCH)</baseurl>
-      <repoid>BGTP-1.0</repoid>
-      <reponame>bigtop</reponame>
-      <components>contrib</components>
     </repo>
   </os>
 </reposinfo>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/FLINK/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/FLINK/metainfo.xml
@@ -22,7 +22,7 @@
       <name>FLINK</name>
       <displayName>Flink</displayName>
       <comment>Flink is a framework and distributed processing engine for stateful computations over unbounded and bounded data streams</comment>
-      <version>Bigtop+3.1</version>
+      <version>Bigtop+3.2</version>
       <components>
         <component>
           <name>FLINK_HISTORYSERVER</name>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HBASE/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HBASE/metainfo.xml
@@ -24,7 +24,7 @@
       <comment>Non-relational distributed database and centralized service for configuration management &amp;
         synchronization
       </comment>
-      <version>Bigtop+3.1</version>
+      <version>Bigtop+3.2</version>
       <components>
         <component>
           <name>HBASE_MASTER</name>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HDFS/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HDFS/metainfo.xml
@@ -23,7 +23,7 @@
       <displayName>HDFS</displayName>
       <serviceType>HDFS</serviceType> <!-- This tag is used only for main fileSystem service. It sets filesystem schema for ambari -->
       <comment>Apache Hadoop Distributed File System</comment>
-      <version>Bigtop+3.1</version>
+      <version>Bigtop+3.2</version>
 
       <components>
         <component>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HIVE/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/HIVE/metainfo.xml
@@ -24,7 +24,7 @@
             <comment>Data warehouse system for ad-hoc queries &amp; analysis of large datasets and table &amp; storage
                 management service
             </comment>
-            <version>Bigtop+3.1</version>
+            <version>Bigtop+3.2</version>
             <credential-store>
                 <supported>true</supported>
                 <enabled>true</enabled>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/KAFKA/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/KAFKA/metainfo.xml
@@ -22,7 +22,7 @@
       <name>KAFKA</name>
       <displayName>Kafka</displayName>
       <comment>A high-throughput distributed messaging system</comment>
-      <version>Bigtop+3.1</version>
+      <version>Bigtop+3.2</version>
 
       <components>
         <component>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/SOLR/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/SOLR/metainfo.xml
@@ -22,7 +22,7 @@
       <name>SOLR</name>
       <displayName>Solr</displayName>
       <comment>Solr is the popular, blazing-fast, open source enterprise search platform built on Apache Lucene.</comment>
-      <version>Bigtop+3.1</version>
+      <version>Bigtop+3.2</version>
       <components>
         <component>
           <name>SOLR</name>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/SPARK/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/SPARK/metainfo.xml
@@ -23,7 +23,7 @@
       <name>SPARK</name>
       <displayName>Spark</displayName>
       <comment>Apache Spark is a unified analytics engine for large-scale data processing.</comment>
-      <version>Bigtop+3.1</version>
+      <version>Bigtop+3.2</version>
       <components>
         <component>
           <name>SPARK_JOBHISTORYSERVER</name>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/TEZ/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/TEZ/metainfo.xml
@@ -22,7 +22,7 @@
             <name>TEZ</name>
             <displayName>Tez</displayName>
             <comment>Tez is the next generation Hadoop Query Processing framework written on top of YARN.</comment>
-            <version>Bigtop+3.1</version>
+            <version>Bigtop+3.2</version>
             <components>
                 <component>
                     <name>TEZ_CLIENT</name>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/YARN/metainfo.xml
@@ -23,7 +23,7 @@
       <name>YARN</name>
       <displayName>YARN</displayName>
       <comment>Apache Hadoop NextGen MapReduce (YARN)</comment>
-      <version>2.1.0.2.0</version>
+      <version>Bigtop+3.2</version>
       <components>
 
         <component>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/ZEPPELIN/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/ZEPPELIN/metainfo.xml
@@ -25,7 +25,7 @@ limitations under the License.
         make beautiful data-driven, interactive and collaborative documents with SQL, Scala
         and more.
       </comment>
-      <version>Bigtop+3.1</version>
+      <version>Bigtop+3.2</version>
       <components>
         <component>
           <name>ZEPPELIN_MASTER</name>

--- a/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/ZOOKEEPER/metainfo.xml
+++ b/bigtop-packages/src/common/bigtop-ambari-mpack/bgtp-ambari-mpack/src/main/resources/stacks/BGTP/1.0/services/ZOOKEEPER/metainfo.xml
@@ -22,7 +22,7 @@
       <name>ZOOKEEPER</name>
       <displayName>ZooKeeper</displayName>
       <comment>Centralized service which provides highly reliable distributed coordination</comment>
-      <version>3.4.5</version>
+      <version>Bigtop+3.2</version>
       <components>
 
         <component>


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->
https://issues.apache.org/jira/browse/BIGTOP-3726

### Description of PR
Align the version of the components in Mpack.
Also update repo info to 3.2.

### How was this patch tested?
Deploy Mpack and check services versions:
`cd bigtop/provisioner/bigtop-stack-provisioner/docker/centos7`

Build environment image: `./build-image.sh`

Setup Environment: `./build-containers.sh`

Access Ambari webui: `localhost:8080`

Check Bigtop serivces:
![1669630469032](https://user-images.githubusercontent.com/20575685/204252186-cce2536a-3112-427f-9031-68d289782713.png)

