### PR TITLE
BIGTOP-3931: fix kafka directory permission

### DIFF
--- a/bigtop-packages/src/rpm/kafka/SPECS/kafka.spec
+++ b/bigtop-packages/src/rpm/kafka/SPECS/kafka.spec
@@ -180,12 +180,11 @@ fi
 
 %files
 %defattr(-,root,root,755)
+%{usr_lib_kafka}
 %{bin_dir}/*
 %config(noreplace) %{etc_kafka_conf_dist}
 %config(noreplace) %{etc_default}/kafka
 %attr(0755,kafka,kafka) %{np_etc_kafka}
-%attr(0755,kafka,kafka) %{usr_lib_kafka}
-%attr(0755,kafka,kafka) %docdir %{doc_kafka}
 %attr(0755,kafka,kafka) %{var_lib_kafka}
 %attr(0755,kafka,kafka) %{np_var_run_kafka}
 %attr(0755,kafka,kafka) %{np_var_log_kafka}

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -301,7 +301,7 @@ bigtop {
       name    = 'kafka'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Kafka'
-      version { base = '2.8.1'; pkg = base; release = 2 }
+      version { base = '2.8.1'; pkg = base; release = 3 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
 fix kafka directory permission
details in https://issues.apache.org/jira/browse/BIGTOP-3931

### How was this patch tested?
Before the fix, the permission of /usr/bigtop/3.2.0/usr/lib/kafka and its subdirectories was set to kafka, instead of root. This caused a permission error when trying to install Ranger Kafka plugin.
![image](https://user-images.githubusercontent.com/18082602/233350571-3ab45769-4318-4163-a0ba-d2cbfc751bc2.png)

![image](https://user-images.githubusercontent.com/18082602/233349644-aa9b86aa-0479-4329-b3f9-cef4cce09c4f.png)

After the fix, the permission of /usr/bigtop/3.2.0/usr/lib/kafka and its subdirectories were restored to root, and Ranger Kafka plugin could be installed without issues.
![image](https://user-images.githubusercontent.com/18082602/233349954-2ba35025-366a-458a-9112-8a5ae8008469.png)
![image](https://user-images.githubusercontent.com/18082602/233350746-a4195321-192c-4a15-a579-9eb2a71d567b.png)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/