### PR TITLE
BIGTOP-4013. Fix toolchain to install R 3.6.0+ into Debian 10.

### DIFF
--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -34,7 +34,7 @@ class bigtop_toolchain::renv {
     }
     /(Ubuntu|Debian)/: {
       if (($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemmajrelease, '18.04') <= 0) or
-          ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') < 0)) {
+          ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') <= 0)) {
         $pkgs = [
           "r-base-dev",
           "libcairo2-dev",
@@ -85,7 +85,7 @@ class bigtop_toolchain::renv {
   #
   # Then Install required R packages dependency
   if (($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemmajrelease, '18.04') <= 0) or
-      ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') < 0)) {
+      ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') <= 0)) {
     $url = "https://cran.r-project.org/src/base/R-3/"
     $rfile = "R-3.6.3.tar.gz"
     $rdir = "R-3.6.3"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Currently, Bigtop toolchain installs R 3.5.2 into Debian 10, but it's not compatible with the latest version of the dependent libraries. This PR fixes it to install R 3.6.3 instead.

### How was this patch tested?

Ran `./gradlew bigtop-slaves -POS=debian-10` on trunk with the patch submitted by #1185.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/