### PR TITLE
BIGTOP-3977: Support appending suffix to phoenix rpm package name

### DIFF
--- a/bigtop-packages/src/common/phoenix/install_phoenix.sh
+++ b/bigtop-packages/src/common/phoenix/install_phoenix.sh
@@ -29,6 +29,7 @@ usage: $0 <options>
      --lib-dir=DIR               path to install phoenix home [/usr/lib/phoenix]
      --installed-lib-dir=DIR     path where lib-dir will end up on target system
      --bin-dir=DIR               path to install bins [/usr/bin]
+     --var-lib-dir=DIR           path to install phoenix contents [/var/lib/phoenix]
      --examples-dir=DIR          path to install examples [doc-dir/examples]
      ... [ see source for more similar options ]
   "
@@ -45,6 +46,7 @@ OPTS=$(getopt \
   -l 'bin-dir:' \
   -l 'examples-dir:' \
   -l 'conf-dir:' \
+  -l 'var-lib-dir:' \
   -l 'build-dir:' -- "$@")
 
 if [ $? != 0 ] ; then
@@ -78,6 +80,9 @@ while true ; do
         --conf-dir)
         CONF_DIR=$2 ; shift 2
         ;;
+        --var-lib-dir)
+        VAR_LIB_DIR=$2 ; shift 2
+        ;;
         --)
         shift ; break
         ;;
@@ -102,6 +107,7 @@ LIB_DIR=${LIB_DIR:-/usr/lib/phoenix}
 BIN_DIR=${BIN_DIR:-/usr/lib/phoenix/bin}
 ETC_DIR=${ETC_DIR:-/etc/phoenix}
 CONF_DIR=${CONF_DIR:-${ETC_DIR}/conf.dist}
+VAR_LIB_DIR=${VAR_LIB_DIR:-/var/lib/phoenix}
 
 install -d -m 0755 $PREFIX/$BIN_DIR
 install -d -m 0755 $PREFIX/$LIB_DIR
@@ -110,7 +116,7 @@ install -d -m 0755 $PREFIX/$DOC_DIR
 install -d -m 0755 $PREFIX/$MAN_DIR
 install -d -m 0755 $PREFIX/$ETC_DIR
 install -d -m 0755 $PREFIX/$CONF_DIR
-install -d -m 0755 $PREFIX/var/lib/phoenix
+install -d -m 0755 $PREFIX/$VAR_LIB_DIR
 install -d -m 0755 $PREFIX/var/log/phoenix
 
 cp $BUILD_DIR/*.jar $PREFIX/$LIB_DIR/

--- a/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
+++ b/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
@@ -12,20 +12,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-%define phoenix_home /usr/lib/%{name}
+%define phoenix_name phoenix
+%define phoenix_pkg_name phoenix%{pkg_name_suffix}
+%define phoenix_home %{parent_dir}/usr/lib/%{phoenix_name}
 %define bin_phoenix %{phoenix_home}/bin
 %define examples_phoenix %{phoenix_home}/examples
-%define etc_phoenix_conf %{_sysconfdir}/%{name}/conf
+%define etc_phoenix_conf %{_sysconfdir}/%{phoenix_name}/conf
 %define etc_phoenix_conf_dist %{etc_phoenix_conf}.dist
-%define var_lib_phoenix /var/lib/%{name}
-%define var_log_phoenix /var/log/%{name}
+%define var_lib_phoenix %{parent_dir}/var/lib/%{phoenix_name}
+%define var_log_phoenix /var/log/%{phoenix_name}
 %define man_dir %{_mandir}
-%define zookeeper_home /usr/lib/zookeeper
-%define hadoop_home /usr/lib/hadoop
-%define hadoop_mapreduce_home /usr/lib/hadoop-mapreduce
-%define hadoop_yarn_home /usr/lib/hadoop-yarn
-%define hadoop_hdfs_home /usr/lib/hadoop-hdfs
-%define hbase_home /usr/lib/hbase
+%define zookeeper_home %{parent_dir}/usr/lib/zookeeper
+%define hadoop_home %{parent_dir}/usr/lib/hadoop
+%define hadoop_mapreduce_home %{parent_dir}/usr/lib/hadoop-mapreduce
+%define hadoop_yarn_home %{parent_dir}/usr/lib/hadoop-yarn
+%define hadoop_hdfs_home %{parent_dir}/usr/lib/hadoop-hdfs
+%define hbase_home %{parent_dir}/usr/lib/hbase
 #BIGTOP_PATCH_FILES
 
 %if  %{?suse_version:1}0
@@ -45,7 +47,7 @@
     /usr/lib/rpm/brp-compress ; \
     %{nil}
 
-%define doc_phoenix %{_docdir}/%{name}
+%define doc_phoenix %{_docdir}/%{phoenix_name}
 %define alternatives_cmd update-alternatives
 
 %else
@@ -67,20 +69,20 @@
     %{nil}
 %endif
 
-%define doc_phoenix %{_docdir}/%{name}-%{phoenix_version}
+%define doc_phoenix %{_docdir}/%{phoenix_name}-%{phoenix_version}
 %define alternatives_cmd alternatives
 
 %endif
 
-Name: phoenix
+Name: %{phoenix_pkg_name}
 Version: %{phoenix_version}
 Release: %{phoenix_release}
 Summary: Phoenix is a SQL skin over HBase and client-embedded JDBC driver.
 URL: http://phoenix.apache.org
 Group: Development/Libraries
-Buildroot: %{_topdir}/INSTALL/%{name}-%{version}
+Buildroot: %{_topdir}/INSTALL/%{phoenix_name}-%{version}
 License: ASL 2.0
-Source0: %{name}-%{phoenix_base_version}-src.tar.gz
+Source0: %{phoenix_name}-%{phoenix_base_version}-src.tar.gz
 Source1: do-component-build
 Source2: install_phoenix.sh
 Source3: bigtop.bom
@@ -109,7 +111,7 @@ tens of millions of rows. Applications interact with Phoenix through a
 standard JDBC interface; all the usual interfaces are supported.
 
 %prep
-%setup -n %{name}-%{phoenix_base_version}
+%setup -n %{phoenix_name}-%{phoenix_base_version}
 #BIGTOP_PATCH_COMMANDS
 
 %build
@@ -120,14 +122,17 @@ bash %{SOURCE1}
 bash %{SOURCE2} \
   --build-dir=build \
   --doc-dir=%{doc_phoenix} \
-  --prefix=$RPM_BUILD_ROOT
+  --prefix=$RPM_BUILD_ROOT \
+  --bin-dir=%{bin_phoenix} \
+  --lib-dir=%{phoenix_home} \
+  --var-lib-dir=%{var_lib_phoenix}
 
 %pre
 getent group phoenix >/dev/null || groupadd -r phoenix
 getent passwd phoenix >/dev/null || useradd -c "Phoenix" -s /sbin/nologin -g phoenix -r -d %{var_lib_phoenix} phoenix 2> /dev/null || :
 
 %post
-%{alternatives_cmd} --install %{etc_phoenix_conf} %{name}-conf %{etc_phoenix_conf_dist} 30
+%{alternatives_cmd} --install %{etc_phoenix_conf} %{phoenix_name}-conf %{etc_phoenix_conf_dist} 30
 
 %if  0%{?rhel} >= 8
 %{alternatives_cmd} --set python /usr/bin/python3
@@ -136,7 +141,7 @@ getent passwd phoenix >/dev/null || useradd -c "Phoenix" -s /sbin/nologin -g pho
 
 %preun
 if [ "$1" = 0 ]; then
-  %{alternatives_cmd} --remove %{name}-conf %{etc_phoenix_conf_dist} || :
+  %{alternatives_cmd} --remove %{phoenix_name}-conf %{etc_phoenix_conf_dist} || :
 fi
 
 

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -246,6 +246,7 @@ bigtop {
 
     'phoenix' {
       name    = 'phoenix'
+      rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Phoenix: A SQL skin over HBase'
       version { base = "5.1.2"; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tar.gz"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Append suffix to phoenix rpm package name

### How was this patch tested?
1 Run './gradlew phoenix-clean phoenix-pkg -PparentDir=/usr/bigtop -PpkgSuffix '
2 rpm -qpi build/phoenix/rpm/RPMS/noarch/phoenix_3_3_0-5.1.2-1.el7.noarch.rpm
```
Name        : phoenix_3_3_0
Version     : 5.1.2
Release     : 1.el7
Architecture: noarch
Install Date: (not installed)
Group       : Development/Libraries
Size        : 245557729
License     : ASL 2.0
Signature   : (none)
Source RPM  : phoenix_3_3_0-5.1.2-1.el7.src.rpm
Build Date  : Thu 03 Aug 2023 08:45:55 PM CST
Build Host  : hecs-161106
Relocations : (not relocatable)
URL         : http://phoenix.apache.org
Summary     : Phoenix is a SQL skin over HBase and client-embedded JDBC driver.
Description :
Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
The Phoenix query engine transforms an SQL query into one or more HBase scans,
and orchestrates their execution to produce standard JDBC result sets. Direct
use of the HBase API, along with coprocessors and custom filters, results in
performance on the order of milliseconds for small queries, or seconds for
tens of millions of rows. Applications interact with Phoenix through a
standard JDBC interface; all the usual interfaces are supported.
```
3 rpm -qpl build/phoenix/rpm/RPMS/noarch/phoenix_3_3_0-5.1.2-1.el7.noarch.rpm
```
/etc/phoenix/conf.dist
/usr/bigtop/3.3.0/usr/lib/phoenix/bin
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/argparse-1.4.0
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/argparse-1.4.0/argparse.py
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/daemon.py
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/end2endTest.py
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/hadoop-metrics2-hbase.properties
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/hadoop-metrics2-phoenix.properties
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/hbase-omid-client-config.yml
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/hbase-site.xml
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/log4j.properties
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/performance.py
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/pherf-standalone.py
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/phoenix_utils.py
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/psql.py
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/readme.txt
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/sqlline.py
/usr/bigtop/3.3.0/usr/lib/phoenix/bin/traceserver.py
/usr/bigtop/3.3.0/usr/lib/phoenix/examples
/usr/bigtop/3.3.0/usr/lib/phoenix/examples/STOCK_SYMBOL.csv
/usr/bigtop/3.3.0/usr/lib/phoenix/examples/STOCK_SYMBOL.sql
/usr/bigtop/3.3.0/usr/lib/phoenix/examples/WEB_STAT.csv
/usr/bigtop/3.3.0/usr/lib/phoenix/examples/WEB_STAT.sql
/usr/bigtop/3.3.0/usr/lib/phoenix/examples/WEB_STAT_QUERIES.sql
/usr/bigtop/3.3.0/usr/lib/phoenix/phoenix-client-hbase-2.4-5.1.2.jar
/usr/bigtop/3.3.0/usr/lib/phoenix/phoenix-client.jar
/usr/bigtop/3.3.0/usr/lib/phoenix/phoenix-pherf-5.1.2.jar
/usr/bigtop/3.3.0/usr/lib/phoenix/phoenix-server-hbase-2.4-5.1.2.jar
/usr/bigtop/3.3.0/usr/lib/phoenix/phoenix-server.jar
/usr/share/doc/phoenix-5.1.2
/usr/share/doc/phoenix-5.1.2/LICENSE
/usr/share/doc/phoenix-5.1.2/NOTICE
```

4 Run './gradlew phoenix-clean phoenix-pkg'
5 rpm -qpi build/phoenix/rpm/RPMS/noarch/phoenix-5.1.2-1.el7.noarch.rpm
```
Name        : phoenix
Version     : 5.1.2
Release     : 1.el7
Architecture: noarch
Install Date: (not installed)
Group       : Development/Libraries
Size        : 245557729
License     : ASL 2.0
Signature   : (none)
Source RPM  : phoenix-5.1.2-1.el7.src.rpm
Build Date  : Thu 03 Aug 2023 09:03:36 PM CST
Build Host  : hecs-161106
Relocations : (not relocatable)
URL         : http://phoenix.apache.org
Summary     : Phoenix is a SQL skin over HBase and client-embedded JDBC driver.
Description :
Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
The Phoenix query engine transforms an SQL query into one or more HBase scans,
and orchestrates their execution to produce standard JDBC result sets. Direct
use of the HBase API, along with coprocessors and custom filters, results in
performance on the order of milliseconds for small queries, or seconds for
tens of millions of rows. Applications interact with Phoenix through a
standard JDBC interface; all the usual interfaces are supported.
```
6 rpm -qpl build/phoenix/rpm/RPMS/noarch/phoenix-5.1.2-1.el7.noarch.rpm
```
/etc/phoenix/conf.dist
/usr/lib/phoenix/bin
/usr/lib/phoenix/bin/argparse-1.4.0
/usr/lib/phoenix/bin/argparse-1.4.0/argparse.py
/usr/lib/phoenix/bin/daemon.py
/usr/lib/phoenix/bin/end2endTest.py
/usr/lib/phoenix/bin/hadoop-metrics2-hbase.properties
/usr/lib/phoenix/bin/hadoop-metrics2-phoenix.properties
/usr/lib/phoenix/bin/hbase-omid-client-config.yml
/usr/lib/phoenix/bin/hbase-site.xml
/usr/lib/phoenix/bin/log4j.properties
/usr/lib/phoenix/bin/performance.py
/usr/lib/phoenix/bin/pherf-standalone.py
/usr/lib/phoenix/bin/phoenix_utils.py
/usr/lib/phoenix/bin/psql.py
/usr/lib/phoenix/bin/readme.txt
/usr/lib/phoenix/bin/sqlline.py
/usr/lib/phoenix/bin/traceserver.py
/usr/lib/phoenix/examples
/usr/lib/phoenix/examples/STOCK_SYMBOL.csv
/usr/lib/phoenix/examples/STOCK_SYMBOL.sql
/usr/lib/phoenix/examples/WEB_STAT.csv
/usr/lib/phoenix/examples/WEB_STAT.sql
/usr/lib/phoenix/examples/WEB_STAT_QUERIES.sql
/usr/lib/phoenix/phoenix-client-hbase-2.4-5.1.2.jar
/usr/lib/phoenix/phoenix-client.jar
/usr/lib/phoenix/phoenix-pherf-5.1.2.jar
/usr/lib/phoenix/phoenix-server-hbase-2.4-5.1.2.jar
/usr/lib/phoenix/phoenix-server.jar
/usr/share/doc/phoenix-5.1.2
/usr/share/doc/phoenix-5.1.2/LICENSE
/usr/share/doc/phoenix-5.1.2/NOTICE
```





















### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/