### PR TITLE
BIGTOP-3960. Fix build failure of Hadoop due to version mismatch between triple-beam and node.js.

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch0-YARN-11528.diff
+++ b/bigtop-packages/src/common/hadoop/patch0-YARN-11528.diff
@@ -1,0 +1,24 @@
+commit 5acb18576b6c8c8365c4d8ece931da43c786cf49
+Author: Masatake Iwasaki <iwasakims@apache.org>
+Date:   Tue Jul 11 15:38:09 2023 +0900
+
+    YARN-11528. Lock triple-beam to the version compatible with node.js 12 to avoid compilation error. (#5827). Contributed by Masatake Iwasaki
+    
+    Reviewed-by: Shilun Fan <slfan1989@apache.org>
+    Signed-off-by: Ayush Saxena <ayushsaxena@apache.org>
+    (cherry picked from commit a822a3c70bac8bb25b7b5b926030a2cd9499f52e)
+
+diff --git a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/package.json b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/package.json
+index f09442cfc4e..59cc3da179f 100644
+--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/package.json
++++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/package.json
+@@ -19,6 +19,9 @@
+         "shelljs": "^0.2.6",
+         "apidoc": "0.17.7"
+     },
++    "resolutions": {
++        "triple-beam": "1.3.0"
++    },
+     "scripts": {
+         "prestart": "npm install & mvn clean package",
+         "pretest": "npm install"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3960

```
Running 'yarn ' in /ws/build/hadoop/rpm/BUILD/hadoop-3.3.5-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target
yarn install v1.22.5
info No lockfile found.
[1/4] Resolving packages...
warning angular-route@1.6.10: For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.
warning angular@1.6.10: For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.
[2/4] Fetching packages...
error triple-beam@1.4.1: The engine "node" is incompatible with this module. Expected version ">= 14.0.0". Got "12.22.1"
error Found incompatible module.
```

We need to backport [YARN-11528](https://issues.apache.org/jira/browse/YARN-11528) to lock the version of triple-beam.