### PR TITLE
BIGTOP-3922:zkcli.sh of Solr does not have executable permissions

### DIFF
--- a/bigtop-packages/src/common/solr/install_solr.sh
+++ b/bigtop-packages/src/common/solr/install_solr.sh
@@ -136,6 +136,7 @@ cp -a ${BUILD_DIR}/bin/oom_solr.sh $PREFIX/$LIB_DIR/bin
 #cp -a ${BUILD_DIR}/server/scripts/cloud-scripts/*.sh $PREFIX/$LIB_DIR/bin
 #cp -a $DISTRO_DIR/zkcli.sh $PREFIX/$LIB_DIR/bin
 chmod 755 $PREFIX/$LIB_DIR/bin/*
+chmod 755 $PREFIX/$LIB_DIR/server/scripts/cloud-scripts/*
 
 install -d -m 0755 $PREFIX/$LIB_DIR/licenses
 cp -a  ${BUILD_DIR}/licenses/* $PREFIX/$LIB_DIR/licenses

--- a/bigtop-packages/src/common/solr/install_solr.sh
+++ b/bigtop-packages/src/common/solr/install_solr.sh
@@ -136,7 +136,9 @@ cp -a ${BUILD_DIR}/bin/oom_solr.sh $PREFIX/$LIB_DIR/bin
 #cp -a ${BUILD_DIR}/server/scripts/cloud-scripts/*.sh $PREFIX/$LIB_DIR/bin
 #cp -a $DISTRO_DIR/zkcli.sh $PREFIX/$LIB_DIR/bin
 chmod 755 $PREFIX/$LIB_DIR/bin/*
-chmod 755 $PREFIX/$LIB_DIR/server/scripts/cloud-scripts/*
+chmod 755 $PREFIX/$LIB_DIR/server/scripts/cloud-scripts/zkcli.sh
+chmod 755 $PREFIX/$LIB_DIR/server/scripts/cloud-scripts/zkcli.bat
+chmod 755 $PREFIX/$LIB_DIR/server/scripts/cloud-scripts/snapshotscli.sh
 
 install -d -m 0755 $PREFIX/$LIB_DIR/licenses
 cp -a  ${BUILD_DIR}/licenses/* $PREFIX/$LIB_DIR/licenses

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -206,7 +206,7 @@ bigtop {
       name    = 'solr'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Solr'
-      version { base = '8.11.2'; pkg = base; release = 1 }
+      version { base = '8.11.2'; pkg = base; release = 2 }
       tarball { destination = "$name-${version.base}-src.tgz"
                 source      = destination }
       url     { download_path = "lucene/$name/${version.base}"


### PR DESCRIPTION
### Description of PR

Resolve issue [BIGTOP-3922](https://issues.apache.org/jira/browse/BIGTOP-3922)  by adding executable permissions to files in {SOLR_HOME}/server/scripts/cloud-scripts

### How was this patch tested?

building Solr,
Checking the permissions of thoese files by installing Solr or decompressing Solr package


### For code changes:
install_solr.sh