### PR TITLE
BIGTOP-3913:The path information is incorrect in the zookeeper-client script file by building with -PparentDir

### DIFF
--- a/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
+++ b/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
@@ -170,11 +170,11 @@ cat > $wrapper <<EOF
 # Autodetect JAVA_HOME if not defined
 . /usr/lib/bigtop-utils/bigtop-detect-javahome
 
-export ZOOKEEPER_HOME=\${ZOOKEEPER_CONF:-/usr/lib/zookeeper}
+export ZOOKEEPER_HOME=\${ZOOKEEPER_CONF:-${LIB_DIR}}
 export ZOOKEEPER_CONF=\${ZOOKEEPER_CONF:-/etc/zookeeper/conf}
 export CLASSPATH=\$CLASSPATH:\$ZOOKEEPER_CONF:\$ZOOKEEPER_HOME/*:\$ZOOKEEPER_HOME/lib/*
 export ZOOCFGDIR=\${ZOOCFGDIR:-\$ZOOKEEPER_CONF}
-env CLASSPATH=\$CLASSPATH /usr/lib/zookeeper/bin/zkCli.sh "\$@"
+env CLASSPATH=\$CLASSPATH \${ZOOKEEPER_HOME}/bin/zkCli.sh "\$@"
 EOF
 chmod 755 $wrapper
 
@@ -188,7 +188,7 @@ for pairs in zkServer.sh/zookeeper-server zkServer-initialize.sh/zookeeper-serve
 . /usr/lib/bigtop-utils/bigtop-detect-javahome
 
 export ZOOPIDFILE=\${ZOOPIDFILE:-/var/run/zookeeper/zookeeper_server.pid}
-export ZOOKEEPER_HOME=\${ZOOKEEPER_CONF:-/usr/lib/zookeeper}
+export ZOOKEEPER_HOME=\${ZOOKEEPER_CONF:-${LIB_DIR}}
 export ZOOKEEPER_CONF=\${ZOOKEEPER_CONF:-/etc/zookeeper/conf}
 export ZOOCFGDIR=\${ZOOCFGDIR:-\$ZOOKEEPER_CONF}
 export CLASSPATH=\$CLASSPATH:\$ZOOKEEPER_CONF:\$ZOOKEEPER_HOME/*:\$ZOOKEEPER_HOME/lib/*
@@ -196,7 +196,7 @@ export ZOO_LOG_DIR=\${ZOO_LOG_DIR:-/var/log/zookeeper}
 export ZOO_LOG4J_PROP=\${ZOO_LOG4J_PROP:-INFO,ROLLINGFILE}
 export JVMFLAGS=\${JVMFLAGS:--Dzookeeper.log.threshold=INFO}
 export ZOO_DATADIR_AUTOCREATE_DISABLE=\${ZOO_DATADIR_AUTOCREATE_DISABLE:-true}
-env CLASSPATH=\$CLASSPATH /usr/lib/zookeeper/bin/${upstream_script} "\$@"
+env CLASSPATH=\$CLASSPATH \${ZOOKEEPER_HOME}/bin/${upstream_script} "\$@"
 EOF
   chmod 755 $wrapper
 done

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -135,7 +135,7 @@ bigtop {
       version {
         base  = '3.5.9'
         pkg   = base
-        release = 2
+        release = 3
       }
       tarball {
         source      = "apache-zookeeper-${version.base}.tar.gz"


### PR DESCRIPTION
### Description of PR

fix bug, see:  [BIGTOP-3913](https://issues.apache.org/jira/browse/BIGTOP-3913)

### How was this patch tested?

Building package with -PparentDir=/usr/bigtop for zk, 
and installing zookeeper, 
and testing by executing zookeeper-client,zookeeper-server,zookeeper-server-cleanup,zookeeper-server-initialize

### For code changes:
install_zookeeper.sh

Please review @iwasakims thanks