### PR TITLE
BIGTOP-4015. Upgrade Maven to 3.8.x.

### DIFF
--- a/bigtop_toolchain/manifests/maven.pp
+++ b/bigtop_toolchain/manifests/maven.pp
@@ -18,7 +18,7 @@ class bigtop_toolchain::maven {
   require bigtop_toolchain::gnupg
   require bigtop_toolchain::packages
 
-  $mvnversion = latest_maven_binary("3.6.[0-9]*")
+  $mvnversion = latest_maven_binary("3.8.[0-9]*")
   $mvn = "apache-maven-$mvnversion"
 
   $apache_prefix = nearest_apache_mirror()


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR fixes toolchain to install Maven 3.8 for building Spark 3.3.

### How was this patch tested?

Ran `./gradlew toolchain` and ensured Maven 3.8.8 was installed.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/