### PR TITLE
BIGTOP-3996: Force a clean build of toolchain images

### DIFF
--- a/docker/bigtop-puppet/build.sh
+++ b/docker/bigtop-puppet/build.sh
@@ -63,5 +63,5 @@ case "${OS}-${VERSION}" in
     ;;
 esac
 
-docker build -t bigtop/puppet:${PREFIX}-${OS}-${VERSION}${ARCH} .
+docker build -t --no-cache bigtop/puppet:${PREFIX}-${OS}-${VERSION}${ARCH} .
 rm -f Dockerfile puppetize.sh

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -89,5 +89,5 @@ fi
 sed -e "s|PREFIX|${PREFIX}|;s|OS|${OS}|;s|VERSION|${VERSION}|" Dockerfile.template | \
   sed -e "s|PUPPET_MODULES|${PUPPET_MODULES}|;s|UPDATE_SOURCE|${UPDATE_SOURCE}|" > Dockerfile
 
-docker build ${NETWORK} --rm -t bigtop/slaves:${PREFIX}-${OS}-${VERSION} -f Dockerfile ../..
+docker build ${NETWORK} --rm --no-cache -t bigtop/slaves:${PREFIX}-${OS}-${VERSION} -f Dockerfile ../..
 rm -f Dockerfile


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3996

When I'm working on openEuler support (Bigtop toolchain images), some issues occurred:
```
++ sed -i -e 's|RUN bash /tmp/puppetize.sh|ENV PATH /usr/lib/jvm/java-1.8.0/bin:$PATH\nRUN bash /tmp/puppetize.sh|' Dockerfile
sed: preserving permissions for ‘./sedNQcfyR’: Operation not permitted
++ sed -i -e 's|RUN bash /tmp/puppetize.sh|RUN bash /tmp/puppetize.sh\nRUN dnf install -y initscripts|' Dockerfile
sed: preserving permissions for ‘./sedAbeaag’: Operation not permitted
```
After fixing the permisson issues above, I start to rebuild the image (bigtop/puppet) in the same node.

But the docker build process always adopt the cache one which was not built properly in the last time. 
IMHO, it is reasonable to force Docker to rebuild a clean image without using the cache for Bigtop development or other use case scenarios.

