### PR TITLE
BIGTOP-3896. Failed to deploy Alluxio on Arm64/ppc64le Fedora-36

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -44,6 +44,11 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dgrpc.version=1.28.0 -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"
 
 else
+  if [ "${OS}" = "fedora" ] ; then
+    sed -i "s|<nodeVersion>v10.11.0</nodeVersion>|<nodeVersion>v12.22.1</nodeVersion>|" webui/pom.xml
+    sed -i "s|<npmVersion>6.4.1</npmVersion>|<npmVersion>6.14.7</npmVersion>|" webui/pom.xml
+    sed -i "s|<activeByDefault>false</activeByDefault>|<activeByDefault>true</activeByDefault>|g" integration/jnifuse/native/pom.xml
+  fi
   mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"
 
 fi

--- a/bigtop-packages/src/common/alluxio/install_alluxio.sh
+++ b/bigtop-packages/src/common/alluxio/install_alluxio.sh
@@ -47,6 +47,9 @@ if [ $? != 0 ] ; then
     usage
 fi
 
+. /etc/os-release
+OS="$ID"
+
 eval set -- "$OPTS"
 while true ; do
     case "$1" in

--- a/bigtop-packages/src/common/alluxio/install_alluxio.sh
+++ b/bigtop-packages/src/common/alluxio/install_alluxio.sh
@@ -129,6 +129,10 @@ cp -a libexec/* $PREFIX/$LIB_DIR/libexec
 cp -a client/* $PREFIX/$LIB_DIR/client
 cp -a integration/* $PREFIX/$LIB_DIR/integration
 cp integration/fuse/target/alluxio-integration-fuse-*-jar-with-dependencies.jar $PREFIX/$LIB_DIR/integration/fuse
+
+if [ ${OS} = "fedora" ] ; then
+  cp integration/jnifuse/native/src/main/resources/libjnifuse*.so $PREFIX/$LIB_DIR/integration/jnifuse/native/target/classes/
+fi
 rm -rf $PREFIX/$LIB_DIR/integration/pom.xml $PREFIX/$LIB_DIR/integration/**/pom.xml
 rm -rf $PREFIX/$LIB_DIR/integration/target $PREFIX/$LIB_DIR/integration/**/target
 rm -rf $PREFIX/$LIB_DIR/integration/**/src

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -68,6 +68,15 @@ class bigtop_toolchain::packages {
 
       if ($operatingsystem == 'Fedora' or $operatingsystemmajrelease !~ /^[0-7]$/) {
         $pkgs = concat($_pkgs, ["python2-devel", "libtirpc-devel", "cmake"])
+        $__pkgs = concat($_pkgs, ["python2-devel", "libtirpc-devel", "cmake"])
+        if ($operatingsystem == 'Fedora' 
+            and versioncmp($operatingsystemmajrelease, '36') >= 0 
+            and $architecture in ['aarch64', 'ppc64le']
+        ){
+          $pkgs = concat($__pkgs, ["fuse3", "fuse3-devel"])
+        } else {
+          $pkgs = $__pkgs
+        }
       } else {
         $pkgs = concat($_pkgs, ["python-devel", "cmake3"])
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3896

The so of alluxio is not compiled by default, and uses the x86 version, so we need to compile libjnifuse*.so and copy it to the corresponding directory of alluxio when building adaptation

1. Modify the _bigtop-release-3.2.0/bigtop-packages/src/common/alluxio/do-component-build_ file to adapt  Arm64 architecture code for fedora OS.
2. Modify the _bigtop-release-3.2.0/bigtop-packages/src/common/alluxio/ install_alluxio.sh_ file to copy the libjnifuse*.so file.


- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3896)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/