### PR TITLE
BIGTOP-4030: Error building Ranger deb using bigtop

### DIFF
--- a/bigtop-packages/src/deb/ranger/control
+++ b/bigtop-packages/src/deb/ranger/control
@@ -35,7 +35,7 @@ Description: Apache Ranger is a framework to enable,
 
 Package: ranger-admin
 Architecture: all
-Depends: adduser, postgresql (>= 8.1), bigtop-utils (>= 0.7), python | python2
+Depends: adduser, postgresql (>= 8.1), libpostgresql-jdbc-java, bigtop-utils (>= 0.7), python | python2
 Description: Ranger-admin is admin component associated with the Ranger framework
 
 Package: ranger-usersync

--- a/bigtop-packages/src/deb/ranger/ranger.postinst.tpl
+++ b/bigtop-packages/src/deb/ranger/ranger.postinst.tpl
@@ -21,7 +21,7 @@ set -e
 
 case "$1" in
 	configure)
-                update-alternatives --install /etc/ranger/conf ranger-conf @etc_ranger@/conf.dist 30
+                update-alternatives --install /etc/ranger/@component_name@/conf ranger-@component_name@-conf @etc_ranger@/@component_name@/conf.dist 30
 		chown ranger:ranger -R /var/run/ranger /var/log/ranger @var_lib_ranger@
 	;;
 

--- a/bigtop-packages/src/deb/ranger/ranger.prerm.tpl
+++ b/bigtop-packages/src/deb/ranger/ranger.prerm.tpl
@@ -35,7 +35,7 @@ set -e
 
 case "$1" in
     remove|upgrade|deconfigure)
-      update-alternatives --remove ranger-conf @etc_ranger@/conf.dist || :
+      update-alternatives --remove ranger-@component_name@-conf @etc_ranger@/@component_name@/conf.dist || :
     ;;
 
     failed-upgrade)

--- a/bigtop-packages/src/deb/ranger/rules
+++ b/bigtop-packages/src/deb/ranger/rules
@@ -38,6 +38,7 @@ etc_default=/etc/default
 etc_ranger=/etc/${ranger_name}
 var_lib_ranger=/var/lib/${ranger_name}
 var_run_ranger=/var/run/${ranger_name}
+var_log_ranger=/var/log/${ranger_name}
 
 usr_lib_hadoop=/usr/lib/hadoop
 usr_lib_hive=/usr/lib/hive
@@ -56,28 +57,28 @@ usr_lib_presto=/usr/lib/presto
 define ranger_admin_install
 ${var_lib_ranger}
 ${var_run_ranger}
-${etc_ranger}/admin/conf.dist
 ${etc_ranger}/admin
 ${usr_lib_ranger}-admin
+${var_log_ranger}
 endef
 
 define ranger_usersync_install
 ${usr_lib_ranger}-usersync
 ${usr_lib_ranger}-usersync/native/credValidator.uexe
-${etc_ranger}/usersync/conf.dist
 ${etc_ranger}/usersync
+${var_log_ranger}
 endef
 
 define ranger_kms_install
 ${usr_lib_ranger}-kms
-${etc_ranger}/kms/conf.dist
 ${etc_ranger}/kms
+${var_log_ranger}
 endef
 
 define ranger_tagsync_install
 ${usr_lib_ranger}-tagsync
-${etc_ranger}/tagsync/conf.dist
 ${etc_ranger}/tagsync
+${var_log_ranger}
 endef
 
 define ranger_hdfs_plugin_install
@@ -155,8 +156,8 @@ endef
 
 define gen_rule
 $(foreach item, postinst preinst prerm,\
-	cp debian/ranger.$(item).tpl debian/range-$(1).$(item);\
-	sed -i -e 's:@var_lib_ranger@:${var_lib_ranger}:g' -e 's:@etc_ranger@:${etc_ranger}:g' debian/range-$(1).$(item);\
+	cp debian/ranger.$(item).tpl debian/ranger-$(1).$(item);\
+	sed -i -e 's:@var_lib_ranger@:${var_lib_ranger}:g' -e 's:@etc_ranger@:${etc_ranger}:g' -e 's:@component_name@:$(1):g' debian/ranger-$(1).$(item);\
 )
 endef
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
This PR addresses several issues:

1.Fixed a bug related to the configuration directory. The command update-alternatives --install /etc/ranger/conf ranger-conf @etc_ranger@/conf.dist 30 was updated. The soft link directory under /etc should correspond to the component's directory, such as /etc/ranger-admin/conf.

2.Added JDBC dependency. When executing the setup.sh script under Ubuntu 22, an error was reported about missing JDBC driver. This was resolved by installing libpostgresql-jdbc-java.

3.Also, a solution was provided for the lack of /var/log/ranger directory when starting Ranger

### How was this patch tested?
manual test
![image](https://github.com/apache/bigtop/assets/18082602/59b7c425-3824-48a8-9517-07f867644311)

unit test

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/