### PR TITLE
BIGTOP-3927: Add patch for build HBase ageinst Hadoop 3.3.5

### DIFF
--- a/bigtop-packages/src/common/hbase/patch2-HBASE-27860-2.4.13.diff
+++ b/bigtop-packages/src/common/hbase/patch2-HBASE-27860-2.4.13.diff
@@ -1,0 +1,23 @@
+diff --git a/hbase-shaded/pom.xml b/hbase-shaded/pom.xml
+index d71b011..6477a16 100644
+--- a/hbase-shaded/pom.xml
++++ b/hbase-shaded/pom.xml
+@@ -130,6 +130,18 @@
+                 <relocations>
+                   <!-- top level com not including sun-->
+                   <relocation>
++                    <pattern>com.sun.istack</pattern>
++                    <shadedPattern>${shaded.prefix}.com.sun.istack</shadedPattern>
++                  </relocation>
++                  <relocation>
++                    <pattern>com.sun.jersey</pattern>
++                    <shadedPattern>${shaded.prefix}.com.sun.jersey</shadedPattern>
++                  </relocation>
++                  <relocation>
++                    <pattern>com.sun.xml</pattern>
++                    <shadedPattern>${shaded.prefix}.com.sun.xml</shadedPattern>
++                  </relocation>
++                  <relocation>
+                     <pattern>com.cedarsoftware</pattern>
+                     <shadedPattern>${shaded.prefix}.com.cedarsoftware</shadedPattern>
+                   </relocation>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
See: [BIGTOP-3927](https://issues.apache.org/jira/browse/BIGTOP-3927)

### How was this patch tested?
Build following command
$ ./gradlew clean hbase-pkg-ind


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/