### PR TITLE
BIGTOP-3883: add hadoop smoke test for openeuler

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -829,10 +829,20 @@ class hadoop ($hadoop_security_authentication = "simple",
   }
 
   define create_storage_dir {
-    exec { "mkdir $name":
-      command => "/bin/mkdir -p $name",
-      creates => $name,
-      user =>"root",
+    # change the cgroup of hdfs and yarn from hadoop to root in openeuler,
+    # otherwise, the namemode of hdfs has not the permission to create directories during smoke test.
+    if ($operatingsystem == 'openEuler'){
+      exec { "mkdir $name":
+        command => "/usr/sbin/usermod -G root yarn && /usr/sbin/usermod -G root hdfs && /bin/mkdir -p $name",
+        creates => $name,
+        user =>"root",
+      }
+    } else {
+      exec { "mkdir $name":
+        command => "/bin/mkdir -p $name",
+        creates => $name,
+        user =>"root",
+      }
     }
   }
 


### PR DESCRIPTION
### Description of PR
  add hadoop smoke test for openeuler
     change the cgroup of hdfs and yarn from hadoop to root in openeuler, otherwise, the namemode of hdfs has not the permission to create directories during smoke test.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id ([BIGTOP-3854](https://issues.apache.org/jira/browse/BIGTOP-3854))
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/