### PR TITLE
BIGTOP-3940:bigtop hadoop and hbase build is failing because MAVEN_OPTS overridden in build scripts

### DIFF
--- a/bigtop-packages/src/common/hadoop/do-component-build
+++ b/bigtop-packages/src/common/hadoop/do-component-build
@@ -124,7 +124,7 @@ mkdir build
 mkdir build/src
  
 # Build artifacts
-MAVEN_OPTS="-Dzookeeper.version=$ZOOKEEPER_VERSION "
+MAVEN_OPTS="$MAVEN_OPTS -Dzookeeper.version=$ZOOKEEPER_VERSION "
 MAVEN_OPTS+="-Dleveldbjni.group=org.fusesource.leveldbjni "
 MAVEN_OPTS+="-DskipTests -DskipITs "
 

--- a/bigtop-packages/src/common/hbase/do-component-build
+++ b/bigtop-packages/src/common/hbase/do-component-build
@@ -18,7 +18,7 @@ set -ex
 
 . `dirname $0`/bigtop.bom
 
-export MAVEN_OPTS="-Xmx1024m"
+export MAVEN_OPTS="$MAVEN_OPTS -Xmx1024m"
 
 MVN_ARGS="-Phadoop-3.0 "
 MVN_ARGS+="-Dhadoop-three.version=${HADOOP_VERSION} "


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR


### How was this patch tested?
build hadoop and hbase before and after the change. After the change user defined  MAVEN_OPTS was used and build was success

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/