### PR TITLE
BIGTOP-3914: Add missing jars to Flink to fix sql-client.sh execution errors

### DIFF
--- a/bigtop-packages/src/common/flink/install_flink.sh
+++ b/bigtop-packages/src/common/flink/install_flink.sh
@@ -116,6 +116,8 @@ install -d -m 0755 $PREFIX/$LIB_DIR
 install -d -m 0755 $PREFIX/$LIB_DIR/bin
 install -d -m 0755 $PREFIX/$LIB_DIR/lib
 install -d -m 0755 $PREFIX/$LIB_DIR/examples
+install -d -m 0755 $PREFIX/$LIB_DIR/opt
+install -d -m 0755 $PREFIX/$LIB_DIR/plugins
 install -d -m 0755 $PREFIX/$NP_ETC_FLINK
 install -d -m 0755 $PREFIX/$ETC_FLINK/conf.dist
 install -d -m 0755 $PREFIX/var/log/flink
@@ -134,6 +136,9 @@ cp -a ${BUILD_DIR}/conf/* $PREFIX/$ETC_FLINK/conf.dist
 ln -s $NP_ETC_FLINK/conf $PREFIX/$LIB_DIR/conf
 
 cp -ra ${BUILD_DIR}/examples/* $PREFIX/${LIB_DIR}/examples/
+
+cp -ra ${BUILD_DIR}/opt/* $PREFIX/${LIB_DIR}/opt/
+cp -ra ${BUILD_DIR}/plugins/* $PREFIX/${LIB_DIR}/plugins/
 
 cp ${BUILD_DIR}/{LICENSE,README.txt} ${PREFIX}/${LIB_DIR}/
 


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR


### How was this patch tested?

`./gradlew flink-clean flink-pkg -PparentDir=/usr/bigtop -PpkgSuffix`
Successful build in Centos7(x86_64).
![1678866824954](https://user-images.githubusercontent.com/16263438/225243210-71cd5d2c-685f-40a0-9f88-46e91bc492c8.png)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/