### PR TITLE
BIGTOP-3962. Fix setup failure of Ant due to unresolved gpg public key.

### DIFF
--- a/bigtop_toolchain/manifests/ant.pp
+++ b/bigtop_toolchain/manifests/ant.pp
@@ -34,6 +34,11 @@ class bigtop_toolchain::ant {
     unless  => "/usr/bin/test -f /usr/src/$ant-bin.tar.gz.asc",
   } ~>
 
+  exec { 'Import KEYS to verify signature':
+    command => "/usr/bin/curl -q $apache_prefix/ant/KEYS | /usr/bin/$bigtop_toolchain::gnupg::cmd --import -",
+    cwd     => "/usr/src",
+  } ->
+
   exec { 'Verify Ant binaries':
     command => "/usr/bin/$bigtop_toolchain::gnupg::cmd -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com $ant-bin.tar.gz.asc",
     cwd     => "/usr/src",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3962

```
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Download Ant binaries]/returns: executed successfully
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Download Ant binaries signature]/returns: executed successfully
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Download Ant binaries signature]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg: armor header: Version: GnuPG v1
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg: assuming signed data in 'apache-ant-1.9.9-bin.tar.gz'
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg: Signature made Thu Feb  2 18:30:59 2017 UTC
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg:                using DSA key A2115AE15F6B8B72
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg: Can't check signature: No public key
Error: '/usr/bin/gpg2 -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com apache-ant-1.9.9-bin.tar.gz.asc' returned 2 instead of one of [0]
Error: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: change from 'notrun' to ['0'] failed: '/usr/bin/gpg2 -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com apache-ant-1.9.9-bin.tar.gz.asc' returned 2 instead of one of [0]
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg: armor header: Version: GnuPG v1
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg: assuming signed data in 'apache-ant-1.9.9-bin.tar.gz'
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg: Signature made Thu Feb  2 18:30:59 2017 UTC
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg:                using DSA key A2115AE15F6B8B72
Notice: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]/returns: gpg: Can't check signature: No public key
Error: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]: Failed to call refresh: '/usr/bin/gpg2 -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com apache-ant-1.9.9-bin.tar.gz.asc' returned 2 instead of one of [0]
Error: /Stage[main]/Bigtop_toolchain::Ant/Exec[Verify Ant binaries]: '/usr/bin/gpg2 -v --verify --auto-key-retrieve --keyserver hkp://keyserver.ubuntu.com apache-ant-1.9.9-bin.tar.gz.asc' returned 2 instead of one of [0]
```

`--auto-key-retrieve` does not work even if I run the command manually on my local or fresh container. Manually importing KEYS should be the fix.