### PR TITLE
BIGTOP-3890: Failed to build gpdb on Fedora-36

### DIFF
--- a/bigtop-packages/src/rpm/gpdb/SPECS/gpdb.spec
+++ b/bigtop-packages/src/rpm/gpdb/SPECS/gpdb.spec
@@ -25,6 +25,8 @@
 %endif
 %define  debug_package %{nil}
 
+%undefine _auto_set_build_flags
+
 Name: gpdb
 Version: %{gpdb_version}
 Release: %{gpdb_release}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Fix build error by adding opt-out flag to the spec file.
(cf. https://fedoraproject.org/wiki/Changes/SetBuildFlagsBuildCheck)

### How was this patch tested?
I tested on ubuntu-20.04/x86 and centos-7/arm64 host machine.

```sh
 ./gradlew -POS=fedora-36 -Pdocker-run-option="--privileged" gpdb-clean gpdb-pkg-ind
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/