### PR TITLE
BIGTOP-3954. Fix the version definition in bigtop.bom so that `./gradlew setversion` works.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -93,8 +93,8 @@
 
 bigtop {
 /** Base Configuration of the mirror and archives */
-  base_version = "3.3.0"
-  version = base_version + "-SNAPSHOT"
+  version = "3.3.0-SNAPSHOT"
+  base_version = version.takeWhile { it != '-' }
   stack {
     'jdk' { version = "1." + ( System.getenv('BIGTOP_JDK') ?: "8" ); version_base = version }
     'scala' { version = '2.12.13'; version_base = version }


### PR DESCRIPTION
### Description of PR

This PR fixes version definitions in bigtop.bom so that [`./gradlew setversion`](/apache/bigtop/blob/master/release.gradle#L64-L74) works. That command replaces the same strings as the value of [the `version` variable defined in build.gradle](/apache/bigtop/blob/master/build.gradle#L152), so we have to assign a literal rather than a variable to [the `bigtop.version` variable in bigtop.bom](/apache/bigtop/blob/master/bigtop.bom#L97).

### How was this patch tested?

Made sure that `./gradlew setversion` works as expected with this PR:

```
$ ./gradlew all-components | head

> Task :all-components
bigtop 3.3.0-SNAPSHOT stack includes the following components
        alluxio                        2.8.0
        ambari                         2.7.5
        bigtop-ambari-mpack            2.7.5
        bigtop-groovy                  2.5.4
        bigtop-jsvc                    1.2.4
        bigtop-select         3.3.0-SNAPSHOT (RPM only)
        bigtop-utils          3.3.0-SNAPSHOT
$ ./gradlew setversion -Pnextversion=3.4.0

> Task :setversion

...

Fixing /home/vagrant/bigtop/bigtop.bom
Done! Please inspect changes to make sure everything is in order.

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
$ ./gradlew all-components | head

> Task :all-components
bigtop 3.4.0 stack includes the following components
        alluxio                        2.8.0
        ambari                         2.7.5
        bigtop-ambari-mpack            2.7.5
        bigtop-groovy                  2.5.4
        bigtop-jsvc                    1.2.4
        bigtop-select                  3.4.0 (RPM only)
        bigtop-utils                   3.4.0
```

... and the `-PpkgSuffix` option works too.

```
$ ./gradlew zookeeper-clean zookeeper-pkg -PpkgSuffix

...

BUILD SUCCESSFUL in 1m 36s
7 actionable tasks: 7 executed
$ ls -l output/zookeeper
total 3036
drwxr-xr-x. 2 vagrant vagrant     265  6月 28 14:15 x86_64
-rw-rw-r--. 1 vagrant vagrant 3107665  6月 28 14:13 zookeeper_3_4_0-3.5.9-3.el7.src.rpm
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/