### PR TITLE
BIGTOP-4021. Upgrade ZooKeeper to 3.7.2.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -133,7 +133,7 @@ bigtop {
       pkg     = name
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       version {
-        base  = '3.6.4'
+        base  = '3.7.2'
         pkg   = base
         release = 1
       }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades ZooKeeper version to 3.7.2.

### How was this patch tested?

Ran the following commands on Rocky 8 (x86_64).

```
$ ./gradlew allclean hadoop-pkg repo -Dbuildwithdeps=true
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_rockylinux-8.yaml -F docker-compose-cgroupv2.yml -G -L -k zookeeper -s zookeeper -c 1

...

TestZookeeper > testZkServerStatus STANDARD_ERROR
    23/10/15 14:45:04 INFO lang.Object: Running zkServer.sh status
    23/10/15 14:45:04 INFO lang.Object: zkServer.sh status checks out.
Finished generating test XML results (0.007 secs) into: /bigtop-home/bigtop-tests/smoke-tests/zookeeper/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.018 secs) into: /bigtop-home/bigtop-tests/smoke-tests/zookeeper/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:zookeeper:test (Thread[Daemon worker,5,main]) completed. Took 1.095 secs.

BUILD SUCCESSFUL in 29s
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/