### PR TITLE
BIGTOP-3824: add support for ranger

### DIFF
--- a/bigtop-deploy/puppet/modules/ranger/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ranger/manifests/init.pp
@@ -77,7 +77,7 @@ class ranger {
     }
     
     if ($operatingsystem == 'openEuler') {
-      service { 'ranger-admin':
+      exec { 'ranger-admin':
         command => "/usr/sbin/usermod -G root ranger && /sbin/service ranger-admin start",
         require => Exec['systemctl daemon-reload'],
       }

--- a/bigtop-deploy/puppet/modules/ranger/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ranger/manifests/init.pp
@@ -75,10 +75,17 @@ class ranger {
       path    => ["/bin", "/usr/bin"],
       require => Exec['/usr/lib/ranger-admin/set_globals.sh'],
     }
-
-    service { 'ranger-admin':
-      ensure  => running,
-      require => Exec['systemctl daemon-reload'],
+    
+    if ($operatingsystem == 'openEuler') {
+      service { 'ranger-admin':
+        command => "/usr/sbin/usermod -G root ranger && /sbin/service ranger-admin start",
+        require => Exec['systemctl daemon-reload'],
+      }
+    } else {
+      service { 'ranger-admin':
+        ensure  => running,
+        require => Exec['systemctl daemon-reload'],
+      }
     }
   }
 }

--- a/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
+++ b/bigtop-packages/src/rpm/ranger/SPECS/ranger.spec
@@ -120,7 +120,10 @@ Requires: coreutils, insserv
 
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
-%if %{!?suse_version:1}0 && %{!?mgaversion:1}0
+# using the openeuler-lsb replace redhat-lsb in openEuler
+%if 0%{?openEuler}
+Requires: coreutils, openeuler-lsb
+%elif %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
 Requires: coreutils, redhat-lsb
 %endif
@@ -150,7 +153,10 @@ Requires: coreutils, insserv
 
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
-%if %{!?suse_version:1}0 && %{!?mgaversion:1}0
+# using the openeuler-lsb replace redhat-lsb in openEuler
+%if 0%{?openEuler}
+Requires: coreutils, openeuler-lsb
+%elif %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
 Requires: coreutils, redhat-lsb
 %endif
@@ -180,7 +186,10 @@ Requires: coreutils, insserv
 
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
-%if %{!?suse_version:1}0 && %{!?mgaversion:1}0
+# using the openeuler-lsb replace redhat-lsb in openEuler
+%if 0%{?openEuler}
+Requires: coreutils, openeuler-lsb
+%elif %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
 Requires: coreutils, redhat-lsb
 %endif
@@ -210,7 +219,10 @@ Requires: coreutils, insserv
 
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
-%if %{!?suse_version:1}0 && %{!?mgaversion:1}0
+# using the openeuler-lsb replace redhat-lsb in openEuler
+%if 0%{?openEuler}
+Requires: coreutils, openeuler-lsb
+%elif %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
 Requires: coreutils, redhat-lsb
 %endif
@@ -236,12 +248,17 @@ AutoReq: no
 # Required for init scripts
 Requires: coreutils, insserv
 %endif
+
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
-%if %{!?suse_version:1}0 && %{!?mgaversion:1}0
+# using the openeuler-lsb replace redhat-lsb in openEuler
+%if 0%{?openEuler}
+Requires: coreutils, openeuler-lsb
+%elif %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
 Requires: coreutils, redhat-lsb
 %endif
+
 %if  0%{?mgaversion}
 Requires: chkconfig, xinetd-simple-services, zlib, initscripts
 %endif


### PR DESCRIPTION
### Description of PR
Add support for ranger component, the point modifed is:

1. using the openeuler-lsb replace redhat-lsb on openeuler.
2. add the ranger user cgroup to root cgroup, or no permission to start ranger admin service.
3. using /sbin/service to start ranger-admin, like phoenix component: https://github.com/apache/bigtop/pull/1130#issuecomment-1647554191

### How was this patch tested?
docker run --rm -v pwd:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew ranger-pkg'

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3824)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/