### PR TITLE
BIGTOP-3961: Fix version mismatch of hbase-client used by hadoop-yarn-server-timelineservice-hbase

### DIFF
--- a/bigtop-packages/src/common/hadoop/do-component-build
+++ b/bigtop-packages/src/common/hadoop/do-component-build
@@ -125,6 +125,7 @@ mkdir build/src
  
 # Build artifacts
 MAVEN_OPTS="-Dzookeeper.version=$ZOOKEEPER_VERSION "
+MAVEN_OPTS+="-Dhbase.profile=2.0 "
 MAVEN_OPTS+="-Dleveldbjni.group=org.fusesource.leveldbjni "
 MAVEN_OPTS+="-DskipTests -DskipITs "
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
After deploying yarn TimelineService v2, it fails to start because Hadoop 3, by default, includes HBase 1 client in the packaging of hadoop-yarn-server-timelineservice-hbase-client-3.3.4.jar. When the TimelineServiceReader starts and attempts to create an HBase table, it encounters compatibility issues between HBase 1 and 2 APIs, resulting in the failure to find the required method and thus unable to create the table.


see more details in  https://issues.apache.org/jira/browse/BIGTOP-3961

### How was this patch tested?
manual test
after fixed yarn timeline service v2  working normally 
![image](https://github.com/apache/bigtop/assets/18082602/79b6f188-419d-412d-8e68-02f0058c2adb)

![image](https://github.com/apache/bigtop/assets/18082602/fc5cd0c5-dad6-4985-a293-b27ebf1ebe54)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/