### PR TITLE
BIGTOP-3894: Failed to build Alluxio on Centos-7

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -18,8 +18,25 @@ set -ex
 
 . `dirname $0`/bigtop.bom
 
+. /etc/os-release
+OS="$ID"
+
 if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.28.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/src/grpc-java-1.28.0/compiler/build/exe/java_plugin/protoc-gen-grpc-java "$@"
+  # BIGTOP-3894
+  # protobuf-3.19.2/3.17.3 doesn't offically support ppc64le;
+  # Skip protoc backwards compatibility check here.
+  sed -i -e :a -e '$!N;s/.*\n\(.*salesforce\)/\1/;ta' -e 'P;D' pom.xml
+  sed -i '/com.salesforce.servicelibs/,+3d' pom.xml
+  sed -i '/Proto lock for preventing/,+14d' core/transport/pom.xml
+
+  # 'protobuf-3.17.3' was pre-installed in Bigtop toolchain for ppc64le.
+  # And protoc grpc-java-1.28.0 was also built based on protobuf-3.17.3 in Bigtop toolchain.
+  # So manually install 3.17.3 here to workaound the GLIBC issue on Centos-7.
+  if [ "${OS}" = "centos" ]; then
+    mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=3.17.3 \
+      -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-3.17.3/bin/protoc "$@"
+  fi
 
   sed -i "s|<nodeVersion>v10.11.0</nodeVersion>|<nodeVersion>v12.22.1</nodeVersion>|" webui/pom.xml
   sed -i "s|<npmVersion>6.4.1</npmVersion>|<npmVersion>6.14.7</npmVersion>|" webui/pom.xml


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3894

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
`protobuf-3.17.3` was pre-installed in Bigtop toolchain for ppc64le. And protoc `grpc-java-1.28.0` was also built based on `protobuf-3.17.3` in Bigtop toolchain.
So manually install 3.17.3 to workaound the GLIBC issue.

And `protobuf-3.19.2/3.17.3` doesn't offically support ppc64le;
Skip protoc backwards compatibility check here.


### How was this patch tested?
Build Alluxio on centos, debian, ubuntu and fedora.
Run smoke tests:
```
./docker-hadoop.sh --create 3 --image bigtop/puppet:3.2.0-centos-7 \
--memory 16g --repo file:///bigtop-home/output \
--disable-gpg-check --enable-local-repo \
--stack hdfs,yarn,mapreduce,alluxio \
--smoke-tests alluxio
```
```
...
..
.
Successfully started process 'Gradle Test Executor 2'

Gradle Test Executor 2 finished executing tests.

> Task :bigtop-tests:smoke-tests:alluxio:test
Finished generating test XML results (0.018 secs) into: /bigtop-home/bigtop-tests/smoke-tests/alluxio/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.034 secs) into: /bigtop-home/bigtop-tests/smoke-tests/alluxio/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:alluxio:test (Thread[Execution worker for ':' Thread 10,5,main]) completed. Took 34.645 secs.

BUILD SUCCESSFUL in 1m 12s
30 actionable tasks: 7 executed, 23 up-to-date
Stopped 1 worker daemon(s).
+ rm -rf buildSrc/build/test-results/binary
+ rm -rf /bigtop-home/.gradle
jenkins@bigtop1slave:~/bigtop/provisioner/docker$ uname -m
ppc64le
jenkins@bigtop1slave:~/bigtop/provisioner/docker$
```


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/