### PR TITLE
[BIGTOP-3899] Exclude docker/bigtop-slaves/Dockerfile from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build
 dl
 dist
+docker/bigtop-slaves/Dockerfile
 output
 target
 *~


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Exclude the temp file `docker/bigtop-slaves/Dockerfile` for git which is created during `./gradlew -Pprefix=3.2.0 bigtop-slaves`, and if the task failed, the file stays here.

### How was this patch tested?

Local command line.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/