### PR TITLE
BIGTOP-3879: add support for ycsb

### DIFF
--- a/bigtop-packages/src/rpm/ycsb/SPECS/ycsb.spec
+++ b/bigtop-packages/src/rpm/ycsb/SPECS/ycsb.spec
@@ -36,7 +36,12 @@ Source3: bigtop.bom
 #BIGTOP_PATCH_FILES
 ## This package _explicitly_ turns off the auto-discovery of required dependencies
 ## to work around OSGI corner case, added to RPM lately. See BIGTOP-2421 for more info.
+## python2 be compiled manually and install, not installed by rpm in openEuler
+%if 0%{?openEuler}
+Requires: coreutils, bigtop-utils >= 0.7
+%else
 Requires: coreutils, bigtop-utils >= 0.7, python2
+%endif
 AutoReq: no
 
 %description 


### PR DESCRIPTION
### Description of PR
Add support for ycsb component, include compile command and problem.
1. python2 be compiled manually and install, not installed by rpm in openEuler

### How was this patch tested?
build command
docker run --rm -v pwd:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew ycsb-pkg'

smoke test command
./docker-hadoop.sh -C config_openeuler-22.03.yaml -c 3 -s

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3879)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/