### PR TITLE
BIGTOP-4042:Fix ISAL Compilation Failure in openEuler System Slave Do…

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -223,7 +223,9 @@ class bigtop_toolchain::packages {
        "openeuler-lsb",
        "pcre-devel",
        "texlive",
-       "rpmdevtools"
+       "rpmdevtools",
+       "nasm",
+       "yasm"
     ] }
     /(Ubuntu|Debian)/: {
       $_pkgs = [


### PR DESCRIPTION
…cker Image Due to Missing nasm and yasm Libraries

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
When packaging the openEuler system slave Docker image with bitop, the lack of nasm and yasm libraries causes a compilation failure issue with ISAL

### How was this patch tested?
manual test
before
![image](https://github.com/apache/bigtop/assets/18082602/74651341-a100-4f31-993a-339bceea8003)

after
![image](https://github.com/apache/bigtop/assets/18082602/b8904251-1281-4bf3-bf39-ebeffd267946)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/