### PR TITLE
BIGTOP-3946. Fix build failure of Ambari due to expired certificate of bower repo.

### DIFF
--- a/bigtop-packages/src/common/ambari/patch13-AMBARI-25946.diff
+++ b/bigtop-packages/src/common/ambari/patch13-AMBARI-25946.diff
@@ -1,0 +1,33 @@
+commit 7d047f5330b94354933636868c599e8ff8afbde3
+Author: Yu Hou <524860213@qq.com>
+Date:   Mon May 22 14:32:44 2023 +0800
+
+    AMBARI-25946: Fix CI/CD error for Ambari WebUI Tests (#3699)
+    
+    * AMBARI-25946: Fix CI/CD error for Ambari WebUI Tests
+    
+    Signed-off-by: Brahma Reddy Battula <brahma@apache.org>
+
+diff --git a/ambari-admin/src/main/resources/ui/admin-web/.bowerrc b/ambari-admin/src/main/resources/ui/admin-web/.bowerrc
+index d0f0b6fe31..9516cf171c 100644
+--- a/ambari-admin/src/main/resources/ui/admin-web/.bowerrc
++++ b/ambari-admin/src/main/resources/ui/admin-web/.bowerrc
+@@ -1,3 +1,4 @@
+ {
+-    "directory": "app/bower_components"
++    "directory": "app/bower_components",
++    "registry": "https://bower.herokuapp.com"
+ }
+\ No newline at end of file
+diff --git a/ambari-admin/src/main/resources/ui/admin-web/test/.bowerrc b/ambari-admin/src/main/resources/ui/admin-web/test/.bowerrc
+index 44491d3df5..8ea830f2a3 100644
+--- a/ambari-admin/src/main/resources/ui/admin-web/test/.bowerrc
++++ b/ambari-admin/src/main/resources/ui/admin-web/test/.bowerrc
+@@ -1,3 +1,4 @@
+ {
+-    "directory": "bower_components"
+-}
++    "directory": "bower_components",
++    "registry": "https://bower.herokuapp.com"
++}
+\ No newline at end of file


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3946

While upgrading bower should be the right solution, it is not yet done in Ambari upstream. I just added the patch of [AMBARI-25946](https://issues.apache.org/jira/browse/AMBARI-25946).