### PR TITLE
BIGTOP-3906. Wrapper script for hive sources wrong default file

### DIFF
--- a/bigtop-packages/src/common/hive/install_hive.sh
+++ b/bigtop-packages/src/common/hive/install_hive.sh
@@ -166,7 +166,7 @@ if [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
 fi
 
 BIGTOP_DEFAULTS_DIR=\${BIGTOP_DEFAULTS_DIR-$ETC_DEFAULT}
-[ -n "\${BIGTOP_DEFAULTS_DIR}" -a -r \${BIGTOP_DEFAULTS_DIR}/hbase ] && . \${BIGTOP_DEFAULTS_DIR}/hbase
+[ -n "\${BIGTOP_DEFAULTS_DIR}" -a -r \${BIGTOP_DEFAULTS_DIR}/hive ] && . \${BIGTOP_DEFAULTS_DIR}/hive
 
 export HIVE_HOME=$HIVE_DIR
 exec $HIVE_DIR/bin/$file "\$@"
@@ -238,7 +238,7 @@ cat >>$wrapper <<EOF
 
 
 BIGTOP_DEFAULTS_DIR=\${BIGTOP_DEFAULTS_DIR-$ETC_DEFAULT}
-[ -n "\${BIGTOP_DEFAULTS_DIR}" -a -r \${BIGTOP_DEFAULTS_DIR}/hadoop ] && . \${BIGTOP_DEFAULTS_DIR}/hadoop
+[ -n "\${BIGTOP_DEFAULTS_DIR}" -a -r \${BIGTOP_DEFAULTS_DIR}/hive ] && . \${BIGTOP_DEFAULTS_DIR}/hive
 
 # Autodetect JAVA_HOME if not defined
 if [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Fix typo in wrapper scripts for Hive.


### How was this patch tested?

Manually tested

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?