### PR TITLE
BIGTOP-3908 Upgrade Spark Rpm Packages for PySpark Requres Python3

### DIFF
--- a/bigtop-packages/src/common/spark/install_spark.sh
+++ b/bigtop-packages/src/common/spark/install_spark.sh
@@ -182,7 +182,7 @@ cat > $PREFIX/$BIN_DIR/pyspark <<EOF
 # Autodetect JAVA_HOME if not defined
 . /usr/lib/bigtop-utils/bigtop-detect-javahome
 
-export PYSPARK_PYTHON=python
+export PYSPARK_PYTHON=python3
 
 exec $LIB_DIR/bin/pyspark "\$@"
 EOF

--- a/bigtop-packages/src/rpm/spark/SPECS/spark.spec
+++ b/bigtop-packages/src/rpm/spark/SPECS/spark.spec
@@ -116,11 +116,7 @@ Server for Spark worker
 %package -n %{spark_pkg_name}-python
 Summary: Python client for Spark
 Group: Development/Libraries
-%if 0%{?rhel} >= 8
-Requires: %{spark_pkg_name}-core = %{version}-%{release}, python2
-%else
-Requires: %{spark_pkg_name}-core = %{version}-%{release}, python
-%endif
+Requires: %{spark_pkg_name}-core = %{version}-%{release}, python36
 
 %description -n %{spark_pkg_name}-python
 Includes PySpark, an interactive Python shell for Spark, and related libraries
@@ -183,19 +179,6 @@ bash $RPM_SOURCE_DIR/do-component-build
 %__rm -rf $RPM_BUILD_ROOT
 %__install -d -m 0755 $RPM_BUILD_ROOT/%{initd_dir}/
 
-%if 0%{?rhel} >= 8
-PYSPARK_PYTHON=python2 bash $RPM_SOURCE_DIR/install_spark.sh \
-          --build-dir=`pwd`         \
-          --source-dir=$RPM_SOURCE_DIR \
-          --prefix=$RPM_BUILD_ROOT  \
-          --doc-dir=%{doc_spark} \
-          --lib-dir=%{usr_lib_spark} \
-          --var-dir=%{var_lib_spark} \
-          --bin-dir=%{bin_dir} \
-          --man-dir=%{man_dir} \
-          --etc-default=%{etc_default} \
-          --etc-spark=%{etc_spark}
-%else
 bash $RPM_SOURCE_DIR/install_spark.sh \
           --build-dir=`pwd`         \
           --source-dir=$RPM_SOURCE_DIR \
@@ -207,7 +190,6 @@ bash $RPM_SOURCE_DIR/install_spark.sh \
           --man-dir=%{man_dir} \
           --etc-default=%{etc_default} \
           --etc-spark=%{etc_spark}
-%endif
 
 %__rm -f $RPM_BUILD_ROOT/%{usr_lib_spark}/jars/hadoop-*.jar
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Upgade spark rpm packages for pyspark requires python3, according to the [doc](https://spark.apache.org/docs/3.2.3/api/python/getting_started/quickstart_df.html).

### How was this patch tested?
```bash
./docker-hadoop.sh \
       -d \
       -dcp\
       --create 1 \
       --image bigtop/puppet:trunk-rockylinux-8 \
       --memory 8g \
       -L \
       --repo file:///bigtop-home/output \
       --disable-gpg-check \
       --stack hdfs,yarn,mapreduce,spark,hive
```

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/