### PR TITLE
BIGTOP-3703. Add smoke tests for Ranger.

### DIFF
--- a/bigtop-tests/smoke-tests/ranger/TestRangerSimple.groovy
+++ b/bigtop-tests/smoke-tests/ranger/TestRangerSimple.groovy
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bigtop.itest.ranger
+
+import groovy.json.JsonSlurper
+import org.junit.Test
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
+
+class TestRangerSmoke {
+
+  static String prop(String key) {
+     def value = System.getenv(key)
+     assertNotNull(value)
+     return value
+  }
+
+  def url = "${prop('RANGER_URL')}/service/"
+  def header = ['Authorization':
+    "Basic ${new String(Base64.getEncoder().encode('admin:Admin01234'.getBytes()))}"]
+
+  @Test
+  void testServiceDefs() {
+    def json = new URL(url + 'public/v2/api/servicedef').getText(requestProperties: header)
+    def serviceDefs = new JsonSlurper().parseText(json)
+    assertTrue(0 < serviceDefs.size())
+
+    // Check if some major service definitions were registered through setup
+    def serviceNames = serviceDefs.stream().map{ it.name }.collect()
+    assertTrue(['hdfs', 'hbase', 'hive'].every { serviceNames.contains(it) })
+  }
+}

--- a/bigtop-tests/smoke-tests/ranger/build.gradle
+++ b/bigtop-tests/smoke-tests/ranger/build.gradle
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def junitVersion = '4.13.2'
+dependencies {
+  compile group: 'junit', name: 'junit', version: junitVersion, transitive: 'true'
+}
+
+sourceSets {
+  test {
+    groovy {
+      srcDirs = ["./"]
+    }
+  }
+}
+
+test.doFirst {
+  checkEnv(["RANGER_URL"])
+}

--- a/provisioner/utils/smoke-tests.sh
+++ b/provisioner/utils/smoke-tests.sh
@@ -48,6 +48,7 @@ export KAFKA_HOME=${KAFKA_HOME:-/usr/lib/kafka}
 export LIVY_HOME=${LIVY_HOME:-/usr/lib/livy}
 export OOZIE_TAR_HOME=${OOZIE_TAR_HOME:-/usr/lib/oozie}
 export OOZIE_URL=${OOZIE_URL:-http://localhost:11000/oozie}
+export RANGER_URL=${RANGER_URL:-http://localhost:6080}
 export SPARK_HOME=${SPARK_HOME:-/usr/lib/spark}
 export TEZ_HOME=${TEZ_HOME:-/usr/lib/tez}
 export WEBHDFS_URL=${WEBHDFS_URL:-$(hostname):50070/webhdfs/v1}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Based on BIGTOP-3702, this PR adds a simple smoke test for Ranger.

### How was this patch tested?

Ran the added test locally, as follows:

CentOS 7

```
$ ./docker-hadoop.sh -d -C config_centos-7.yaml -G -L -k bigtop-utils,ranger -s ranger -c 1

...

> Task :bigtop-tests:smoke-tests:ranger:test
Finished generating test XML results (0.011 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.031 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:ranger:test (Thread[Daemon worker,5,main]) completed. Took 3.035 secs.

BUILD SUCCESSFUL in 1m 34s
```

Rocky Linux 8

```
$ ./docker-hadoop.sh -d -C config_rockylinux-8.yaml -F docker-compose-cgroupv2.yml -G -L -k bigtop-utils,ranger -s ranger -c 1

...

> Task :bigtop-tests:smoke-tests:ranger:test
Finished generating test XML results (0.011 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.021 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:ranger:test (Thread[Daemon worker,5,main]) completed. Took 3.94 secs.

BUILD SUCCESSFUL in 1m 22s
```

Fedora 35

```
$ ./docker-hadoop.sh -d -C config_fedora-35.yaml -F docker-compose-cgroupv2.yml -G -L -k bigtop-utils,ranger -s ranger -c 1

...

> Task :bigtop-tests:smoke-tests:ranger:test
Finished generating test XML results (0.01 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.027 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:ranger:test (Thread[Daemon worker,5,main]) completed. Took 2.672 secs.

BUILD SUCCESSFUL in 1m 3s
```

Fedora 36

```
$ ./docker-hadoop.sh -d -C config_fedora-36.yaml -F docker-compose-cgroupv2.yml -G -L -k bigtop-utils,ranger -s ranger -c 1

...

> Task :bigtop-tests:smoke-tests:ranger:test
Finished generating test XML results (0.011 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.026 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:ranger:test (Thread[Execution worker for ':',5,main]) completed. Took 2.56 secs.

BUILD SUCCESSFUL in 1m 16s
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/