### PR TITLE
Add support for alluxio component

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -17,6 +17,8 @@
 set -ex
 
 . `dirname $0`/bigtop.bom
+. /etc/os-release
+OS="$ID"
 
 if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.28.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/src/grpc-java-1.28.0/compiler/build/exe/java_plugin/protoc-gen-grpc-java "$@"
@@ -26,6 +28,15 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dgrpc.version=1.28.0 -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"
 
 else
+  if [ "${OS}" = "openEuler" ] ; then
+    sed -i "s|<nodeVersion>v10.11.0</nodeVersion>|<nodeVersion>v12.22.1</nodeVersion>|" webui/pom.xml
+    sed -i "s|<npmVersion>6.4.1</npmVersion>|<npmVersion>6.14.7</npmVersion>|" webui/pom.xml
+    sed -i "s|<activeByDefault>false</activeByDefault>|<activeByDefault>true</activeByDefault>|g" integration/jnifuse/native/pom.xml
+    sed -i 's|"node-gyp": "^3.8.0",|"node-gyp": "^6.0.0",|g'  `find -name npm-shrinkwrap.json`
+    sed -i 's|"version": "3.8.0",|"version": "6.0.0",|g' `find -name npm-shrinkwrap.json`
+    sed -i 's|node-gyp-3.8.0.tgz|node-gyp-6.0.0.tgz|g'  `find -name npm-shrinkwrap.json`
+    sed -i 's|sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==|sha512-Qz6Xda2bKzdsooXITarGf2uaCJcYh7ua+jeRMifBFmTz0peo0JW6IjpqELlX+ZiHXphsKzISgaCsZeQch5a+NA==|g' `find -name npm-shrinkwrap.json`
+  fi
   mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"
 
 fi

--- a/bigtop-packages/src/common/alluxio/install_alluxio.sh
+++ b/bigtop-packages/src/common/alluxio/install_alluxio.sh
@@ -47,6 +47,9 @@ if [ $? != 0 ] ; then
     usage
 fi
 
+. /etc/os-release
+OS="$ID"
+
 eval set -- "$OPTS"
 while true ; do
     case "$1" in
@@ -129,6 +132,9 @@ cp -a libexec/* $PREFIX/$LIB_DIR/libexec
 cp -a client/* $PREFIX/$LIB_DIR/client
 cp -a integration/* $PREFIX/$LIB_DIR/integration
 cp integration/fuse/target/alluxio-integration-fuse-*-jar-with-dependencies.jar $PREFIX/$LIB_DIR/integration/fuse
+if [${OS} = "openEuler"] ; then
+   cp integration/jnifuse/native/src/main/resources/libjnifuse*.so $PREFIX/$LIB_DIR/integration/jnifuse/native/target/classes/
+fi
 rm -rf $PREFIX/$LIB_DIR/integration/pom.xml $PREFIX/$LIB_DIR/integration/**/pom.xml
 rm -rf $PREFIX/$LIB_DIR/integration/target $PREFIX/$LIB_DIR/integration/**/target
 rm -rf $PREFIX/$LIB_DIR/integration/**/src


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Add support for alluxio component

libjnifues3.so and libjnifuse.so need the version of glibc is 2.2.5, which is old version not in ARM openEuler.
The file of libjnifuse3.so is X86 arch, which should be compiled manually

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3881)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/