### PR TITLE
BIGTOP-3955: add support for phoenix

### DIFF
--- a/bigtop-deploy/puppet/modules/phoenix/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/phoenix/manifests/init.pp
@@ -28,28 +28,54 @@ class phoenix {
   }
 
   class hbase_master_restart {
-    exec { "hbase_master_restart":
-      command => "systemctl restart hbase-master",
-      path    => ['/usr/bin', '/bin'],
-      cwd     => '/tmp',
-      timeout => 3000,
-      require => [
-        File['phoenix-server-lib'],
-        Service['hbase-master'],
-        ],
+    if ($operatingsystem == 'openEuler') {
+      exec { "hbase_master_restart":
+        command => "/sbin/service hbase-master restart",
+        path    => ['/usr/bin', '/bin','/sbin'],
+        cwd     => '/tmp',
+        timeout => 3000,
+        require => [
+          File['phoenix-server-lib'],
+          Service['hbase-master'],
+         ],
+     }
+    } else {
+        exec { "hbase_master_restart":
+          command => "systemctl restart hbase-master",
+          path    => ['/usr/bin', '/bin'],
+          cwd     => '/tmp',
+          timeout => 3000,
+          require => [
+            File['phoenix-server-lib'],
+            Service['hbase-master'],
+          ],
+        }
     }
   }
 
   class hbase_server_restart {
-    exec { "hbase_server_restart":
-      command => "systemctl restart hbase-regionserver",
-      path    => ['/usr/bin', '/bin'],
-      cwd     => '/tmp',
-      timeout => 3000,
-      require => [
-        File['phoenix-server-lib'],
-        Service['hbase-regionserver'],
-        ],
+    if ($operatingsystem == 'openEuler') {
+      exec { "hbase_server_restart":
+        command => "/sbin/service hbase-regionserver restart",
+        path    => ['/usr/bin', '/bin','/sbin'],
+        cwd     => '/tmp',
+        timeout => 3000,
+        require => [
+          File['phoenix-server-lib'],
+          Service['hbase-regionserver'],
+         ],
+     }
+    } else {
+        exec { "hbase_server_restart":
+          command => "systemctl restart hbase-regionserver",
+          path    => ['/usr/bin', '/bin'],
+          cwd     => '/tmp',
+          timeout => 3000,
+          require => [
+            File['phoenix-server-lib'],
+            Service['hbase-regionserver'],
+          ],
+        }
     }
   }
 

--- a/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
+++ b/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
@@ -93,7 +93,7 @@ Requires: bsh-utils
 Requires: coreutils
 %endif
 
-%if  0%{?rhel} >= 8
+%if  0%{?rhel} >= 8 || 0%{?openEuler}
 Requires: python3
 %else
 Requires: python


### PR DESCRIPTION
### Description of PR
Add support for phoenix component, the point modifed is:

   select the python3 on openeuler.

### How was this patch tested?
docker run --rm -v pwd:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew phoenix-pkg'

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3955)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/