### PR TITLE
Add support for kafka component

### DIFF
--- a/bigtop-packages/src/rpm/kafka/SPECS/kafka.spec
+++ b/bigtop-packages/src/rpm/kafka/SPECS/kafka.spec
@@ -95,7 +95,11 @@ Requires: kafka = %{version}-%{release}
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?openEuler}
+Requires: openeuler-lsb
+%else
 Requires: redhat-lsb
+%endif
 %endif
 
 %description server


### PR DESCRIPTION
redhat-rpm-config should be instead of openEuler-rpm-config in openEuler

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
    redhat-rpm-config should be instead of openEuler-rpm-config in openEuler


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3878)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/