### PR TITLE
BIGTOP-3880: add support for gpdb

### DIFF
--- a/bigtop-packages/src/common/gpdb/do-component-configure
+++ b/bigtop-packages/src/common/gpdb/do-component-configure
@@ -16,4 +16,12 @@
 
 set -ex
 
+#specify the verion of python for openEuler
+. /etc/os-release
+OS="$ID"
+if [ "${OS}" = "openEuler" ]; then
+  sed -i 's|python setup.py build|python2 setup.py build|g'  gpMgmt/bin/Makefile
+  sed -i 's|python gpconfig_modules|python2 gpconfig_modules|g' gpMgmt/bin/Makefile
+fi
+
 ./configure --prefix=$1 --with-python --with-libxml --with-gssapi --disable-orca CFLAGS='-fcommon -Wno-implicit-fallthrough'

--- a/bigtop-packages/src/rpm/gpdb/SPECS/gpdb.spec
+++ b/bigtop-packages/src/rpm/gpdb/SPECS/gpdb.spec
@@ -43,7 +43,13 @@ Source2: install_gpdb.sh
 Source3: do-component-configure
 #BIGTOP_PATCH_FILES
 AutoReqProv: %{autorequire}
+
+#python2 be compiled manually and install, not installed by rpm in openEuler
+%if 0%{?openEuler}
+Requires: bigtop-utils >= 0.7, gcc, libffi-devel, make, openssl-devel
+%else
 Requires: bigtop-utils >= 0.7, gcc, libffi-devel, make, openssl-devel, python2-devel
+%endif
 
 %description
 gpdb


### PR DESCRIPTION
### Description of PR
Add support for gpdb component, include compile command and problem.
1. specify the verion of python for openEuler
2. python2 be compiled manually and install, not installed by rpm in openEuler

### How was this patch tested?
build command         
           docker run --rm -v `pwd`:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew gpdb-pkg'

smoke test command
           ./docker-hadoop.sh -C config_openeuler-22.03.yaml -c 3 -s

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3880)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/