### PR TITLE
BIGTOP-3975: add the python2 for openEuler docker slaves

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -383,4 +383,26 @@ class bigtop_toolchain::packages {
       }
     }
   }
+
+  # download python 2.7.14 for openEuler docker slaves
+  if $operatingsystem == 'openEuler' {
+    exec { "download_python2.7":
+      cwd => "/usr/src",
+      command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.14 && /bin/tar -xvzf Python-2.7.14.tgz -C Python-2.7.14 --strip-components=1 && cd Python-2.7.14",
+      creates => "/usr/src/Python-2.7.14",
+    }
+
+    exec { "install_python2.7":
+      cwd => "/usr/src/Python-2.7.14",
+      command => "/usr/src/Python-2.7.14/configure --prefix=/usr/local/python2.7.14 --enable-optimizations && /usr/bin/make -j8 && /usr/bin/make install -j8",
+      require => [Exec["download_python2.7"]],
+      timeout => 3000
+    }
+
+    exec { "ln python2.7":
+      cwd => "/usr/bin",
+      command => "/usr/bin/ln -s /usr/local/python2.7.14/bin/python2.7 python2.7 && /usr/bin/ln -snf python2.7 python2",
+      require => Exec["install_python2.7"],
+    }
+  }
 }


### PR DESCRIPTION
### Description of PR
   We add the python2 for openEuler docker slaves by compile manually.
  Many components need python2, including ambari/ycsb/gpdb.

### How was this patch tested?
   The build command :
              ARM arch: /bigtop/docker/bigtop-slaves/build.sh trunk-openeuler-22.03-aarch64
              X86 arch: /bigtop/docker/bigtop-slaves/build.sh trunk-openeuler-22.03

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3975)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/