### PR TITLE
BIGTOP-4002. Fix build failure of Zeppelin against Hadoop 3.3.6 due to dependency convergence error.

### DIFF
--- a/bigtop-packages/src/common/zeppelin/patch4-exclude-metrics-core.diff
+++ b/bigtop-packages/src/common/zeppelin/patch4-exclude-metrics-core.diff
@@ -1,0 +1,26 @@
+diff --git a/zeppelin-server/pom.xml b/zeppelin-server/pom.xml
+index 3f9d7f7ef..d3386499f 100644
+--- a/zeppelin-server/pom.xml
++++ b/zeppelin-server/pom.xml
+@@ -307,6 +307,10 @@
+           <groupId>org.eclipse.jetty.websocket</groupId>
+           <artifactId>websocket-client</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>io.dropwizard.metrics</groupId>
++          <artifactId>metrics-core</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+ 
+@@ -333,6 +337,10 @@
+           <groupId>javax.xml.bind</groupId>
+           <artifactId>jaxb-api</artifactId>
+         </exclusion>
++        <exclusion>
++          <groupId>io.dropwizard.metrics</groupId>
++          <artifactId>metrics-core</artifactId>
++        </exclusion>
+       </exclusions>
+     </dependency>
+ 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4002

Fix build failure of Zeppelin against Hadoop 3.3.6 due to dependency convergence error

```
[INFO] ----------------< org.apache.zeppelin:zeppelin-server >-----------------
[INFO] Building Zeppelin: Server 0.10.1                                 [45/60]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ zeppelin-server ---
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle-fail-build) @ zeppelin-server ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce) @ zeppelin-server ---
[WARNING]
Dependency convergence error for io.dropwizard.metrics:metrics-core:4.1.14 paths to dependency are:
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-io.dropwizard.metrics:metrics-servlets:4.1.14
    +-io.dropwizard.metrics:metrics-core:4.1.14
and
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-io.dropwizard.metrics:metrics-servlets:4.1.14
    +-io.dropwizard.metrics:metrics-json:4.1.14
      +-io.dropwizard.metrics:metrics-core:4.1.14
and
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-io.dropwizard.metrics:metrics-servlets:4.1.14
    +-io.dropwizard.metrics:metrics-jvm:4.1.14
      +-io.dropwizard.metrics:metrics-core:4.1.14
and
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-io.dropwizard.metrics:metrics-jmx:4.1.14
    +-io.dropwizard.metrics:metrics-core:4.1.14
and
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-org.apache.hadoop:hadoop-client:3.3.6
    +-org.apache.hadoop:hadoop-common:3.3.6
      +-io.dropwizard.metrics:metrics-core:3.2.4
and
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-org.apache.hadoop:hadoop-common:3.3.6
    +-org.apache.hadoop:hadoop-auth:3.3.6
      +-io.dropwizard.metrics:metrics-core:3.2.4
and
+-org.apache.zeppelin:zeppelin-server:0.10.1
  +-org.apache.hadoop:hadoop-common:3.3.6
    +-io.dropwizard.metrics:metrics-core:3.2.4
```