### PR TITLE
BIGTOP-3972. Fix startup failure of Oozie due to permission error on reading ssl-client.xml.

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -325,7 +325,7 @@ class hadoop ($hadoop_security_authentication = "simple",
         content => template('hadoop/ssl-client.xml'),
         owner   => 'root',
         group   => 'hadoop',
-        mode    => '0660',
+        mode    => '0664',
         require => [Package["hadoop"]],
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3972

In Bigtop deployment, Oozie reads /etc/hadoop/conf/ssl-client.xml on startup. The file should be readable by Oozie user.

* https://github.com/apache/oozie/blob/release-5.2.1/core/src/main/java/org/apache/oozie/service/HadoopAccessorService.java#L260-L261
* https://github.com/apache/bigtop/blob/02c1fb93f86edb587d7a215517c16c0181e8c576/bigtop-deploy/puppet/modules/hadoop_oozie/templates/oozie-site.xml#L224-L235

```
2023-08-01 12:11:07,913 ERROR Services:514 - SERVER[4d0ff4043c6d.bigtop.apache.org] E0100: Could not initialize service [org.apache.oozie.service.HadoopAccessorService], /etc/hadoop/conf/ssl-client.xml (Permission denied)
org.apache.oozie.service.ServiceException: E0100: Could not initialize service [org.apache.oozie.service.HadoopAccessorService], /etc/hadoop/conf/ssl-client.xml (Permission denied)
        at org.apache.oozie.service.HadoopAccessorService.loadHadoopConfigs(HadoopAccessorService.java:321)
        at org.apache.oozie.service.HadoopAccessorService.init(HadoopAccessorService.java:167)
        at org.apache.oozie.service.HadoopAccessorService.init(HadoopAccessorService.java:126)
        at org.apache.oozie.service.Services.setServiceInternal(Services.java:387)
        at org.apache.oozie.service.Services.setService(Services.java:373)
        at org.apache.oozie.service.Services.loadServices(Services.java:304)
        at org.apache.oozie.service.Services.init(Services.java:212)
        at org.apache.oozie.server.guice.ServicesProvider.get(ServicesProvider.java:31)
        at org.apache.oozie.server.guice.ServicesProvider.get(ServicesProvider.java:25)
        at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:55)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1031)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.Scopes$1$1.get(Scopes.java:65)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:40)
        at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
        at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:84)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:254)
        at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:53)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1031)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.Scopes$1$1.get(Scopes.java:65)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:40)
        at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
        at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:84)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:254)
        at com.google.inject.internal.InjectorImpl$4$1.call(InjectorImpl.java:978)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1024)
        at com.google.inject.internal.InjectorImpl$4.get(InjectorImpl.java:974)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1013)
        at org.apache.oozie.server.EmbeddedOozieServer.main(EmbeddedOozieServer.java:273)
Caused by: java.io.FileNotFoundException: /etc/hadoop/conf/ssl-client.xml (Permission denied)
        at java.io.FileInputStream.open0(Native Method)
        at java.io.FileInputStream.open(FileInputStream.java:195)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at org.apache.oozie.service.HadoopAccessorService.loadHadoopConf(HadoopAccessorService.java:269)
        at org.apache.oozie.service.HadoopAccessorService.loadHadoopConfigs(HadoopAccessorService.java:314)
        ... 33 more
2023-08-01 12:11:07,914  INFO Services:520 - SERVER[4d0ff4043c6d.bigtop.apache.org] Shutdown
```

