### PR TITLE
BIGTOP-3988: using bigtop/puppet for hadoop

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -833,7 +833,7 @@ class hadoop ($hadoop_security_authentication = "simple",
     # otherwise, the namemode of hdfs has not the permission to create directories during smoke test.
     if ($operatingsystem == 'openEuler'){
       exec { "mkdir $name":
-        command => "/usr/sbin/usermod -G root yarn && /usr/sbin/usermod -G root hdfs && /bin/mkdir -p $name",
+        command => "/usr/sbin/usermod -G root hdfs && /bin/mkdir -p $name",
         creates => $name,
         user =>"root",
       }
@@ -987,6 +987,13 @@ class hadoop ($hadoop_security_authentication = "simple",
       group => yarn,
       mode => '755',
       require => [Package["hadoop-yarn"]],
+    }
+
+    if ($operatingsystem == 'openEuler') {
+      exec { "usermod yarn":
+        command => "/usr/sbin/usermod -G root yarn",
+        require => Package["hadoop-yarn-nodemanager"],
+      }
     }
   }
 


### PR DESCRIPTION
### Description of PR
Using bigtop/puppet for hadoop, include compile command and problem.

### How was this patch tested?

build command, such as:
docker run --rm -v pwd:/home/bigtop --workdir /home/bigtop bigtop/slaves:trunk-openeuler-22.03-aarch64 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew hadoop-pkg'

smoke test command, sush as:
./docker-hadoop.sh --create 3 --image bigtop/puppet:test-openeuler-22.03 --memory 16g --repo file:///bigtop-home/output --disable-gpg-check --enable-local-repo --stack bigtop-utils,hadoop--smoke-tests hadoop


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3988)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/