### PR TITLE
BIGTOP-3901. Fix failure of Kerberos deployment on Rocky Linux 8 and Ubuntu 22.04.

### DIFF
--- a/bigtop-deploy/puppet/modules/kerberos/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/kerberos/manifests/init.pp
@@ -68,7 +68,7 @@ class kerberos {
     }
 
     # Required for SPNEGO
-    @principal { "HTTP": 
+    @kerberos::principal { "HTTP":
 
     }
   }
@@ -111,7 +111,7 @@ class kerberos {
       subscribe => File["${kdc_etc_path}/kdc.conf"],
       # refreshonly => true, 
 
-      require => [Package["$package_name_kdc"], File["${kdc_etc_path}/kdc.conf"], File["/etc/krb5.conf"]],
+      require => [Package["$package_name_kdc"], Package["$package_name_admin"], File["${kdc_etc_path}/kdc.conf"], File["/etc/krb5.conf"]],
     }
 
     service { $service_name_kdc:

--- a/bigtop-deploy/puppet/modules/kerberos/templates/kdc.conf
+++ b/bigtop-deploy/puppet/modules/kerberos/templates/kdc.conf
@@ -28,8 +28,7 @@ default_realm = <%= @realm %>
         key_stash_file = <%= @kdc_etc_path %>/stash
         max_life = 10h 0m 0s
         max_renewable_life = 7d 0h 0m 0s
-        master_key_type = des3-hmac-sha1
-        supported_enctypes = arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
-#        supported_enctypes = des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal des-cbc-crc:v4 des-cbc-crc:afs3
+        master_key_type = aes256-cts
+        supported_enctypes = aes256-cts:normal aes128-cts:normal arcfour-hmac:normal camellia256-cts:normal camellia128-cts:normal
         # default_principal_flags = -preauth
     }

--- a/bigtop-deploy/puppet/modules/kerberos/templates/krb5.conf
+++ b/bigtop-deploy/puppet/modules/kerberos/templates/krb5.conf
@@ -20,9 +20,7 @@
     ticket_lifetime = 24h
     forwardable = true
     udp_preference_limit = 1000000
-    default_tkt_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
-    default_tgs_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
-    permitted_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
+    permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac
 
 [realms]
     <%= @realm %> = {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3901

Encryption types must be updated to fix the error on recent versions of Kerberos+

```
Error: 'rm -f /etc/kadm5.keytab ; kdb5_util -P cthulhu -r BIGTOP.APACHE.ORG create -s && kadmin.local -q 'cpw -pw secure kadmin/admin'' returned 1 instead of one of [0]
```

In addition, dependencies of `Exec[kdb5_util]` must be fixed because kadmin.local belongs krb5-admin-server package in Ubuntu.

```
Error: /Stage[main]/Kerberos::Kdc/Exec[kdb5_util]/returns: change from 'notrun' to ['0'] failed: Loading random data
Initializing database '/var/lib/krb5kdc/principal' for realm 'BIGTOP.APACHE.ORG',
master key name 'K/M@BIGTOP.APACHE.ORG'
sh: 1: kadmin.local: not found
```
