### PR TITLE
BIGTOP-3930. Fix deployment failure on Ubuntu 22.04 due to unavailable dependency on python.

### DIFF
--- a/bigtop-deploy/puppet/manifests/python.pp
+++ b/bigtop-deploy/puppet/manifests/python.pp
@@ -13,15 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Source: bigtop-ambari-mpack
-Section: misc
-Priority: extra
-Maintainer: Bigtop <dev@bigtop.apache.org>
-Build-Depends: debhelper (>= 6)
-Standards-Version: 3.8.0
-Homepage: http://ambari.apache.org/
-
-Package: bigtop-ambari-mpack
-Architecture: all
-Depends: openssl, postgresql (>= 8.1), python (>= 2.6) | python2 (>= 2.6), curl
-Description: Ambari Mpack 
+class python {
+    if (($operatingsystem == 'Ubuntu' and 0 <= versioncmp($operatingsystemmajrelease, '22.04'))) {
+        file { '/usr/bin/python':
+          ensure => 'link',
+          target => '/usr/bin/python2',
+        }
+    }
+}

--- a/bigtop-deploy/puppet/manifests/site.pp
+++ b/bigtop-deploy/puppet/manifests/site.pp
@@ -33,6 +33,8 @@ node default {
   } else {
     include node_with_components
   }
+
+  include python
 }
 
 if versioncmp($::puppetversion,'3.6.1') >= 0 {

--- a/bigtop-packages/src/deb/ambari/control
+++ b/bigtop-packages/src/deb/ambari/control
@@ -23,10 +23,10 @@ Homepage: http://ambari.apache.org/
 
 Package: ambari-server
 Architecture: all
-Depends: openssl, postgresql (>= 8.1), python (>= 2.6), curl
+Depends: openssl, postgresql (>= 8.1), python (>= 2.6) | python2 (>= 2.6), curl
 Description: Ambari Server 
 
 Package: ambari-agent
 Architecture: all
-Depends: openssl, python (>= 2.6), curl
+Depends: openssl, python (>= 2.6) | python2 (>= 2.6), curl
 Description: Ambari Agent 

--- a/bigtop-packages/src/deb/gpdb/control
+++ b/bigtop-packages/src/deb/gpdb/control
@@ -22,6 +22,6 @@ Homepage: https://github.com/greenplum-db/gpdb
 
 Package: gpdb
 Architecture: any
-Depends: ${shlibs:Depends}, bigtop-utils (>= 0.7), gcc, libffi-dev, libssl-dev, make, python-dev (>= 2.6), python-dev (<< 3)
+Depends: ${shlibs:Depends}, bigtop-utils (>= 0.7), gcc, libffi-dev, libssl-dev, make, python-dev (>= 2.6) | python2-dev (>= 2.6), python-dev (<< 3) | python2-dev
 Description: Greenplum MPP database engine
   Provides the Greenplum MPP database engine

--- a/bigtop-packages/src/deb/hive/control
+++ b/bigtop-packages/src/deb/hive/control
@@ -25,7 +25,7 @@ Homepage: http://hive.apache.org/
 Package: hive
 Architecture: all
 Depends: adduser, hadoop-client, bigtop-utils (>= 0.7), zookeeper,
-         hive-jdbc (= ${source:Version}), python
+         hive-jdbc (= ${source:Version}), python | python2
 Description: Data warehouse infrastructure built on top of Hadoop
  Hive is a data warehouse infrastructure built on top of Hadoop that provides
  tools to enable easy data summarization, adhoc querying and analysis of large
@@ -66,7 +66,7 @@ Description: Provides libraries necessary to connect to Apache Hive via JDBC
 
 Package: hive-hcatalog
 Architecture: all
-Depends: hadoop, hive, bigtop-utils (>= 0.6), python
+Depends: hadoop, hive, bigtop-utils (>= 0.6), python | python2
 Description: Table and storage management service for Apache Hadoop.
  This includes:
    * Providing a shared schema and data type mechanism.

--- a/bigtop-packages/src/deb/phoenix/control
+++ b/bigtop-packages/src/deb/phoenix/control
@@ -23,7 +23,7 @@ Homepage: http://phoenix.apache.org
 
 Package: phoenix
 Architecture: all
-Depends: bigtop-utils (>= 0.7),  python (>= 2.6)
+Depends: bigtop-utils (>= 0.7),  python (>= 2.6) | python2 (>= 2.6)
 Description: Phoenix is a SQL skin over HBase and client-embedded JDBC driver.
  Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
  The Phoenix query engine transforms an SQL query into one or more HBase scans,

--- a/bigtop-packages/src/deb/spark/control
+++ b/bigtop-packages/src/deb/spark/control
@@ -45,7 +45,7 @@ Description: Server for Spark worker
 
 Package: spark-python
 Architecture: all
-Depends: spark-core (= ${source:Version}), python
+Depends: spark-core (= ${source:Version}), python | python2
 Description: Python client for Spark
  Includes PySpark, an interactive Python shell for Spark, and related libraries
 

--- a/bigtop-packages/src/deb/ycsb/control
+++ b/bigtop-packages/src/deb/ycsb/control
@@ -23,7 +23,7 @@ Homepage: http://labs.yahoo.com/news/yahoo-cloud-serving-benchmark
 
 Package: ycsb
 Architecture: all
-Depends: python
+Depends: python | python2
 Description: The Yahoo! Cloud Serving Benchmark (YCSB) is an open-source
  specification and program suite for evaluating retrieval and 
  maintenance capabilities of computer programs. It is often used to 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3930

* added alternative dependency to python2.
* added manifest to use `/usr/bin/python` pointing to python2 on Ubuntu 22.04.