### PR TITLE
BIGTOP-3948. Fix build failure of Tez due to expired certificate of bower repo.

### DIFF
--- a/bigtop-packages/src/common/tez/patch6-TEZ-4492.diff
+++ b/bigtop-packages/src/common/tez/patch6-TEZ-4492.diff
@@ -1,0 +1,17 @@
+commit ccad71dabceb850b58ff38e77fd206e68f62ce4b
+Author: AnmolSun <124231245+AnmolSun@users.noreply.github.com>
+Date:   Thu May 4 13:26:14 2023 +0530
+
+    TEZ-4492: Update Bowerrc to use bower.herokuapp mirror to avoid Bower Registry CERT_EXPIRE issue (BOWER-2608) (#284) (Anmol Sundaram reviewed by Laszlo Bodor)
+
+diff --git a/tez-ui/src/main/webapp/.bowerrc b/tez-ui/src/main/webapp/.bowerrc
+index 5b0b07d75..b798d4977 100644
+--- a/tez-ui/src/main/webapp/.bowerrc
++++ b/tez-ui/src/main/webapp/.bowerrc
+@@ -1,5 +1,6 @@
+ {
+   "directory": "bower_components",
++  "registry": "https://bower.herokuapp.com",
+   "analytics": false,
+   "resolvers": [
+     "bower-shrinkwrap-resolver-ext"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3948

We need to cherry-pick the patch of [TEZ-4492](https://issues.apache.org/jira/browse/TEZ-4492) since Tez 0.10.3 is not yet released.