### PR TITLE
BIGTOP-3878: add support for kafka

### DIFF
--- a/bigtop-packages/src/rpm/kafka/SPECS/kafka.spec
+++ b/bigtop-packages/src/rpm/kafka/SPECS/kafka.spec
@@ -97,7 +97,11 @@ Requires: %{name} = %{version}-%{release}
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?openEuler}
+Requires: openeuler-lsb
+%else
 Requires: redhat-lsb
+%endif
 %endif
 
 %description server


### PR DESCRIPTION
### Description of PR
Add support for kafka component, the point modifed is:

redhat-lsb should be instead of openeuler-lsb in openEuler.

### How was this patch tested?
docker run --rm -v pwd:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew kafka-pkg'

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3878)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/