### PR TITLE
BIGTOP-3993. Bump ZooKeeper to 3.6.4.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -133,9 +133,9 @@ bigtop {
       pkg     = name
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       version {
-        base  = '3.5.9'
+        base  = '3.6.4'
         pkg   = base
-        release = 3
+        release = 1
       }
       tarball {
         source      = "apache-zookeeper-${version.base}.tar.gz"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3993

While I know ZooKeeper 3.6 is already EOL, Hadoop 3.3.6 is developed against it now (and having compilation issue against ZooKeeper 3.5). I think bumping ZooKeeper from 3.5 to 3.6 is good as intermediate step to upgrade to 3.7 or later and good candidate to merge into branch-3.2 (i.e. Bigtop 3.2.2) too.

I built zookeeper-pkg and ran smoke-tests of zookeeper this on Ubuntu 22.04 (x86_64) and Rocky Linux 8 (aarch64).

```
$ ./docker-hadoop.sh \
    --create 1 \
    --image bigtop/puppet:trunk-ubuntu-22.04 \
    --docker-compose-yml docker-compose-cgroupv2.yml \
    --docker-compose-plugin \
    --memory 16g \
    --repo file:///bigtop-home/output/apt \
    --disable-gpg-check \
    --stack zookeeper \
    --smoke-tests zookeeper
```

This breaks build of Hadoop until [BIGTOP-3994](https://issues.apache.org/jira/browse/BIGTOP-3994) is landed.