### PR TITLE
BIGTOP-3968: add support for tez

### DIFF
--- a/bigtop-packages/src/common/tez/do-component-build
+++ b/bigtop-packages/src/common/tez/do-component-build
@@ -33,4 +33,11 @@ BUILD_TEZ_OPTS="clean package \
 -Phadoop28 \
 -DskipTests"
 
+# install tez-ui by bower need the root permissions in openEuler
+. /etc/os-release
+OS="$ID"
+if [ "${OS}" = "openEuler" ]; then
+  sed -i 's|--allow-root=false|--allow-root=true|g'  tez-ui/pom.xml
+fi
+
 mvn ${BUILD_TEZ_OPTS} "$@"


### PR DESCRIPTION
### Description of PR
Add support for tez component, include compile command and problem.
1. install tez-ui by bower need the root permissions in openEuler

### How was this patch tested?
build command
docker run --rm -v pwd:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew tez-pkg'

smoke test command
./docker-hadoop.sh -C config_openeuler-22.03.yaml -c 3 -s

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3968)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/