### PR TITLE
install puppetlabs-stdlib 4.12.0 by puppet in openeuler

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -71,16 +71,14 @@ case ${ID}-${VERSION_ID} in
         dnf config-manager --set-enabled codeready-builder-for-rhel-8-rhui-rpms
         ;;
     openEuler-*)
-        yum -y install hostname curl sudo unzip wget ruby vim patch systemd-devel rng-tools
+        yum -y install hostname curl sudo unzip wget ruby vim patch systemd-devel rng-tools findutils
         # openEuler ruby version is 3.X,so use puppet-7.22.0.
         gem install puppet -v 7.22.0
         gem install xmlrpc
         gem install sync
-        gem install puppetmodule-stdlib
+        puppet module install puppetlabs-stdlib --version 4.12.0
         #openEuler dnf defaulted is not use module,so comment module in puppet-7.22.0
         sed -i "91c execute([command(:dnf), 'install', '-d', '0', '-e', self.class.error_level, '-y', args])" /usr/local/share/gems/gems/puppet-7.22.0/lib/puppet/provider/package/dnfmodule.rb
-        mkdir -p /etc/puppetlabs/code/modules/stdlib
-        cp -r /usr/local/share/gems/gems/puppetmodule-stdlib-4.0.2/* /etc/puppetlabs/code/modules/stdlib/
         ;;
     *)
         echo "Unsupported OS ${ID}-${VERSION_ID}."


### PR DESCRIPTION
### Description of PR
   puppet module install puppetlabs-stdlib --version 4.12.0 in openeuler

### How was this patch tested?
 create the openeuler puppet docker image cmd:
 _**sh build.sh trunk-openeuler-22.03**_

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id ()
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/