### PR TITLE
BIGTOP-3891: Fix build issues of Spark in Debian11/Ubuntu22 packaging

### DIFF
--- a/bigtop-packages/src/deb/spark/control
+++ b/bigtop-packages/src/deb/spark/control
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Source: spark-core
+Source: spark
 Section: misc
 Priority: extra
 Maintainer: Bigtop <dev@bigtop.apache.org>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3891

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
From the latest [Debian packaging policies 4.6.1](https://www.debian.org/doc/debian-policy/ch-source.html), 
the package name in debian/changelog is autogenerated from the bigtop package (spark-pkg/spark-deb). But 'spark-core' was named in debian/control which caused the conflict:
```
> Task :spark-sdeb
dpkg-buildpackage: info: source package spark
dpkg-buildpackage: info: source version 3.2.3-1
dpkg-buildpackage: info: source distribution stable
dpkg-buildpackage: info: source changed by Bigtop <dev@bigtop.apache.org>
dpkg-buildpackage: warning: debian/rules is not executable; fixing that
 dpkg-source --before-build .
dpkg-source: error: source package has two conflicting values - spark-core and spark
dpkg-buildpackage: error: dpkg-source --before-build . subprocess returned exit status 25

> Task :spark-sdeb FAILED
```

### How was this patch tested?
Build Spark on Debian-11 and Ubuntu-22.04 (x86/Arm64) and run the Spark smoke tests.

All were passed:
```
+components: [hdfs, yarn, mapreduce, spark]
+enable_local_repo: true
+smoke_test_components: [spark]
```

```
$ ./docker-hadoop.sh -C config_ubuntu-22.04.yaml -c 3 -s -d 
...
..
.
Gradle Test Executor 2 finished executing tests.

> Task :bigtop-tests:smoke-tests:spark:test
Finished generating test XML results (0.73 secs) into: /bigtop-home/bigtop-tests/smoke-tests/spark/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.727 secs) into: /bigtop-home/bigtop-tests/smoke-tests/spark/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:spark:test (Thread[Execution worker for ':' Thread 15,5,main]) completed. Took 4 mins 14.765 secs.

BUILD SUCCESSFUL in 5m 34s
30 actionable tasks: 5 executed, 25 up-to-date
```

```
$ ./docker-hadoop.sh -C config_debian-11.yaml -c 3 -s -d
...
..
.
Gradle Test Executor 2 finished executing tests.

> Task :bigtop-tests:smoke-tests:spark:test
Finished generating test XML results (0.011 secs) into: /bigtop-home/bigtop-tests/smoke-tests/spark/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.021 secs) into: /bigtop-home/bigtop-tests/smoke-tests/spark/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:spark:test (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 1 mins 31.929 secs.

BUILD SUCCESSFUL in 2m 35s
30 actionable tasks: 5 executed, 25 up-to-date

```
