### PR TITLE
BIGTOP-3966: Make hive 3.1.3 compatible with hadoop 3.3.5

### DIFF
--- a/bigtop-packages/src/common/hive/patch15-HIVE-27535-support-hadoop3.3.5.diff
+++ b/bigtop-packages/src/common/hive/patch15-HIVE-27535-support-hadoop3.3.5.diff
@@ -1,0 +1,13 @@
+diff --git a/pom.xml b/pom.xml
+index cb54806ef5..475b379d1c 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -169,7 +169,7 @@
+     <jdo-api.version>3.0.1</jdo-api.version>
+     <jettison.version>1.1</jettison.version>
+     <jetty.version>9.3.20.v20170531</jetty.version>
+-    <jersey.version>1.19</jersey.version>
++    <jersey.version>1.19.4</jersey.version>
+     <!-- Glassfish jersey is included for Spark client test only -->
+     <glassfish.jersey.version>2.22.2</glassfish.jersey.version>
+     <jline.version>2.12</jline.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Hive version: 3.1.3
Hadoop version: 3.3.5

After upgrading to Hadoop 3.3.5, the Hive WebHCat server fails to start because of inconsistent versions of the Jersey JAR package. Hive HCat lacks the jersey-server-1.19 jar.
for more details see: https://issues.apache.org/jira/browse/BIGTOP-3966

### How was this patch tested?
manual test
after apply this patch WebHCat start normally
![image](https://github.com/apache/bigtop/assets/18082602/3aecb9f6-2327-4b82-bca3-29100a9cc53a)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/