### PR TITLE
BIGTOP-3905: Update Bigtop-stack-provisioner repo for the latest 3.2.0 release

### DIFF
--- a/provisioner/bigtop-stack-provisioner/docker/centos7/Dockerfile
+++ b/provisioner/bigtop-stack-provisioner/docker/centos7/Dockerfile
@@ -22,7 +22,7 @@ RUN /bin/sed -i 's,#   StrictHostKeyChecking ask,StrictHostKeyChecking no,g' /et
 
 RUN ssh-keygen -f "/root/.ssh/id_rsa" -N ""
 
-RUN wget https://downloads.apache.org/bigtop/bigtop-3.1.1/repos/centos-7/bigtop.repo -O /etc/yum.repos.d/bigtop.repo \
+RUN wget https://downloads.apache.org/bigtop/bigtop-3.2.0/repos/centos-7/bigtop.repo -O /etc/yum.repos.d/bigtop.repo \
     && yum -y install ambari-server ambari-agent \
     && rm -f /etc/yum.repos.d/bigtop.repo
 

--- a/provisioner/docker/config_centos-7.yaml
+++ b/provisioner/docker/config_centos-7.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-centos-7"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/centos/7/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.2.0/centos/7/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_debian-10.yaml
+++ b/provisioner/docker/config_debian-10.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-debian-10"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/debian/10/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.0/debian/10/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_debian-11.yaml
+++ b/provisioner/docker/config_debian-11.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-debian-11"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/debian/11/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.0/debian/11/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_fedora-36.yaml
+++ b/provisioner/docker/config_fedora-36.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-fedora-36"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/fedora/36/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.2.0/fedora/36/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_rockylinux-8.yaml
+++ b/provisioner/docker/config_rockylinux-8.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-rockylinux-8"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/rockylinux/8/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.2.0/rockylinux/8/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_ubuntu-20.04.yaml
+++ b/provisioner/docker/config_ubuntu-20.04.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image:  "bigtop/puppet:trunk-ubuntu-20.04"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/ubuntu/20.04/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.0/ubuntu/20.04/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_ubuntu-22.04.yaml
+++ b/provisioner/docker/config_ubuntu-22.04.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image:  "bigtop/puppet:trunk-ubuntu-22.04"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/ubuntu/22.04/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.0/ubuntu/22.04/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3905

Update 3.2.0 release repo in Bigtop-stack-provisioner `Dockerfile` and smoke tests `yaml`s.