### PR TITLE
BIGTOP-4028 : Excluding log dependencies corresponding to hbase in the hive service

### DIFF
--- a/bigtop-packages/src/common/hive/patch16-HIVE-SHELL.diff
+++ b/bigtop-packages/src/common/hive/patch16-HIVE-SHELL.diff
@@ -1,0 +1,13 @@
+diff --git a/bin/hive b/bin/hive
+index 1ade51e..f645ef1 100755
+--- a/bin/hive
++++ b/bin/hive
+@@ -293,7 +293,7 @@ if [ "$SKIP_HBASECP" = false ]; then
+     # exclude ZK, PB, and Guava (See HIVE-2055)
+     # depends on HBASE-8438 (hbase-0.94.14+, hbase-0.96.1+) for `hbase mapredcp` command
+     for x in $($HBASE_BIN mapredcp 2>&2 | tr ':' '\n') ; do
+-      if [[ $x == *zookeeper* || $x == *protobuf-java* || $x == *guava* ]] ; then
++      if [[ $x == *zookeeper* || $x == *protobuf-java* || $x == *guava*  || $x == *log* || $x == *slf4j* ]] ; then
+         continue
+       fi
+       # TODO: should these should be added to AUX_PARAM as well?


### PR DESCRIPTION
…e hive service

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Excluding log dependencies corresponding to hbase in the hive service
before:
![image](https://github.com/apache/bigtop/assets/53458004/e433e1c7-c70e-4b7c-8489-884fc66d7ae2)

after:
![image](https://github.com/apache/bigtop/assets/53458004/73dbe4bc-467e-474c-be37-550595ebff97)


### How was this patch tested?
Launch hive CLI to view startup logs

### For code changes:

- [1 ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [1] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/