### PR TITLE
BIGTOP-3969: add support for oozie 

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop_oozie/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop_oozie/manifests/init.pp
@@ -54,12 +54,22 @@ class hadoop_oozie {
       require => Package["oozie"],
     }
 
-    exec { "Oozie DB init":
-      command => "/etc/init.d/oozie init",
-      cwd     => "/var/lib/oozie",
-      creates => "/var/lib/oozie/derby.log",
-      require => Package["oozie"],
-      unless => "/etc/init.d/oozie status",
+    if ($operatingsystem == "openEuler") {
+      exec { "Oozie DB init":
+        command => "/usr/sbin/usermod -G hadoop oozie && /etc/init.d/oozie init",
+        cwd     => "/var/lib/oozie",
+        creates => "/var/lib/oozie/derby.log",
+        require => Package["oozie"],
+        unless => "/etc/init.d/oozie status",
+      }
+    } else {
+      exec { "Oozie DB init":
+        command => "/etc/init.d/oozie init",
+        cwd     => "/var/lib/oozie",
+        creates => "/var/lib/oozie/derby.log",
+        require => Package["oozie"],
+        unless => "/etc/init.d/oozie status",
+      }
     }
 
     service { "oozie":


### PR DESCRIPTION
### Description of PR
Add support for oozie component, include compile command and problem.

### How was this patch tested?
build command
docker run --rm -v pwd:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew oozie-pkg'

smoke test command
./docker-hadoop.sh -C config_openeuler-22.03.yaml -c 3 -s

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3969)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/