### PR TITLE
BIGTOP-3950: fix ranger etc conf dir

### DIFF
--- a/bigtop-packages/src/common/ranger/install_ranger.sh
+++ b/bigtop-packages/src/common/ranger/install_ranger.sh
@@ -109,16 +109,16 @@ cp -r ${BUILD_DIR}/ranger-*-${COMPONENT}/* ${PREFIX}/${COMP_DIR}/
 
 # Config
 if [[ "${COMPONENT}" =~ ^(admin|usersync|tagsync|kms)$ ]]; then
-  install -d -m 0755 ${PREFIX}/${NP_ETC_RANGER}-${COMPONENT}
+  install -d -m 0755 ${PREFIX}/${NP_ETC_RANGER}/${COMPONENT}
   install -d -m 0755 ${PREFIX}/${ETC_RANGER}-${COMPONENT}/conf.dist
 
   if [[ "${COMPONENT}" = "admin" || "${COMPONENT}" = "kms" ]]; then
     cp -a ${PREFIX}/${COMP_DIR}/ews/webapp/WEB-INF/classes/conf.dist/* ${PREFIX}/${ETC_RANGER}-${COMPONENT}/conf.dist
-    ln -s ${NP_ETC_RANGER}-${COMPONENT}/conf ${PREFIX}/${COMP_DIR}/conf
-    ln -s ${NP_ETC_RANGER}-${COMPONENT}/conf ${PREFIX}/$COMP_DIR/ews/webapp/WEB-INF/classes/conf
+    ln -s ${NP_ETC_RANGER}/${COMPONENT}/conf ${PREFIX}/${COMP_DIR}/conf
+    ln -s ${NP_ETC_RANGER}/${COMPONENT}/conf ${PREFIX}/$COMP_DIR/ews/webapp/WEB-INF/classes/conf
   else
     cp -a ${PREFIX}/${COMP_DIR}/conf.dist/* ${PREFIX}/${ETC_RANGER}-${COMPONENT}/conf.dist
-    ln -s ${NP_ETC_RANGER}-${COMPONENT}/conf ${PREFIX}/${COMP_DIR}/conf
+    ln -s ${NP_ETC_RANGER}/${COMPONENT}/conf ${PREFIX}/${COMP_DIR}/conf
   fi
 else
   RANGER_COMPONENT=${COMPONENT}

--- a/bigtop-packages/src/common/ranger/install_ranger.sh
+++ b/bigtop-packages/src/common/ranger/install_ranger.sh
@@ -110,14 +110,14 @@ cp -r ${BUILD_DIR}/ranger-*-${COMPONENT}/* ${PREFIX}/${COMP_DIR}/
 # Config
 if [[ "${COMPONENT}" =~ ^(admin|usersync|tagsync|kms)$ ]]; then
   install -d -m 0755 ${PREFIX}/${NP_ETC_RANGER}/${COMPONENT}
-  install -d -m 0755 ${PREFIX}/${ETC_RANGER}-${COMPONENT}/conf.dist
+  install -d -m 0755 ${PREFIX}/${ETC_RANGER}/${COMPONENT}/conf.dist
 
   if [[ "${COMPONENT}" = "admin" || "${COMPONENT}" = "kms" ]]; then
-    cp -a ${PREFIX}/${COMP_DIR}/ews/webapp/WEB-INF/classes/conf.dist/* ${PREFIX}/${ETC_RANGER}-${COMPONENT}/conf.dist
+    cp -a ${PREFIX}/${COMP_DIR}/ews/webapp/WEB-INF/classes/conf.dist/* ${PREFIX}/${ETC_RANGER}/${COMPONENT}/conf.dist
     ln -s ${NP_ETC_RANGER}/${COMPONENT}/conf ${PREFIX}/${COMP_DIR}/conf
     ln -s ${NP_ETC_RANGER}/${COMPONENT}/conf ${PREFIX}/$COMP_DIR/ews/webapp/WEB-INF/classes/conf
   else
-    cp -a ${PREFIX}/${COMP_DIR}/conf.dist/* ${PREFIX}/${ETC_RANGER}-${COMPONENT}/conf.dist
+    cp -a ${PREFIX}/${COMP_DIR}/conf.dist/* ${PREFIX}/${ETC_RANGER}/${COMPONENT}/conf.dist
     ln -s ${NP_ETC_RANGER}/${COMPONENT}/conf ${PREFIX}/${COMP_DIR}/conf
   fi
 else

--- a/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
+++ b/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
@@ -440,7 +440,7 @@ getent group ranger >/dev/null || groupadd -r ranger
 getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m -d %{var_lib_ranger} ranger 2> /dev/null || :
 
 %post admin
-%{alternatives_cmd} --install %{np_etc_ranger}-admin/conf ranger-admin-conf %{etc_ranger}-admin/conf.dist 30
+%{alternatives_cmd} --install %{np_etc_ranger}/admin/conf ranger-admin-conf %{etc_ranger}-admin/conf.dist 30
 
 %preun admin
 if [ "$1" = 0 ]; then
@@ -452,7 +452,7 @@ getent group ranger >/dev/null || groupadd -r ranger
 getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m -d %{var_lib_ranger}} ranger 2> /dev/null || :
 
 %post usersync
-%{alternatives_cmd} --install %{np_etc_ranger}-usersync/conf ranger-usersync-conf %{etc_ranger}-usersync/conf.dist 30
+%{alternatives_cmd} --install %{np_etc_ranger}/usersync/conf ranger-usersync-conf %{etc_ranger}-usersync/conf.dist 30
 if [ -f %{usr_lib_ranger}-usersync/native/credValidator.uexe ]; then
     chmod u+s %{usr_lib_ranger}-usersync/native/credValidator.uexe
 fi
@@ -467,7 +467,7 @@ getent group ranger >/dev/null || groupadd -r ranger
 getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m -d %{var_lib_ranger} ranger 2> /dev/null || :
 
 %post kms
-%{alternatives_cmd} --install %{np_etc_ranger}-kms/conf ranger-kms-conf %{etc_ranger}-kms/conf.dist 30
+%{alternatives_cmd} --install %{np_etc_ranger}/kms/conf ranger-kms-conf %{etc_ranger}-kms/conf.dist 30
 
 %preun kms
 if [ "$1" = 0 ]; then
@@ -479,7 +479,7 @@ getent group ranger >/dev/null || groupadd -r ranger
 getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m -d %{var_lib_ranger} ranger 2> /dev/null || :
 
 %post tagsync
-%{alternatives_cmd} --install %{np_etc_ranger}-tagsync/conf ranger-tagsync-conf %{etc_ranger}-tagsync/conf.dist 30
+%{alternatives_cmd} --install %{np_etc_ranger}/tagsync/conf ranger-tagsync-conf %{etc_ranger}-tagsync/conf.dist 30
 
 %preun tagsync
 if [ "$1" = 0 ]; then
@@ -498,7 +498,7 @@ if [ "$1" = 0 ]; then
 %attr(0775,ranger,ranger) %{var_lib_ranger}
 %attr(0775,ranger,ranger) %{np_var_run_ranger}
 %config(noreplace) %{etc_ranger}-admin/conf.dist
-%attr(0755,ranger,ranger) %{np_etc_ranger}-admin
+%attr(0755,ranger,ranger) %{np_etc_ranger}/admin
 %{usr_lib_ranger}-admin
 
 %files usersync
@@ -506,19 +506,19 @@ if [ "$1" = 0 ]; then
 %{usr_lib_ranger}-usersync
 %attr(750,root,ranger) %{usr_lib_ranger}-usersync/native/credValidator.uexe
 %config(noreplace) %{etc_ranger}-usersync/conf.dist
-%attr(0755,ranger,ranger) %{np_etc_ranger}-usersync
+%attr(0755,ranger,ranger) %{np_etc_ranger}/usersync
 
 %files kms
 %defattr(-,root,root,755)
 %{usr_lib_ranger}-kms
 %config(noreplace) %{etc_ranger}-kms/conf.dist
-%attr(0755,ranger,ranger) %{np_etc_ranger}-kms
+%attr(0755,ranger,ranger) %{np_etc_ranger}/kms
 
 %files tagsync
 %defattr(-,root,root,755)
 %{usr_lib_ranger}-tagsync
 %config(noreplace) %{etc_ranger}-tagsync/conf.dist
-%attr(0755,ranger,ranger) %{np_etc_ranger}-tagsync
+%attr(0755,ranger,ranger) %{np_etc_ranger}/tagsync
 
 %files hdfs-plugin
 %defattr(-,root,root,755)

--- a/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
+++ b/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
@@ -484,7 +484,7 @@ getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m
 %preun tagsync
 if [ "$1" = 0 ]; then
         %{alternatives_cmd} --remove ranger-tagsync-conf %{etc_ranger}/tagsync/conf.dist || :
-
+fi
 
 %preun
 

--- a/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
+++ b/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
@@ -440,11 +440,11 @@ getent group ranger >/dev/null || groupadd -r ranger
 getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m -d %{var_lib_ranger} ranger 2> /dev/null || :
 
 %post admin
-%{alternatives_cmd} --install %{np_etc_ranger}/admin/conf ranger-admin-conf %{etc_ranger}-admin/conf.dist 30
+%{alternatives_cmd} --install %{np_etc_ranger}/admin/conf ranger-admin-conf %{etc_ranger}/admin/conf.dist 30
 
 %preun admin
 if [ "$1" = 0 ]; then
-        %{alternatives_cmd} --remove ranger-admin-conf %{etc_ranger}-admin/conf.dist || :
+        %{alternatives_cmd} --remove ranger-admin-conf %{etc_ranger}/admin/conf.dist || :
 fi
 
 %pre usersync
@@ -452,14 +452,14 @@ getent group ranger >/dev/null || groupadd -r ranger
 getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m -d %{var_lib_ranger}} ranger 2> /dev/null || :
 
 %post usersync
-%{alternatives_cmd} --install %{np_etc_ranger}/usersync/conf ranger-usersync-conf %{etc_ranger}-usersync/conf.dist 30
+%{alternatives_cmd} --install %{np_etc_ranger}/usersync/conf ranger-usersync-conf %{etc_ranger}/usersync/conf.dist 30
 if [ -f %{usr_lib_ranger}-usersync/native/credValidator.uexe ]; then
     chmod u+s %{usr_lib_ranger}-usersync/native/credValidator.uexe
 fi
 
 %preun usersync
 if [ "$1" = 0 ]; then
-        %{alternatives_cmd} --remove ranger-usersync-conf %{etc_ranger}-usersync/conf.dist || :
+        %{alternatives_cmd} --remove ranger-usersync-conf %{etc_ranger}/usersync/conf.dist || :
 fi
 
 %pre kms
@@ -467,11 +467,11 @@ getent group ranger >/dev/null || groupadd -r ranger
 getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m -d %{var_lib_ranger} ranger 2> /dev/null || :
 
 %post kms
-%{alternatives_cmd} --install %{np_etc_ranger}/kms/conf ranger-kms-conf %{etc_ranger}-kms/conf.dist 30
+%{alternatives_cmd} --install %{np_etc_ranger}/kms/conf ranger-kms-conf %{etc_ranger}/kms/conf.dist 30
 
 %preun kms
 if [ "$1" = 0 ]; then
-        %{alternatives_cmd} --remove ranger-kms-conf %{etc_ranger}-kms/conf.dist || :
+        %{alternatives_cmd} --remove ranger-kms-conf %{etc_ranger}/kms/conf.dist || :
 fi
 
 %pre tagsync
@@ -479,11 +479,11 @@ getent group ranger >/dev/null || groupadd -r ranger
 getent passwd ranger >/dev/null || useradd -c "Ranger" -s /bin/bash -g ranger -m -d %{var_lib_ranger} ranger 2> /dev/null || :
 
 %post tagsync
-%{alternatives_cmd} --install %{np_etc_ranger}/tagsync/conf ranger-tagsync-conf %{etc_ranger}-tagsync/conf.dist 30
+%{alternatives_cmd} --install %{np_etc_ranger}/tagsync/conf ranger-tagsync-conf %{etc_ranger}/tagsync/conf.dist 30
 
 %preun tagsync
 if [ "$1" = 0 ]; then
-        %{alternatives_cmd} --remove ranger-tagsync-conf %{etc_ranger}-tagsync/conf.dist || :
+        %{alternatives_cmd} --remove ranger-tagsync-conf %{etc_ranger}/tagsync/conf.dist || :
 
 
 %preun
@@ -497,7 +497,7 @@ if [ "$1" = 0 ]; then
 %defattr(-,root,root,755)
 %attr(0775,ranger,ranger) %{var_lib_ranger}
 %attr(0775,ranger,ranger) %{np_var_run_ranger}
-%config(noreplace) %{etc_ranger}-admin/conf.dist
+%config(noreplace) %{etc_ranger}/admin/conf.dist
 %attr(0755,ranger,ranger) %{np_etc_ranger}/admin
 %{usr_lib_ranger}-admin
 
@@ -505,19 +505,19 @@ if [ "$1" = 0 ]; then
 %defattr(-,root,root,755)
 %{usr_lib_ranger}-usersync
 %attr(750,root,ranger) %{usr_lib_ranger}-usersync/native/credValidator.uexe
-%config(noreplace) %{etc_ranger}-usersync/conf.dist
+%config(noreplace) %{etc_ranger}/usersync/conf.dist
 %attr(0755,ranger,ranger) %{np_etc_ranger}/usersync
 
 %files kms
 %defattr(-,root,root,755)
 %{usr_lib_ranger}-kms
-%config(noreplace) %{etc_ranger}-kms/conf.dist
+%config(noreplace) %{etc_ranger}/kms/conf.dist
 %attr(0755,ranger,ranger) %{np_etc_ranger}/kms
 
 %files tagsync
 %defattr(-,root,root,755)
 %{usr_lib_ranger}-tagsync
-%config(noreplace) %{etc_ranger}-tagsync/conf.dist
+%config(noreplace) %{etc_ranger}/tagsync/conf.dist
 %attr(0755,ranger,ranger) %{np_etc_ranger}/tagsync
 
 %files hdfs-plugin


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
This PR modifies the configuration directories for Ranger Admin, Ranger Tag Sync, and Ranger User Sync from `/etc/ranger-admin`, `/etc/ranger-tagsync`, and `/etc/ranger-usersync` to `/etc/ranger/{admin,tagsync,usersync}`. The detailed reason for this change can be found in the following issue: https://issues.apache.org/jira/projects/BIGTOP/issues/BIGTOP-3950

### How was this patch tested?
manual test
before fix, ranger-tagsync can't start,because it ranger can't found /etc/ranger/tagsync/logback.xml

![image](https://github.com/apache/bigtop/assets/18082602/3d96c485-976c-4110-8cc8-1a9ed5f11a81)

after fix , ranger-tagsync works smoonthly
![image](https://github.com/apache/bigtop/assets/18082602/33b402b1-d6b6-45e8-9946-c8c741d90b7d)
![image](https://github.com/apache/bigtop/assets/18082602/8073b76a-274e-480c-a554-d862a774311b)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/