### PR TITLE
BIGTOP-4012. Update Adoptium repository settings for Debian 11 in bigtop_toolchain.

### DIFF
--- a/bigtop-deploy/puppet/manifests/bigtop_repo.pp
+++ b/bigtop-deploy/puppet/manifests/bigtop_repo.pp
@@ -70,8 +70,8 @@ class bigtop_repo {
       # BIGTOP-3343. This is a JDK-related stuff, so it should be in jdk.pp ordinarily.
       # But it looks like that this definition must be here to avoid cyclic resource dependencies.
       if ($operatingsystem == 'Debian' and 0 <= versioncmp($operatingsystemrelease, "10")) {
-        apt::source { 'adoptopenjdk':
-          location => 'https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/',
+        apt::source { 'adoptium':
+          location => 'https://packages.adoptium.net/artifactory/deb/',
         }
       }
 
@@ -86,9 +86,9 @@ class bigtop_repo {
 
         # BIGTOP-3343. This is a JDK-related stuff, but it's here for the same reason described above.
         if ($operatingsystem == 'Debian' and 0 <= versioncmp($operatingsystemrelease, "10")) {
-          apt::key { "add_adoptopenjdk_key":
-            id => "8ED17AF5D7E675EB3EE3BCE98AC3B29174885C03",
-            source => "https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public",
+          apt::key { "add_adoptium_key":
+            id => "3B04D753C9050D9A5D343F39843C48A565F8F04B",
+            source => "https://packages.adoptium.net/artifactory/api/gpg/key/public",
           }
         }
       } else {

--- a/bigtop-deploy/puppet/manifests/jdk.pp
+++ b/bigtop-deploy/puppet/manifests/jdk.pp
@@ -23,7 +23,7 @@ class jdk {
       if versioncmp($operatingsystemrelease, "10") < 0 {
         $jdk_pkg_name = 'openjdk-8-jdk'
       } else {
-        $jdk_pkg_name = 'adoptopenjdk-8-hotspot'
+        $jdk_pkg_name = 'temurin-8-jdk'
       }
       package { 'jdk':
         name => $jdk_pkg_name,

--- a/bigtop-packages/src/common/bigtop-utils/bigtop-detect-javahome
+++ b/bigtop-packages/src/common/bigtop-utils/bigtop-detect-javahome
@@ -36,7 +36,7 @@ OPENJAVA8_HOME_CANDIDATES=(
     '/usr/lib/jvm/java-1.8.0-openjdk-ppc64el'
     '/usr/lib/jvm/java-1.8.0-openjdk'
     '/usr/lib64/jvm/java-1.8.0-openjdk-1.8.0'
-    '/usr/lib/jvm/adoptopenjdk-8-hotspot'
+    '/usr/lib/jvm/temurin-8-jdk'
 )
 
 MISCJAVA_HOME_CANDIDATES=(

--- a/bigtop_toolchain/manifests/env.pp
+++ b/bigtop_toolchain/manifests/env.pp
@@ -29,7 +29,7 @@ class bigtop_toolchain::env {
       if $::operatingsystemmajrelease =~ /^\d$/ {
         $javahome = "/usr/lib/jvm/${java}-openjdk-$arch"
       } else {
-        $javahome = "/usr/lib/jvm/adoptopenjdk-8-hotspot-$arch"
+        $javahome = "/usr/lib/jvm/temurin-8-jdk-$arch"
       }
     }
     'Ubuntu': {

--- a/bigtop_toolchain/manifests/installer.pp
+++ b/bigtop_toolchain/manifests/installer.pp
@@ -31,7 +31,7 @@ class bigtop_toolchain::installer {
   case $::operatingsystem {
     /Debian/: {
       exec { 'ensure java 8 is set as default':
-        command => "update-java-alternatives --set adoptopenjdk-8*",
+        command => "update-java-alternatives --set temurin-8*",
         path    => ['/usr/sbin', '/usr/bin', '/bin'],
         require => Class['bigtop_toolchain::jdk'],
       }

--- a/bigtop_toolchain/manifests/jdk.pp
+++ b/bigtop_toolchain/manifests/jdk.pp
@@ -16,19 +16,19 @@
 class bigtop_toolchain::jdk {
   case $::operatingsystem {
     /Debian/: {
-      # We need JDK 8, but Debian 10 only provides the openjdk-11-jdk package in the official repo.
-      # So we use AdoptOpenJDK instead, following the steps described on:
-      # https://adoptopenjdk.net/installation.html#linux-pkg
+      # We need JDK 8, but Debian 10+ only provides the openjdk-11-jdk package (or greater) in the official repo.
+      # So we use Eclipse Temurin instead, following the steps described on:
+      # https://adoptium.net/installation/linux/#_deb_installation_on_debian_or_ubuntu
       include apt
 
-      apt::source { 'adoptopenjdk':
-        location => 'https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/',
+      apt::source { 'adoptium':
+        location => 'https://packages.adoptium.net/artifactory/deb/',
         key      => {
-          id     => '8ED17AF5D7E675EB3EE3BCE98AC3B29174885C03',
-          source => 'https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public',
+          id     => '3B04D753C9050D9A5D343F39843C48A565F8F04B',
+          source => 'https://packages.adoptium.net/artifactory/api/gpg/key/public',
         },
       } ->
-      package { 'adoptopenjdk-8-hotspot' :
+      package { 'temurin-8-jdk' :
         ensure => present,
       }
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Currently we're using AdoptOpenJDK 8 for Debian, but its repository has been moved. This PR updates its repository URL and package name.

### How was this patch tested?

Ran `sudo puppet apply --modulepath=/usr/share/puppet/modules:/path/to/bigtop -e "bigtop_toolchain::installer"` on Debian 11 and ensured it was successful.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/