### PR TITLE
BIGTOP-3985: Make a symlink of hadoop-yarn-server-timelineservice-hba…

### DIFF
--- a/bigtop-packages/src/common/hadoop/install_hadoop.sh
+++ b/bigtop-packages/src/common/hadoop/install_hadoop.sh
@@ -397,6 +397,12 @@ for conf in conf.pseudo ; do
 done
 cp ${BUILD_DIR}/etc/hadoop/log4j.properties $PREFIX/$ETC_HADOOP/conf.pseudo
 
+# Make a symlink of hadoop-yarn-server-timelineservice-hbase-coprocessor.jar to hadoop-yarn-server-timelineservice-hbase-coprocessor-version.jar
+for x in $PREFIX/$YARN_DIR/timelineservice/hadoop-yarn-server-timelineservice-hbase-coprocessor-[[:digit:]]*.jar ; do
+  x=$(basename $x)
+  ln -s $x  $PREFIX/$YARN_DIR/timelineservice/hadoop-yarn-server-timelineservice-hbase-coprocessor.jar
+done
+
 # FIXME: Provide a convenience link for configuration (HADOOP-7939)
 install -d -m 0755 $PREFIX/$HADOOP_DIR/etc
 ln -s $NP_ETC_HADOOP/conf $PREFIX/$HADOOP_DIR/etc/hadoop


### PR DESCRIPTION
…se-coprocessor.jar to hadoop-yarn-server-timelineservice-hbase-coprocessor-version.jar

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
When using YARN Timeline Service v2, you need to configure the following property in yarn-site:
yarn.timeline-service.hbase.coprocessor.jar.hdfs.location
hadoop-yarn-server-timelineservice-hbase-coprocessor-3.3.5.jar
This binding to version 3.3.5 can complicate automated configuration and installation. Similar to other components that depend on ZooKeeper's jar, symbolic links are often created to handle version dependencies, generating zookeeper.jar. Both Ambari HDP and Bigtop stacks utilize similar code for configuring this property, making it easier to automatically populate the configuration without needing to consider the specific Hadoop version.

details see https://issues.apache.org/jira/browse/BIGTOP-3985

### How was this patch tested?
manual test
after apply this patch and rebuild hadoop rpm, yarn ui2 show logs normally with ambari bigtop stack
![image](https://github.com/apache/bigtop/assets/18082602/ad212784-47f0-4dbc-b4fa-d8aa748a0ba7)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/