### PR TITLE
BIGTOP-3924: Fix the issue of Ranger 2.3 compilation failure

### DIFF
--- a/bigtop-packages/src/common/ranger/do-component-build
+++ b/bigtop-packages/src/common/ranger/do-component-build
@@ -19,7 +19,7 @@ set -e
 . `dirname $0`/bigtop.bom
 
 
-mvn clean compile package install \
+mvn clean compile package  \
         -DskipTests=true       \
         -Dcheckstyle.skip=true \
         -Djacoco.skip=true     \


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Environment: bigtop/slaves:3.2.0-centos-7 
bigtop/slaves:3.2.0-centos-7 

The ranger compilation failed in the "do-component-build" because the compilation command for ranger was incorrect. Removing "install" will result in a successful compilation.


```
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single (default) on project ranger-distro: Failed to create assembly: Error creating assembly archive schema-registry-plugin: Problem creating jar: jar:file:/ws/build/ranger/rpm/BUILD/ranger-release-ranger-2.3.0/distro/target/ranger-distro-2.3.0.jar!/META-INF/maven/org.apache.ranger/ranger-distro/pom.xml: JAR entry META-INF/maven/org.apache.ranger/ranger-distro/pom.xml not found in /ws/build/ranger/rpm/BUILD/ranger-release-ranger-2.3.0/distro/target/ranger-distro-2.3.0.jar -> [Help 1]
[ERROR]
[ERROR] To see the full stack
 ```

detail in 
https://issues.apache.org/jira/browse/BIGTOP-3924

### How was this patch tested?
manula test
before apply this change 
![image](https://user-images.githubusercontent.com/18082602/229284526-f9caf45b-2128-4dc5-930c-9036a1c5857c.png)

after apply this change 
![image](https://user-images.githubusercontent.com/18082602/229284545-0b7f14d0-199a-4189-ae61-7576f6783f79.png)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/