### PR TITLE
BIGTOP-3987: Upgrade phoenix version to 5.1.3

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -247,7 +247,7 @@ bigtop {
     'phoenix' {
       name    = 'phoenix'
       relNotes = 'Apache Phoenix: A SQL skin over HBase'
-      version { base = "5.1.2"; pkg = base; release = 1 }
+      version { base = "5.1.3"; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
Apache Phoenix is an add-on for Apache HBase that provides a programmatic ANSI SQL interface. Apache Phoenix implements best-practice optimizations to enable software engineers to develop next-generation data-driven applications based on HBase.

Hbase in Bigtop 3.3 is 2.5 that needs Phoenix 5.1.3 to support.


++ PHOENIX_VERSION=5.1.3
++ HBASE_VERSION=2.5.3
++ JDK_VERSION=1.8

export MAVEN_OPTS=-Xmx1024m
MAVEN_OPTS=-Xmx1024m
MVN_ARGS='-Phadoop-3.0 '
MVN_ARGS+='-Dhadoop-three.version=3.3.5 '
MVN_ARGS+='-Dhadoop.guava.version=27.0-jre '
MVN_ARGS+='-Djetty.version=9.3.29.v20201019 '
MVN_ARGS+='-Dzookeeper.version=3.5.9 '
MVN_ARGS+='-DskipTests '
MVN_ARGS+='-Dcheckstyle.skip=true '