### PR TITLE
BIGTOP-3999. Make docker provisioner of upstream aware of Bigtop 3.2.1.

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/repo.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/repo.yaml
@@ -1,5 +1,5 @@
 bigtop::bigtop_repo_gpg_check: true
-bigtop::bigtop_repo_apt_key: "B60B04798ACB6352CA7CC41B48FE45F9CB1784BB"
+bigtop::bigtop_repo_apt_key: "36243EECE206BB0D"
 bigtop::bigtop_repo_yum_key_url: "https://dlcdn.apache.org/bigtop/KEYS"
-bigtop::bigtop_repo_default_version: "3.2.0"
+bigtop::bigtop_repo_default_version: "3.2.1"
 

--- a/provisioner/docker/config_centos-7.yaml
+++ b/provisioner/docker/config_centos-7.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-centos-7"
 
-repo: "http://repos.bigtop.apache.org/releases/3.2.0/centos/7/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/centos/7/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_debian-10.yaml
+++ b/provisioner/docker/config_debian-10.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-debian-10"
 
-repo: "http://repos.bigtop.apache.org/releases/3.2.0/debian/10/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/debian/10/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_debian-11.yaml
+++ b/provisioner/docker/config_debian-11.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-debian-11"
 
-repo: "http://repos.bigtop.apache.org/releases/3.2.0/debian/11/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/debian/11/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_fedora-35.yaml
+++ b/provisioner/docker/config_fedora-35.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-fedora-35"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/fedora/35/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/fedora/35/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_fedora-36.yaml
+++ b/provisioner/docker/config_fedora-36.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-fedora-36"
 
-repo: "http://repos.bigtop.apache.org/releases/3.2.0/fedora/36/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/fedora/36/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_rockylinux-8.yaml
+++ b/provisioner/docker/config_rockylinux-8.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-rockylinux-8"
 
-repo: "http://repos.bigtop.apache.org/releases/3.2.0/rockylinux/8/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/rockylinux/8/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_ubuntu-18.04.yaml
+++ b/provisioner/docker/config_ubuntu-18.04.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image:  "bigtop/puppet:trunk-ubuntu-18.04"
 
-repo: "http://repos.bigtop.apache.org/releases/3.1.0/ubuntu/18.04/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/ubuntu/18.04/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_ubuntu-20.04.yaml
+++ b/provisioner/docker/config_ubuntu-20.04.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image:  "bigtop/puppet:trunk-ubuntu-20.04"
 
-repo: "http://repos.bigtop.apache.org/releases/3.2.0/ubuntu/20.04/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/ubuntu/20.04/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false

--- a/provisioner/docker/config_ubuntu-22.04.yaml
+++ b/provisioner/docker/config_ubuntu-22.04.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image:  "bigtop/puppet:trunk-ubuntu-22.04"
 
-repo: "http://repos.bigtop.apache.org/releases/3.2.0/ubuntu/22.04/$(ARCH)"
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/ubuntu/22.04/$(ARCH)"
 distro: debian
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3999

Some config files for docker provisioner point to 3.2.0. Since this fix can not cleanly cherry-picked from branch-3.2, I'm submitting a patch here.

Tested docker provisioner with updated config.yaml on Ubuntu 22.04 (x86_64) and Rocky Linux 8 (aarch64).