### PR TITLE
BIGTOP-3965: Fix hadoop 3.3.5 NameNode can't start after enable range…

### DIFF
--- a/bigtop-packages/src/common/ranger/patch3-RANGER-4327.diff
+++ b/bigtop-packages/src/common/ranger/patch3-RANGER-4327.diff
@@ -1,0 +1,37 @@
+From eabfa05567270fd2ef98a327f327ff651a5f280e Mon Sep 17 00:00:00 2001
+From: jialiang <jialiangcaimd@gmail.com>
+Date: Wed, 26 Jul 2023 11:38:55 +0800
+Subject: [PATCH] Make ranger hdfs plugin support hadoop 3.3.5 +
+
+---
+ distro/src/main/assembly/hdfs-agent.xml  | 1 +
+ distro/src/main/assembly/plugin-yarn.xml | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/distro/src/main/assembly/hdfs-agent.xml b/distro/src/main/assembly/hdfs-agent.xml
+index 15254c9da..a23b9fca9 100644
+--- a/distro/src/main/assembly/hdfs-agent.xml
++++ b/distro/src/main/assembly/hdfs-agent.xml
+@@ -84,6 +84,7 @@
+         <fileMode>644</fileMode>
+         <includes>
+           <include>commons-lang:commons-lang</include>
++          <include>org.codehaus.jackson:jackson-jaxrs:jar:${codehaus.jackson.version}</include>
+           <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
+           <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
+           <include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>
+diff --git a/distro/src/main/assembly/plugin-yarn.xml b/distro/src/main/assembly/plugin-yarn.xml
+index c0a8ca3af..7f4a95925 100644
+--- a/distro/src/main/assembly/plugin-yarn.xml
++++ b/distro/src/main/assembly/plugin-yarn.xml
+@@ -54,6 +54,7 @@
+         <fileMode>644</fileMode>
+         <includes>
+           <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
++          <include>org.codehaus.jackson:jackson-jaxrs:jar:${codehaus.jackson.version}</include>
+           <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
+           <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
+           <include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>
+-- 
+2.37.0
+

--- a/bigtop-packages/src/common/ranger/patch4-RANGER-4333.diff
+++ b/bigtop-packages/src/common/ranger/patch4-RANGER-4333.diff
@@ -1,0 +1,12 @@
+diff --git a/distro/src/main/assembly/hive-agent.xml b/distro/src/main/assembly/hive-agent.xml
+index 5bae92ac5..68a037cff 100644
+--- a/distro/src/main/assembly/hive-agent.xml
++++ b/distro/src/main/assembly/hive-agent.xml
+@@ -53,6 +53,7 @@
+         <directoryMode>755</directoryMode>
+         <fileMode>644</fileMode>
+         <includes>
++          <include>org.codehaus.jackson:jackson-jaxrs:jar:${codehaus.jackson.version}</include>
+           <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
+           <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
+           <include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>


### PR DESCRIPTION
…r(2.4)

### Description of PR
hadoop 3.3.5 has upgraded its jackson dependency and removed all jackson 1.x packages, including the jackson-jaxrs jar. As a result, when starting with the Ranger plugin enabled, Hadoop namenode fails to start due to the ranger plugin inability to load jackson 1.x.

To address this issue and ensure compatibility with the Hadoop 3.3.5 upgrade, we need to package jackson 1.x jars in the hdfs plugin as well, like the Ozone did https://issues.apache.org/jira/browse/RANGER-2818. This will allow the namenode to start successfully.

look this issue for more details:  https://issues.apache.org/jira/browse/BIGTOP-3965

### How was this patch tested?
manual test
![image](https://github.com/apache/bigtop/assets/18082602/db5f464f-45ac-4a67-a958-4426bdce04c8)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/