### PR TITLE
BIGTOP-3949. Fix dependency convergence error of Zeppelin.

### DIFF
--- a/bigtop-packages/src/common/zeppelin/patch3-exclude-jaxb-api.diff
+++ b/bigtop-packages/src/common/zeppelin/patch3-exclude-jaxb-api.diff
@@ -1,0 +1,15 @@
+diff --git a/zeppelin-server/pom.xml b/zeppelin-server/pom.xml
+index a724c7a63..3f9d7f7ef 100644
+--- a/zeppelin-server/pom.xml
++++ b/zeppelin-server/pom.xml
+@@ -329,6 +329,10 @@
+           <groupId>ch.qos.reload4j</groupId>
+           <artifactId>reload4j</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>javax.xml.bind</groupId>
++          <artifactId>jaxb-api</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+ 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3949

added exclusion to fix dependency convergence error caused by bumping Hadoop to 3.3.5.

```
Dependency convergence error for javax.xml.bind:jaxb-api:2.2.11 paths to dependency are:
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-org.apache.hadoop:hadoop-client:3.3.5
    +-org.apache.hadoop:hadoop-yarn-api:3.3.5
      +-javax.xml.bind:jaxb-api:2.2.11
and
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-org.apache.hadoop:hadoop-client:3.3.5
    +-org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5
      +-org.apache.hadoop:hadoop-yarn-common:3.3.5
        +-javax.xml.bind:jaxb-api:2.2.11
and
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-org.apache.hadoop:hadoop-common:3.3.5
    +-com.github.pjfanning:jersey-json:1.20
      +-com.sun.xml.bind:jaxb-impl:2.2.3-1
        +-javax.xml.bind:jaxb-api:2.2.2
```