### PR TITLE
BIGTOP-3897: Failed to deploy gpdb on Fedora-36 for arm64

### DIFF
--- a/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
@@ -110,10 +110,18 @@ class gpdb {
       }
       # GPDB requires the following python packages as of v5.28.5. See
       # https://github.com/greenplum-db/gpdb/tree/5X_STABLE#building-greenplum-database-with-gporca.
-      exec { 'install_python_packages':
-        command => "/usr/bin/env pip install -q 'cryptography<3.3' lockfile paramiko psutil",
-        require => [Exec["install_pip"]],
-        timeout => 600,
+      if ($operatingsystem == 'CentOS') {
+        exec { 'install_python_packages':
+          command => "/usr/bin/env pip install -q 'cryptography<3.3' lockfile paramiko psutil",
+          require => [Exec["install_pip"]],
+          timeout => 600,
+        }
+      } else {
+        exec { 'install_python_packages':
+          command => "/usr/bin/env pip install -q lockfile paramiko psutil",
+          require => [Exec["install_pip"]],
+          timeout => 600,
+        }
       }
       package { ["gpdb"]:
         ensure => latest,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3897

The root cause: Python's cryptography package was upgraded to python3 and a Arm gcc error would occur when attempting to install the cryptography package by puppet.
The patch is to remove unnecessary package installation in puppet except for CentOS. GPDB smoke tests have been tested in Fedora-36, CentOS-7, Rockylinux-8, Debian-10/11 and Ubuntu-20.04.



