### PR TITLE
BIGTOP-3937:Executing smoke_tests of Solr repeatedly would be failed

### DIFF
--- a/bigtop-tests/smoke-tests/solr/build.gradle
+++ b/bigtop-tests/smoke-tests/solr/build.gradle
@@ -35,6 +35,26 @@ def create_collection() {
   }
 }
 
+def delete_collection() {
+  exec {
+    executable "/usr/bin/solrctl"
+    args "collection", "--delete", "smoke"
+  }
+  exec {
+    executable "/usr/bin/solrctl"
+    args "instancedir", "--delete", "smoke"
+  }
+}
+
+def clean() {
+  if (file("/tmp/smoke_data").exists()) {
+    exec {
+      executable "/usr/bin/rm"
+      args "-rf", "/tmp/smoke_data"
+    }
+  }
+}
+
 def junitVersion = '4.11'
 dependencies {
   compile group: 'junit', name: 'junit', version: junitVersion, transitive: 'true'
@@ -56,6 +76,11 @@ sourceSets {
 test.doFirst {
   checkEnv(["HADOOP_CONF_DIR"])
   create_collection()
+}
+
+test.doLast {
+  delete_collection()
+  clean()
 }
 
 test {


### PR DESCRIPTION
### Description of PR
Fixed issue [BIGTOP-3937](https://issues.apache.org/jira/browse/BIGTOP-3937) by cleaning up the data after Solr smoke testing.


### How was this patch tested?
We can execute Solr's smoke_tests repeatedly after applying this pr.


### For code changes:
solr smoke_tests/build.gradle
