### PR TITLE
BIGTOP-3945: Fix YCSB build issues for deprecated mapr repo url

### DIFF
--- a/bigtop-packages/src/common/ycsb/patch2-maprdb-repo-url.diff
+++ b/bigtop-packages/src/common/ycsb/patch2-maprdb-repo-url.diff
@@ -1,0 +1,13 @@
+diff --git a/maprdb/pom.xml b/maprdb/pom.xml
+index 253eca45..8d56767a 100644
+--- a/maprdb/pom.xml
++++ b/maprdb/pom.xml
+@@ -25,7 +25,7 @@
+ 	<repositories>
+ 		<repository>
+ 			<id>mapr-releases</id>
+-			<url>http://repository.mapr.com/maven/</url>
++			<url>https://repository.mapr.com/nexus/content/groups/mapr-public/</url>
+ 			<snapshots>
+ 				<enabled>false</enabled>
+ 			</snapshots>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3945

Update deprecated mapr repo url to fix YCSB build issues

