### PR TITLE
BIGTOP-3947. Fix build failure of Oozie due to insufficient test scope dependency on hive-service.

### DIFF
--- a/bigtop-packages/src/common/oozie/patch2-fix-hive-test-dependency.diff
+++ b/bigtop-packages/src/common/oozie/patch2-fix-hive-test-dependency.diff
@@ -1,0 +1,18 @@
+diff --git a/core/pom.xml b/core/pom.xml
+index e472129b2..f582ed16a 100644
+--- a/core/pom.xml
++++ b/core/pom.xml
+@@ -517,6 +517,13 @@
+             <scope>test</scope>
+         </dependency>
+ 
++        <dependency>
++            <groupId>org.apache.hive</groupId>
++            <artifactId>hive-service</artifactId>
++            <version>${hive.version}</version>
++            <scope>test</scope>
++        </dependency>
++
+     </dependencies>
+ 
+     <build>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3947

added test scope dependency on hive-service to compilation error.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:testCompile (default-testCompile) on project oozie-core: Compilation failure: Compilation failure:
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[39,31] package org.apache.hive.service does not exist
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[40,35] package org.apache.hive.service.cli does not exist
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[41,35] package org.apache.hive.service.cli does not exist
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[42,42] package org.apache.hive.service.cli.thrift does not exist
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[43,42] package org.apache.hive.service.cli.thrift does not exist
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[44,42] package org.apache.hive.service.cli.thrift does not exist
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[45,38] package org.apache.hive.service.server does not exist
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[55,11] cannot find symbol
[ERROR]   symbol:   class HiveServer2
[ERROR]   location: class org.apache.oozie.test.hive.MiniHS2
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[126,10] cannot find symbol
[ERROR]   symbol:   class CLIServiceClient
[ERROR]   location: class org.apache.oozie.test.hive.MiniHS2
[ERROR] /home/rocky/srcs/bigtop/build/oozie/rpm/BUILD/oozie-5.2.1/core/src/test/java/org/apache/oozie/test/hive/MiniHS2.java:[131,10] cannot find symbol
[ERROR]   symbol:   class CLIServiceClient
[ERROR]   location: class org.apache.oozie.test.hive.MiniHS2
[ERROR] -> [Help 1]
```