### PR TITLE
BIGTOP-3881: add support for alluxio

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -44,6 +44,11 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dgrpc.version=1.28.0 -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"
 
 else
+  #need to manually compile the libjnifuse*.so in openEuler
+  if [ "${OS}" = "openEuler" ] ; then
+    sed -i "s|<activeByDefault>false</activeByDefault>|<activeByDefault>true</activeByDefault>|g" integration/jnifuse/native/pom.xml
+  fi
+
   mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"
 
 fi

--- a/bigtop-packages/src/common/alluxio/install_alluxio.sh
+++ b/bigtop-packages/src/common/alluxio/install_alluxio.sh
@@ -129,6 +129,12 @@ cp -a libexec/* $PREFIX/$LIB_DIR/libexec
 cp -a client/* $PREFIX/$LIB_DIR/client
 cp -a integration/* $PREFIX/$LIB_DIR/integration
 cp integration/fuse/target/alluxio-integration-fuse-*-jar-with-dependencies.jar $PREFIX/$LIB_DIR/integration/fuse
+
+# replace the original libjnifuse*.so file with the manually compiled in openEuler
+if [ ${OS} = "openEuler" ]; then
+  cp integration/jnifuse/native/src/main/resources/libjnifuse*.so $PREFIX/$LIB_DIR/integration/jnifuse/native/target/classes/
+fi
+
 rm -rf $PREFIX/$LIB_DIR/integration/pom.xml $PREFIX/$LIB_DIR/integration/**/pom.xml
 rm -rf $PREFIX/$LIB_DIR/integration/target $PREFIX/$LIB_DIR/integration/**/target
 rm -rf $PREFIX/$LIB_DIR/integration/**/src


### PR DESCRIPTION
### Description of PR
Add support for alluxio component, include compile command and problem.

problem
      1. libjnifues3.so and libjnifuse.so need the version of glibc is 2.2.5, which is old version not in ARM openEuler .
 suggestion:  The file of [libjnifuse3.so](https://github.com/Alluxio/alluxio/blob/master/integration/jnifuse/native/src/main/resources/libjnifuse3.so) is X86 arch, which should be compiled manually.

https://github.com/Alluxio/alluxio/tree/master/integration/jnifuse/native/src/main/resources

### How was this patch tested?
build command         
           docker run --rm -v `pwd`:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew alluxio-pkg'

smoke test command
           ./docker-hadoop.sh -C config_openeuler-22.03.yaml -c 3 -s

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3881)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/