### PR TITLE
BIGTOP-3877: add support for hadoop on openeuler

### DIFF
--- a/bigtop-packages/src/common/hadoop/do-component-build
+++ b/bigtop-packages/src/common/hadoop/do-component-build
@@ -131,6 +131,12 @@ MAVEN_OPTS+="-DskipTests -DskipITs "
 # Include common Maven Deployment logic
 . $(dirname ${0})/maven_deploy.sh
 
+. /etc/os-release
+OS="$ID"
+if [ "${OS}" = "openEuler" ] ; then
+  sed -i 's|node-gyp "^3.8.0"|node-gyp "^6.0.0"|g' hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/yarn.lock 
+fi
+
 # Build artifacts
 mvn $BUNDLE_SNAPPY -Pdist -Pnative -Psrc -Pyarn-ui -Dtar ${MAVEN_OPTS} install ${EXTRA_GOALS} "$@"
 mvn site site:stage ${MAVEN_OPTS} $@

--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -197,7 +197,11 @@ Requires: sh-utils, insserv
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
+%if 0%{?openEuler}
+BuildRequires: pkgconfig, fuse-libs, openEuler-rpm-config, lzo-devel, openssl-devel
+%else
 BuildRequires: pkgconfig, fuse-libs, redhat-rpm-config, lzo-devel, openssl-devel
+%endif
 # Required for init scripts
 Requires: coreutils, /lib/lsb/init-functions
 %endif


### PR DESCRIPTION
### Description of PR
Add support for hadoop component, the point modifed is:
1. redhat-rpm-config should be instead of openEuler-rpm-config in openEuler.
2. The node-gyp 3.8.0 only support python2, but openEuler using the python3.

### How was this patch tested?
docker run --rm -v `pwd`:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew hadoop-pkg'

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3877)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/