### PR TITLE
BIGTOP-3952. Fix toolchain to download Maven from archive.apache.org instead of dlcdn.apache.org.

### DIFF
--- a/bigtop_toolchain/lib/puppet/parser/functions/latest_ant_binary.rb
+++ b/bigtop_toolchain/lib/puppet/parser/functions/latest_ant_binary.rb
@@ -17,6 +17,6 @@ module Puppet::Parser::Functions
     newfunction(:latest_ant_binary, :type => :rvalue) do |args|
         versionmask=args[0]
         # We are using main mirror here because can't be sure about Apache Server config on every mirror. It could be Nginx, btw. 
-        %x(curl -L --stderr /dev/null 'https://dlcdn.apache.org/ant/binaries/?F=0&amp;V=1' | grep -o '<li>.*href="apache-ant-#{versionmask}-bin.tar.gz"'  |  grep -o "apache-ant-#{versionmask}" | tail -1 | tr -d '\r').chomp
+        %x(curl -L --stderr /dev/null 'https://archive.apache.org/dist/ant/binaries/?F=0&amp;V=1' | grep -o '<li>.*href="apache-ant-#{versionmask}-bin.tar.gz"'  |  grep -o "apache-ant-#{versionmask}" | tail -1 | tr -d '\r').chomp
     end
 end

--- a/bigtop_toolchain/lib/puppet/parser/functions/latest_maven_binary.rb
+++ b/bigtop_toolchain/lib/puppet/parser/functions/latest_maven_binary.rb
@@ -17,6 +17,6 @@ module Puppet::Parser::Functions
     newfunction(:latest_maven_binary, :type => :rvalue) do |args|
         versionmask=args[0]
         # We are using main mirror here because can't be sure about Apache Server config on every mirror. It could be Nginx, btw.
-        %x(curl -L --stderr /dev/null 'https://dlcdn.apache.org/maven/maven-3/?F=0&amp;V=1' | grep -o '<li>.*href="#{versionmask}/"' | tail -1 | grep -o '#{versionmask}'| tr -d '\r').chomp
+        %x(curl -L --stderr /dev/null 'https://archive.apache.org/dist/maven/maven-3/?F=0&amp;V=1' | grep -o '<li>.*href="#{versionmask}/"' | tail -1 | grep -o '#{versionmask}'| tr -d '\r').chomp
     end
 end

--- a/bigtop_toolchain/lib/puppet/parser/functions/nearest_apache_mirror.rb
+++ b/bigtop_toolchain/lib/puppet/parser/functions/nearest_apache_mirror.rb
@@ -15,6 +15,6 @@
 
 module Puppet::Parser::Functions
     newfunction(:nearest_apache_mirror, :type => :rvalue) do |args|
-        %x( curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi?as_json=1 | grep preferred |cut -d '"' -f 4 | tr -d '\r').chomp
+        'https://archive.apache.org/dist'
     end
 end


### PR DESCRIPTION
### Description of PR

This PR changes the download site of Maven and Ant from dlcdn.apache.org to archive.apache.org in case that old versions are removed from the former site.

### How was this patch tested?

By running `./gradlew toolchain` on CentOS 7.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/