### PR TITLE
BIGTOP-3929. Fix build failure of Flink due to transitive dependency on pentaho-aggdesigner-algorithm.

### DIFF
--- a/bigtop-packages/src/common/flink/patch0-FLINK-27640-branch-1.15.diff
+++ b/bigtop-packages/src/common/flink/patch0-FLINK-27640-branch-1.15.diff
@@ -1,0 +1,39 @@
+commit f9f989d99b9da64a0cf65e7e19faba3d967a9b8b
+Author: Sergey Nuyanzin <snuyanzin@gmail.com>
+Date:   Wed Mar 29 21:30:46 2023 +0200
+
+    [FLINK-27640][Connector/Hive][SQL Client] Exclude Pentaho dependency from Hive to avoid build problems with newer Maven versions. Newer Maven versions block http repositories such as conjars. Conjars is where Pentaho artifacts are stored (#22299)
+    
+    Co-authored-by: Martijn Visser <martijnvisser@apache.org>
+    (cherry picked from commit 36f39712d289b6b7b0b957a33bd1891266e3f992)
+
+diff --git a/flink-connectors/flink-connector-hive/pom.xml b/flink-connectors/flink-connector-hive/pom.xml
+index 7d0c36f..81f6a0c 100644
+--- a/flink-connectors/flink-connector-hive/pom.xml
++++ b/flink-connectors/flink-connector-hive/pom.xml
+@@ -508,6 +508,10 @@ under the License.
+ 					<groupId>org.slf4j</groupId>
+ 					<artifactId>slf4j-log4j12</artifactId>
+ 				</exclusion>
++				<exclusion>
++					<groupId>org.pentaho</groupId>
++					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
++				</exclusion>
+ 			</exclusions>
+ 		</dependency>
+ 
+diff --git a/flink-table/flink-sql-client/pom.xml b/flink-table/flink-sql-client/pom.xml
+index f6a0675..9224bd5 100644
+--- a/flink-table/flink-sql-client/pom.xml
++++ b/flink-table/flink-sql-client/pom.xml
+@@ -425,6 +425,10 @@ under the License.
+ 					<groupId>commons-lang</groupId>
+ 					<artifactId>commons-lang</artifactId>
+ 				</exclusion>
++				<exclusion>
++					<groupId>org.pentaho</groupId>
++					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
++				</exclusion>
+ 			</exclusions>
+ 		</dependency>
+ 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3929

Building flink fails due to missing transitive dependency on pentaho-aggdesigner-algorithm.

```
[ERROR] Failed to execute goal on project flink-connector-hive_2.12: Could not resolve dependencies for project org.apache.flink:flink-connector-hive_2.12:jar:1.15.3: Failed to collect dependencies at org.apache.hive:hive-exec:jar:2.3.9 -> org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde: Failed to read artifact descriptor for org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde: Could not transfer artifact org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde from/to conjars (http://conjars.org/repo): Transfer failed for http://conjars.org/repo/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom: Connect to conjars.org:80 [conjars.org/54.235.127.59] failed: Connection timed out (Connection timed out) -> [Help 1]
```

I backported the patch of [FLINK-27640](https://issues.apache.org/jira/browse/FLINK-27640) to branch-1.5 here for Bigtop 3.2.1 which should not have big version bumping. We can file another JIRA for bumping Flink (to 1.17.0 or later?) for Bigtop 3.3.0.
