### PR TITLE
BIGTOP-3983: Fix the Ranger-2.4 deploying issues

### DIFF
--- a/bigtop-packages/src/common/ranger/patch3-RANGER-3206-commit-2.diff
+++ b/bigtop-packages/src/common/ranger/patch3-RANGER-3206-commit-2.diff
@@ -1,0 +1,13 @@
+diff --git a/security-admin/scripts/db_setup.py b/security-admin/scripts/db_setup.py
+index 10acb5375..24502f4fb 100644
+--- a/security-admin/scripts/db_setup.py
++++ b/security-admin/scripts/db_setup.py
+@@ -149,7 +149,7 @@ def dbversionBasedOnUserName(userName):
+ def set_env_val(command):
+ 	proc = subprocess.Popen(command, stdout = subprocess.PIPE)
+ 	for line in proc.stdout:
+-		(key, _, value) = line.partition("=")
++		(key, _, value) = line.decode('utf8').partition('=')
+ 		os.environ[key] = value.rstrip()
+ 	proc.communicate()
+ 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3983

Cherry pick the patch from the commit 2 of [RANGER-3206](https://issues.apache.org/jira/browse/RANGER-3206).
(https://github.com/apache/ranger/commit/f6b69ca5846de9a7dfced70ae8e403388ecb89fe.)

The smoke tests were passed on Arm64 Fedora-36.
```
./docker-hadoop.sh -d --create 3 --image bigtop/puppet:3.2.0-fedora-36 --memory 16g \
--repo file:///bigtop-home/output --disable-gpg-check --enable-local-repo \
--stack bigtop-utils,ranger  \
--smoke-tests ranger 
```
```
...
..
.
> Task :bigtop-tests:smoke-tests:ranger:test
Finished generating test XML results (0.026 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.058 secs) into: /bigtop-home/bigtop-tests/smoke-tests/ranger/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:ranger:test (Thread[Execution worker for ':' Thread 8,5,main]) completed. Took 4.962 secs.

BUILD SUCCESSFUL in 53s

```