### PR TITLE
BIGTOP-3970. Fix build failure of Zeppelin due to missing grpc-java-1.26.0 on ppc64le.

### DIFF
--- a/bigtop-packages/src/common/zeppelin/do-component-build
+++ b/bigtop-packages/src/common/zeppelin/do-component-build
@@ -48,7 +48,7 @@ BUILD_OPTS="-Dhadoop3.2.version=${HADOOP_VERSION} \
 if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn install:install-file -DgroupId=com.google.protobuf -DartifactId=protoc -Dversion=3.5.0 \
       -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/local/protobuf-3.17.3/bin/protoc
-  
+  mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.26.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/src/grpc-java-1.26.0/compiler/build/exe/java_plugin/protoc-gen-grpc-java
   mvn install:install-file -DgroupId=io.grpc -DartifactId=protoc-gen-grpc-java -Dversion=1.28.0 -Dclassifier=linux-ppcle_64 -Dpackaging=exe -Dfile=/usr/src/grpc-java-1.28.0/compiler/build/exe/java_plugin/protoc-gen-grpc-java
 sed -i "s|<node.version>v12.3.1</node.version>|<node.version>v12.22.1</node.version>|" pom.xml
 sed -i "s|<npm.version>6.9.0</npm.version>|<npm.version>6.14.12</npm.version>|" pom.xml


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3970

[BIGTOP-3560](https://issues.apache.org/jira/browse/BIGTOP-3560) addressed similar issue caused by missing grpc-java-1.28.0. [BIGTOP-3893](https://issues.apache.org/jira/browse/BIGTOP-3893) addressed Hadoop issue caused by missing grpc-java-1.26.0. Zeppelin requires both grpc-java 1.26.0 and 1.28.0. While [both are compiled by docker_toolchain](https://github.com/apache/bigtop/blob/b52211e4e830d6aeb3b4a637b0222f7176c6ba21/bigtop_toolchain/manifests/grpc.pp#L26-L67), [do-component-build doinstall:install-file for 1.28.0](https://github.com/apache/bigtop/blob/b52211e4e830d6aeb3b4a637b0222f7176c6ba21/bigtop-packages/src/common/zeppelin/do-component-build#L52). If you build Zeppelin after Hadoop reusing local repo (~/.m2/repository), Zeppelin should succeed.

I need to fix this because I'm building each product in independent container for package-wise retry.
https://ci.bigtop.apache.org/job/Bigtop-3.2.1-ppc64le/