### PR TITLE
BIGTOP-4034: Add python3 support in bigtop-select

### DIFF
--- a/bigtop-packages/src/common/bigtop-select/conf-select
+++ b/bigtop-packages/src/common/bigtop-select/conf-select
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/bigtop-packages/src/common/bigtop-select/distro-select
+++ b/bigtop-packages/src/common/bigtop-select/distro-select
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -157,7 +157,7 @@ def listPackages( packages ):
   if packages == None:
     packages = leaves
 
-  packages.sort()
+  packages = sorted(packages)
   for pkg in packages:
     linkname = current + "/" + pkg
     if os.path.isdir(linkname):
@@ -168,13 +168,11 @@ def listPackages( packages ):
 
 # Print the avaialable package names
 def printPackages():
-  packages = leaves.keys()
-  packages.sort()
+  packages = sorted(leaves.keys())
   print("Packages:")
   for pkg in packages:
      print(" " + pkg)
-  groups = aliases.keys()
-  groups.sort()
+  groups = sorted(aliases.keys())
   print("Aliases:")
   for pkg in groups:
     print(" " + pkg)
@@ -199,8 +197,7 @@ def printVersions():
         print("ERROR: Unexpected file/directory found in %s: %s" % (root, f))
         sys.exit(1)
 
-  keys = result.keys()
-  keys.sort()
+  keys = sorted(result.keys())
   for k in keys:
      print(result[k])
 
@@ -221,9 +218,9 @@ def setPackages(packages, version, rpm_mode):
     sys.exit(1)
 
   if not os.path.isdir(current):
-    os.mkdir(current, 0755)
+    os.mkdir(current, 0o755)
 
-  packages.sort()
+  packages = sorted(packages)
   for pkg in packages:
     linkname = current + "/" + pkg
     if os.path.islink(linkname) and rpm_mode:


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Added python3 support in bigtop-select

### How was this patch tested?
Applied changes on already installed ambari hadoop cluster
executed below commands, all got executed successfully
```
ambari-python-wrap /usr/lib/bigtop-select/distro-select versions
ambari-python-wrap /usr/lib/bigtop-select/distro-select packages
ambari-python-wrap /usr/lib/bigtop-select/distro-select status
```



### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/