### PR TITLE
BIGTOP-3951. Fix toolchain to work with the recent version of facter.

### DIFF
--- a/bigtop-deploy/puppet/manifests/bigtop_repo.pp
+++ b/bigtop-deploy/puppet/manifests/bigtop_repo.pp
@@ -20,7 +20,7 @@ class bigtop_repo {
   $default_repo = "http://repos.bigtop.apache.org/releases/${bigtop_repo_default_version}/${lower_os}/${operatingsystemmajrelease}/${architecture}"
 
   case $::operatingsystem {
-    /(OracleLinux|Amazon|CentOS|Fedora|RedHat)/: {
+    /(OracleLinux|Amazon|CentOS|Fedora|RedHat|Rocky)/: {
       $baseurls_array = any2array(hiera("bigtop::bigtop_repo_uri", $default_repo))
       each($baseurls_array) |$count, $baseurl| {
         notify { "Baseurl: $baseurl": }

--- a/bigtop-deploy/puppet/manifests/jdk.pp
+++ b/bigtop-deploy/puppet/manifests/jdk.pp
@@ -41,7 +41,7 @@ class jdk {
         noop => $jdk_preinstalled,
       }
     }
-    /(CentOS|Amazon|Fedora|RedHat)/: {
+    /(CentOS|Amazon|Fedora|RedHat|Rocky)/: {
       package { 'jdk':
         name => 'java-1.8.0-openjdk-devel',
         ensure => present,

--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -998,10 +998,10 @@ class hadoop ($hadoop_security_authentication = "simple",
       include hadoop::common_yarn
 
       $hadoop_client_packages = $operatingsystem ? {
-        /(OracleLinux|CentOS|RedHat|Fedora)/  => [ "hadoop-doc", "hadoop-hdfs-fuse", "hadoop-client", "hadoop-libhdfs", "hadoop-debuginfo" ],
-        /(SLES|OpenSuSE)/                     => [ "hadoop-doc", "hadoop-hdfs-fuse", "hadoop-client", "hadoop-libhdfs" ],
-        /(Ubuntu|Debian)/                     => [ "hadoop-doc", "hadoop-hdfs-fuse", "hadoop-client", "libhdfs0-dev"   ],
-        default                               => [ "hadoop-doc", "hadoop-hdfs-fuse", "hadoop-client" ],
+        /(OracleLinux|CentOS|RedHat|Fedora|Rocky)/ => [ "hadoop-doc", "hadoop-hdfs-fuse", "hadoop-client", "hadoop-libhdfs", "hadoop-debuginfo" ],
+        /(SLES|OpenSuSE)/                          => [ "hadoop-doc", "hadoop-hdfs-fuse", "hadoop-client", "hadoop-libhdfs" ],
+        /(Ubuntu|Debian)/                          => [ "hadoop-doc", "hadoop-hdfs-fuse", "hadoop-client", "libhdfs0-dev"   ],
+        default                                    => [ "hadoop-doc", "hadoop-hdfs-fuse", "hadoop-client" ],
       }
 
       package { $hadoop_client_packages:

--- a/bigtop_toolchain/manifests/cleanup.pp
+++ b/bigtop_toolchain/manifests/cleanup.pp
@@ -15,7 +15,7 @@
 
 class bigtop_toolchain::cleanup {
   $packager_cleanup = $operatingsystem ? {
-    /(?i:(centos|fedora|redhat|amazon))/ => 'yum clean all',
+    /(?i:(centos|fedora|redhat|amazon|rocky))/ => 'yum clean all',
     /(?i:(SLES|opensuse))/ => 'zypper clean -a',
     /Ubuntu|Debian/        => 'apt-get clean',
   } 

--- a/bigtop_toolchain/manifests/env.pp
+++ b/bigtop_toolchain/manifests/env.pp
@@ -35,7 +35,7 @@ class bigtop_toolchain::env {
     'Ubuntu': {
       $javahome = "/usr/lib/jvm/${java}-openjdk-$arch"
     }
-    'Fedora','Centos','RedHat','Amazon': {
+    'Fedora','Centos','RedHat','Amazon','Rocky': {
       $javahome = "/usr/lib/jvm/${java}"
     }
     'OpenSuSE' : {

--- a/bigtop_toolchain/manifests/gnupg.pp
+++ b/bigtop_toolchain/manifests/gnupg.pp
@@ -16,7 +16,7 @@
 class bigtop_toolchain::gnupg {
 
   case $operatingsystem {
-    /(?i:(centos|fedora|redhat))/: {
+    /(?i:(centos|fedora|redhat|rocky))/: {
        $pkg = "gnupg2"
        $cmd = "gpg2"
     }

--- a/bigtop_toolchain/manifests/installer.pp
+++ b/bigtop_toolchain/manifests/installer.pp
@@ -42,7 +42,7 @@ class bigtop_toolchain::installer {
         require => Class['bigtop_toolchain::jdk'],
       }
     }
-    /(CentOS|Fedora|RedHat)/: {
+    /(CentOS|Fedora|RedHat|Rocky)/: {
       exec { 'ensure java 8 is set as default':
         command => "update-alternatives --set java java-1.8.0-openjdk.$(uname -m) \
                     && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)",

--- a/bigtop_toolchain/manifests/jdk.pp
+++ b/bigtop_toolchain/manifests/jdk.pp
@@ -39,7 +39,7 @@ class bigtop_toolchain::jdk {
         ensure  => present,
       }
     }
-    /(CentOS|Amazon|Fedora|RedHat)/: {
+    /(CentOS|Amazon|Fedora|RedHat|Rocky)/: {
       package { 'java-1.8.0-openjdk-devel' :
         ensure => present
       }

--- a/bigtop_toolchain/manifests/jdk11.pp
+++ b/bigtop_toolchain/manifests/jdk11.pp
@@ -22,7 +22,7 @@ class bigtop_toolchain::jdk11 {
         ensure  => present,
       }
     }
-    /(CentOS|Fedora|RedHat)/: {
+    /(CentOS|Fedora|RedHat|Rocky)/: {
       package { 'java-11-openjdk-devel' :
         ensure => present
       }

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -15,7 +15,7 @@
 
 class bigtop_toolchain::packages {
   case $operatingsystem{
-    /(?i:(centos|fedora|redhat))/: {
+    /(?i:(centos|fedora|redhat|rocky))/: {
       $_pkgs = [
         "unzip",
         "rsync",

--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -18,7 +18,7 @@ class bigtop_toolchain::renv {
   require bigtop_toolchain::packages
 
   case $operatingsystem{
-    /(?i:(centos|fedora|redhat|Amazon))/: {
+    /(?i:(centos|fedora|redhat|amazon|rocky))/: {
       $pkgs = [
         "R",
         "R-devel",


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR fixes the toolchain to work properly with the recent versions of facter on Rocky 8.
This PR is for branch-3.2. I'll submit another PR for the master branch.

### How was this patch tested?

```
$ ./gradlew -POS=rockylinux-8 -Pprefix=3.2.1 bigtop-puppet
$ ./gradlew -POS=rockylinux-8 -Pprefix=3.2.1 bigtop-slaves
$ ./gradlew -POS=rockylinux-8 -Pprefix=3.2.1 -Pmvn-cache-volume=true allclean bigtop-groovy-pkg-ind bigtop-jsvc-pkg-ind bigtop-utils-pkg-ind zookeeper-pkg-ind hadoop-pkg-ind repo-ind
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -C config_rockylinux-8.yaml -F docker-compose-cgroupv2.yml -G -L -i bigtop/puppet:3.2.1-rockylinux-8 -k hdfs,yarn -s yarn -c 1
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/