### PR TITLE
BIGTOP-3988: using bigtop/puppet for hadoop/ycsb/gpdb

### DIFF
--- a/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
@@ -73,6 +73,10 @@ class gpdb {
       # here to install it on all distros.
       # add the compile of python2 and install pip3 in openEuler.
       if ($operatingsystem == 'openEuler') {
+         package { ['gcc-c++', 'make', 'cmake']:
+           ensure => latest,
+           before => Exec['download_python2.7'],
+         }
          exec { "download_python2.7":
            cwd     => "/usr/src",
            command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.14 && /bin/tar -xvzf Python-2.7.14.tgz -C Python-2.7.14 --strip-components=1 && cd Python-2.7.14",

--- a/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/gpdb/manifests/init.pp
@@ -71,46 +71,14 @@ class gpdb {
       # doesn't seem to provide it as a standard package. So we use get-pip.py
       # (https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py)
       # here to install it on all distros.
-      # add the compile of python2 and install pip3 in openEuler.
-      if ($operatingsystem == 'openEuler') {
-         package { ['gcc-c++', 'make', 'cmake']:
-           ensure => latest,
-           before => Exec['download_python2.7'],
-         }
-         exec { "download_python2.7":
-           cwd     => "/usr/src",
-           command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.14 && /bin/tar -xvzf Python-2.7.14.tgz -C Python-2.7.14 --strip-components=1 && cd Python-2.7.14",
-           creates => "/usr/src/Python-2.7.14",
-         }
-
-         exec { "install_python2.7":
-           cwd     => "/usr/src/Python-2.7.14",
-           command => "/usr/src/Python-2.7.14/configure --prefix=/usr/local/python2.7.14 --enable-optimizations && /usr/bin/make -j8 && /usr/bin/make install -j8",
-           require => [Exec["download_python2.7"]],
-           timeout => 3000,
-         }
-
-         exec { "ln python2.7":
-           cwd     => "/usr/bin",
-           command => "/usr/bin/ln -s /usr/local/python2.7.14/bin/python2.7 python2.7 && /usr/bin/ln -snf python2.7 python2 && /usr/bin/ln -snf python2 python",
-           require => Exec["install_python2.7"],
-         }
+      exec { 'download_get_pip':
+        cwd => '/tmp',
+        command => '/usr/bin/curl -sLO https://bootstrap.pypa.io/pip/2.7/get-pip.py'
       }
-
-      if ($operatingsystem == 'openEuler') {
-         package { ['python3-pip']:
-           ensure => latest,
-         }
-      } else {
-         exec { 'download_get_pip':
-           cwd => '/tmp',
-           command => '/usr/bin/curl -sLO https://bootstrap.pypa.io/pip/2.7/get-pip.py'
-         }
-         exec { 'install_pip':
-           cwd => '/tmp',
-           command => '/usr/bin/python2 get-pip.py',
-           require => [Exec["download_get_pip"], Package["gpdb"]],
-         }
+      exec { 'install_pip':
+        cwd => '/tmp',
+        command => '/usr/bin/python2 get-pip.py',
+        require => [Exec["download_get_pip"], Package["gpdb"]],
       }
       # GPDB requires the following python packages as of v5.28.5. See
       # https://github.com/greenplum-db/gpdb/tree/5X_STABLE#building-greenplum-database-with-gporca.
@@ -121,18 +89,10 @@ class gpdb {
           timeout => 600,
         }
       } else {
-        if ($operatingsystem == 'openEuler') {
-           exec { 'install_python_packages':
-             command => "/usr/bin/env pip install lockfile paramiko psutil",
-             require => Package['python3-pip'],
-             timeout => 600,
-           }
-        } else {
-           exec { 'install_python_packages':
-             command => "/usr/bin/env pip install -q lockfile paramiko psutil",
-             require => [Exec["install_pip"]],
-             timeout => 600,
-           }
+        exec { 'install_python_packages':
+          command => "/usr/bin/env pip install -q lockfile paramiko psutil",
+          require => [Exec["install_pip"]],
+          timeout => 600,
         }
       }
       package { ["gpdb"]:

--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -831,9 +831,9 @@ class hadoop ($hadoop_security_authentication = "simple",
   define create_storage_dir {
     # change the cgroup of hdfs and yarn from hadoop to root in openeuler,
     # otherwise, the namemode of hdfs has not the permission to create directories during smoke test.
-    if ($operatingsystem == 'openEuler'){
+    if ($operatingsystem == 'openEuler') {
       exec { "mkdir $name":
-        command => "/usr/sbin/usermod -G root yarn && /usr/sbin/usermod -G root hdfs && /bin/mkdir -p $name",
+        command => "/usr/sbin/usermod -G root hdfs && /bin/mkdir -p $name",
         creates => $name,
         user =>"root",
       }
@@ -987,6 +987,13 @@ class hadoop ($hadoop_security_authentication = "simple",
       group => yarn,
       mode => '755',
       require => [Package["hadoop-yarn"]],
+    }
+
+    if ($operatingsystem == 'openEuler') {
+      exec { "usermod yarn":
+        command => "/usr/sbin/usermod -G root yarn",
+        require => Package["hadoop-yarn-nodemanager"],
+      }
     }
   }
 

--- a/bigtop-deploy/puppet/modules/ycsb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ycsb/manifests/init.pp
@@ -22,6 +22,28 @@ class ycsb {
   }
 
   class client {
+    # install python2 in openEuler
+    if ($operatingsystem == 'openEuler') {
+       exec { "download_python2.7":
+         cwd     => "/usr/src",
+         command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.14 && /bin/tar -xvzf Python-2.7.14.tgz -C Python-2.7.14 --strip-components=1 && cd Python-2.7.14",
+         creates => "/usr/src/Python-2.7.14",
+       }
+
+       exec { "install_python2.7":
+         cwd     => "/usr/src/Python-2.7.14",
+         command => "/usr/src/Python-2.7.14/configure --prefix=/usr/local/python2.7.14 --enable-optimizations && /usr/bin/make -j8 && /usr/bin/make install -j8",
+         require => [Exec["download_python2.7"]],
+         timeout => 3000,
+       }
+
+       exec { "ln python2.7":
+         cwd     => "/usr/bin",
+         command => "/usr/bin/ln -s /usr/local/python2.7.14/bin/python2.7 python2.7 && /usr/bin/ln -snf python2.7 python2 && /usr/bin/ln -snf python2 python",
+         require => Exec["install_python2.7"],
+       }
+    }
+
     package { ["ycsb"]:
       ensure => latest,
     }

--- a/bigtop-deploy/puppet/modules/ycsb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ycsb/manifests/init.pp
@@ -22,32 +22,6 @@ class ycsb {
   }
 
   class client {
-    # install python2 in openEuler
-    if ($operatingsystem == 'openEuler') {
-       package { ['gcc-c++', 'make', 'cmake']:
-         ensure => latest,
-         before => Exec['download_python2.7'],
-       }
-       exec { "download_python2.7":
-         cwd     => "/usr/src",
-         command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.14 && /bin/tar -xvzf Python-2.7.14.tgz -C Python-2.7.14 --strip-components=1 && cd Python-2.7.14",
-         creates => "/usr/src/Python-2.7.14",
-       }
-
-       exec { "install_python2.7":
-         cwd     => "/usr/src/Python-2.7.14",
-         command => "/usr/src/Python-2.7.14/configure --prefix=/usr/local/python2.7.14 --enable-optimizations && /usr/bin/make -j8 && /usr/bin/make install -j8",
-         require => [Exec["download_python2.7"]],
-         timeout => 3000,
-       }
-
-       exec { "ln python2.7":
-         cwd     => "/usr/bin",
-         command => "/usr/bin/ln -s /usr/local/python2.7.14/bin/python2.7 python2.7 && /usr/bin/ln -snf python2.7 python2 && /usr/bin/ln -snf python2 python",
-         require => Exec["install_python2.7"],
-       }
-    }
-
     package { ["ycsb"]:
       ensure => latest,
     }

--- a/bigtop-deploy/puppet/modules/ycsb/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ycsb/manifests/init.pp
@@ -24,6 +24,10 @@ class ycsb {
   class client {
     # install python2 in openEuler
     if ($operatingsystem == 'openEuler') {
+       package { ['gcc-c++', 'make', 'cmake']:
+         ensure => latest,
+         before => Exec['download_python2.7'],
+       }
        exec { "download_python2.7":
          cwd     => "/usr/src",
          command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.14 && /bin/tar -xvzf Python-2.7.14.tgz -C Python-2.7.14 --strip-components=1 && cd Python-2.7.14",


### PR DESCRIPTION
### Description of PR
Using bigtop/puppet for hadoop/ycsb/gpdb, include compile command and problem.

1. install python2 in openEuler
2. fix some smoketest bug.

### How was this patch tested?
**build command, such as:**
docker run --rm -v pwd:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew gpdb-pkg'

**smoke test command, sush as:**
./docker-hadoop.sh --create 3 --image bigtop/puppet:test-openeuler-22.03 --memory 16g --repo file:///bigtop-home/output --disable-gpg-check --enable-local-repo --stack bigtop-utils,gpdb  --smoke-tests gpdb

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3988)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/