### PR TITLE
BIGTOP-3926. Fix build failure of Hive against Hadoop 3.3.5.

### DIFF
--- a/bigtop-packages/src/common/hive/patch14-HIVE-26684-branch-3.1.diff
+++ b/bigtop-packages/src/common/hive/patch14-HIVE-26684-branch-3.1.diff
@@ -1,0 +1,13 @@
+diff --git a/pom.xml b/pom.xml
+index 0036027039..6a53cca952 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -105,7 +105,7 @@
+     <maven.install.plugin.version>2.4</maven.install.plugin.version>
+     <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
+     <maven.javadoc.plugin.version>2.4</maven.javadoc.plugin.version>
+-    <maven.shade.plugin.version>3.1.0</maven.shade.plugin.version>
++    <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
+     <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
+     <maven.war.plugin.version>2.4</maven.war.plugin.version>
+     <maven.dependency.plugin.version>2.8</maven.dependency.plugin.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3926

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.1.0:shade (default) on project hive-jdbc: Error creating shaded jar: null: IllegalArgumentException -> [Help 1
```

The error was caused by upgrading Bouncy Castle on Hadoop side. [maven-shade-plugin must be upgraded](https://issues.apache.org/jira/browse/MSHADE-337) to handle multi-JVM jar.

This is follow-up of #1101 and depending on #1102.