### PR TITLE
BIGTOP-3893: Fix Hadoop3.3.4 build issues on ppc64le

### DIFF
--- a/bigtop-packages/src/common/hadoop/do-component-build
+++ b/bigtop-packages/src/common/hadoop/do-component-build
@@ -39,6 +39,13 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
         #cleanup
         rm -rf ${LEVELDBJNI_HOME}
         rm -rf ${LEVELDB_HOME}
+
+        mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 \
+                -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-2.5.0/bin/protoc
+        mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=3.6.1 \
+                -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-3.6.1/bin/protoc
+        mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.26.0 \
+                -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/src/grpc-java-1.26.0/compiler/build/exe/java_plugin/protoc-gen-grpc-java
 fi
 ## BIGTOP-2288
 

--- a/bigtop_toolchain/manifests/grpc.pp
+++ b/bigtop_toolchain/manifests/grpc.pp
@@ -13,33 +13,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# There is no pre-built binary of grpc-java for ppc64le before grpc-java-1.48.0 (2022-08-01).
+# Build some versions of grpc-java Binaries in Bigtop toolchain.
 class bigtop_toolchain::grpc {
 
   require bigtop_toolchain::jdk
   require bigtop_toolchain::protobuf
 
   $grpc_version = '1.28.0'
-  $proto_version = '3.17.3'
   $proto_home = "/usr/local/protobuf-3.17.3"
 
   if ($architecture == 'ppc64le') {
 
-  exec { "download grpc-java ${grpc_version}":
+    # grpc-java 1.28.0 + protobuf-3.17.3 for zeppelin build on ppc64le.
+    exec { "download grpc-java ${grpc_version}":
       cwd  => "/usr/src",
       command => "/usr/bin/wget https://github.com/grpc/grpc-java/archive/refs/tags/v${grpc_version}.tar.gz && mkdir -p grpc-java-${grpc_version} && /bin/tar -xvzf v${grpc_version}.tar.gz -C grpc-java-${grpc_version} --strip-components=1",
       creates => "/usr/src/grpc-java-${grpc_version}",
-  }
+    }
 
     file { "/usr/src/grpc-java-${grpc_version}/grpc-java-${grpc_version}-add-support-for-ppc64le.patch":
       source => "puppet:///modules/bigtop_toolchain/grpc-java-${grpc_version}-add-support-for-ppc64le.patch",
       require => Exec["download grpc-java ${grpc_version}"],
     }
 
-  exec { "build grpc-java ${grpc_version}":
+    exec { "build grpc-java ${grpc_version}":
       cwd => "/usr/src/grpc-java-${grpc_version}",
       command => "/usr/bin/patch -p1 < grpc-java-${grpc_version}-add-support-for-ppc64le.patch && export LDFLAGS=-L/${proto_home}/lib && export CXXFLAGS=-I/${proto_home}/include && export LD_LIBRARY_PATH=/${proto_home}/lib && cd compiler && ../gradlew java_pluginExecutable -PskipAndroid=true",
       creates => "/usr/local/grpc-java-${grpc_version}",
       require => File["/usr/src/grpc-java-${grpc_version}/grpc-java-${grpc_version}-add-support-for-ppc64le.patch"],
+      timeout => 3000
+    }
+
+    # grpc-java 1.26.0 + protobuf-3.6.1 for Hadoop-3.3.4 build on ppc64le.
+    exec { "download grpc-java 1.26.0":
+      cwd  => "/usr/src",
+      command => "/usr/bin/wget https://github.com/grpc/grpc-java/archive/refs/tags/v1.26.0.tar.gz && mkdir -p grpc-java-1.26.0 && /bin/tar -xvzf v1.26.0.tar.gz -C grpc-java-1.26.0 --strip-components=1",
+      creates => "/usr/src/grpc-java-1.26.0",
+    }
+
+    file { "/usr/src/grpc-java-1.26.0/grpc-java-1.26.0-add-support-for-ppc64le.patch":
+      source => "puppet:///modules/bigtop_toolchain/grpc-java-${grpc_version}-add-support-for-ppc64le.patch",
+      require => Exec["download grpc-java ${grpc_version}"],
+    }
+
+    exec { "build grpc-java 1.26.0":
+      cwd => "/usr/src/grpc-java-1.26.0",
+      command => "/usr/bin/patch -p1 < grpc-java-1.26.0-add-support-for-ppc64le.patch && export LDFLAGS=-L//usr/local/protobuf-3.6.1/lib && export CXXFLAGS=-I//usr/local/protobuf-3.6.1/include && export LD_LIBRARY_PATH=//usr/local/protobuf-3.6.1/lib && cd compiler && ../gradlew java_pluginExecutable -PskipAndroid=true",
+      creates => "/usr/local/grpc-java-1.26.0",
+      require => File["/usr/src/grpc-java-1.26.0/grpc-java-1.26.0-add-support-for-ppc64le.patch"],
       timeout => 3000
     }
   }

--- a/bigtop_toolchain/manifests/protobuf.pp
+++ b/bigtop_toolchain/manifests/protobuf.pp
@@ -87,6 +87,20 @@ class bigtop_toolchain::protobuf {
       require => Exec["download protobuf 3.17.3"],
       timeout => 3000
     }
+
+    exec { "download protobuf 3.6.1":
+      cwd  => "/usr/src",
+      command => "/usr/bin/wget https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.6.1.tar.gz && mkdir -p protobuf-3.6.1 && /bin/tar -xvzf v3.6.1.tar.gz -C protobuf-3.6.1 --strip-components=1",
+      creates => "/usr/src/protobuf-3.6.1",
+    }
+
+    exec { "install protobuf 3.6.1":
+      cwd => "/usr/src/protobuf-3.6.1",
+      command => "/usr/src/protobuf-3.6.1/autogen.sh && /usr/src/protobuf-3.6.1/configure --prefix=/usr/local/protobuf-3.6.1 --disable-shared --with-pic && /usr/bin/make install",
+      creates => "/usr/local/protobuf-3.6.1",
+      require => Exec["download protobuf 3.6.1"],
+      timeout => 3000
+    }
   }
 
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3893

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Fix Hadoop3.3.4 build issues on ppc64le.
```
Haoop common depends on protobuf-2.5.0:
[ERROR] Failed to execute goal org.xolstice.maven.plugins:protobuf-maven-plugin:0.5.1:compile (src-compile-protoc-legacy) on project hadoop-common: Missing:
[ERROR] ----------
[ERROR] 1) com.google.protobuf:protoc:exe:linux-ppcle_64:2.5.0
[ERROR]
[ERROR]   Try downloading the file manually from the project website.
[ERROR]
[ERROR]   Then, install it using the command:
[ERROR]       mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/path/to/file
[ERROR]
[ERROR]   Alternatively, if you host your own repository you can deploy the file there:
[ERROR]       mvn deploy:deploy-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=2.5.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]
[ERROR]
[ERROR]   Path to dependency:
[ERROR]         1) org.apache.hadoop:hadoop-common:jar:3.3.4
[ERROR]         2) com.google.protobuf:protoc:exe:linux-ppcle_64:2.5.0
[ERROR]
[ERROR] ----------
[ERROR] 1 required artifact is missing.
[ERROR]
```
In Haddop YARN CSI, it depends on protobuf-3.6.1 and grpc-java 1.26.0.
But there is no pre-built binary of protobuf-3.6.1 and grpc-java-1.26.0 for ppc64le.
It's needed to build protobuf-3.6.1 and grpc-java Binaries in Bigtop toolchain:
```
INFO] Apache Hadoop YARN CSI ............................. FAILURE [  0.552 s

[ERROR] Failed to execute goal org.xolstice.maven.plugins:protobuf-maven-plugin:0.5.1:compile (default) on project hadoop-yarn-csi: Missing:
[ERROR] ----------
[ERROR] 1) com.google.protobuf:protoc:exe:linux-ppcle_64:3.6.1
[ERROR]
[ERROR]   Try downloading the file manually from the project website.
[ERROR]
[ERROR]   Then, install it using the command:
[ERROR]       mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=3.6.1 -Dclassifier=linux-ppcle_64 -Dpackagin                                                                                                                                                                                       g=exe -Dfile=/path/to/file
[ERROR]
[ERROR]   Alternatively, if you host your own repository you can deploy the file there:
[ERROR]       mvn deploy:deploy-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=3.6.1 -Dclassifier=linux-ppcle_64 -Dpackaging=                                                                                                                                                                                       exe -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]
[ERROR]
[ERROR]   Path to dependency:
[ERROR]         1) org.apache.hadoop:hadoop-yarn-csi:jar:3.3.4
[ERROR]         2) com.google.protobuf:protoc:exe:linux-ppcle_64:3.6.1
[ERROR]
[ERROR] ----------
[ERROR] 1 required artifact is missing.
[ERROR]
[ERROR] for artifact:
[ERROR]   org.apache.hadoop:hadoop-yarn-csi:jar:3.3.4
[ERROR]
[ERROR] from the specified remote repositories:
[ERROR]   apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots, releases=true, snapshots=true),
[ERROR]   repository.jboss.org (https://repository.jboss.org/nexus/content/groups/public/, releases=true, snapshots=false),
[ERROR]   central (https://repo.maven.apache.org/maven2, releases=true, snapshots=false)
[ERROR]


#############################################################################
[ERROR] ----------
[ERROR] 1) io.grpc:protoc-gen-grpc-java:exe:linux-ppcle_64:1.26.0
[ERROR]
[ERROR]   Try downloading the file manually from the project website.
[ERROR]
[ERROR]   Then, install it using the command:
[ERROR]       mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.26.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/path/to/file
[ERROR]
[ERROR]   Alternatively, if you host your own repository you can deploy the file there:
[ERROR]       mvn deploy:deploy-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.26.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]
[ERROR]
[ERROR]   Path to dependency:
[ERROR]         1) org.apache.hadoop:hadoop-yarn-csi:jar:3.3.4
[ERROR]         2) io.grpc:protoc-gen-grpc-java:exe:linux-ppcle_64:1.26.0
```


### How was this patch tested?
Build bigtop toolchain (bigtop/slaves docker images) and build Hadoop on ppcle64.


