### PR TITLE
BIGTOP-3982: Fix build issues of openEuler docker images on Bigtop

### DIFF
--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -93,7 +93,7 @@ fi
 sed -e "s|PREFIX|${PREFIX}|;s|OS|${OS}|;s|VERSION|${VERSION}|" Dockerfile.template | \
   sed -e "s|PUPPET_MODULES|${PUPPET_MODULES}|;s|UPDATE_SOURCE|${UPDATE_SOURCE}|" > Dockerfile
 
-if [ $OS == "openeuler" ];then
+if [ "$OS" = "openeuler" ];then
   sed -i "s|\"include bigtop_toolchain::installer\"|\"include bigtop_toolchain::installer\" --modulepath=/etc/puppet/modules/|g" Dockerfile
 fi
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3982
The PR is based on Branch `openEuler-support`

The docker image of openEuler was not able to be built:

```
./build.sh: 96: [: openeuler: unexpected operator
...
..
.
=> ERROR [3/5] RUN if [ -f ~/.bash_profile ]; then . ~/.bash_profile; fi &&     yum clean all && yum updateinfo &&     puppet apply -e "include bigtop_toolchain::installer" || if [ $  27.1s
...
..
.
#0 24.71         14 Important Security notice(s)
#0 24.71          9 Moderate Security notice(s)
#0 27.07 Error: Evaluation Error: Error while evaluating a Function Call, Could not find class ::bigtop_toolchain::installer for buildkitsandbox.shanghai.arm.com (line: 1, column: 1) on node 
```


There is unexpected Operator error in shell script:
`if [ $OS == "openeuler" ];then`


