### PR TITLE
BIGTOP-4044: Enhance Bigtop with Concurrent Compilation Support for A…

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -86,6 +86,7 @@
        packaging = 'rpm' // *optional* If this component can be built only as either
                          // DEB or RPM, specify that packaging format explicitly.
                          // If both formats are supported, omit this option.
+       maven_parallel_build = true
      }
    }
  }
@@ -146,6 +147,7 @@ bigtop {
         site          = "${apache.APACHE_MIRROR}/${download_path}"
         archive       = "${apache.APACHE_ARCHIVE}/${download_path}"
       }
+      maven_parallel_build = true
     }
     'hadoop' {
       name    = 'hadoop'
@@ -168,6 +170,7 @@ bigtop {
       url     { download_path = "/$name/${version.base}/"
                 site = "${apache.APACHE_MIRROR}/${download_path}"
                 archive = "${apache.APACHE_ARCHIVE}/${download_path}" }
+      maven_parallel_build = true
     }
 
     'hive' {
@@ -180,6 +183,7 @@ bigtop {
       url     { download_path = "/$name/$name-${version.base}/"
                 site = "${apache.APACHE_MIRROR}/${download_path}"
                 archive = "${apache.APACHE_ARCHIVE}/${download_path}" }
+      maven_parallel_build = true
     }
     'tez' {
       name    = 'tez'
@@ -231,6 +235,7 @@ bigtop {
       url     { download_path = "/$name/$name-${version.base}"
                 site = "${apache.APACHE_MIRROR}/${download_path}"
                 archive = "${apache.APACHE_ARCHIVE}/${download_path}" }
+      maven_parallel_build = true
     }
 
 
@@ -243,6 +248,7 @@ bigtop {
       url     { download_path = "/$name/$name-${version.base}"
                 site = "${apache.APACHE_MIRROR}/${download_path}"
                 archive = "${apache.APACHE_ARCHIVE}/${download_path}" }
+      maven_parallel_build = true
     }
     'bigtop-groovy' {
       name    = 'bigtop-groovy'
@@ -286,6 +292,7 @@ bigtop {
                 source      = "v${version.base}.tar.gz" }
       url     { site = "https://github.com/Alluxio/alluxio/archive"
                 archive = site }
+      maven_parallel_build = true
     }
     'kafka' {
       name    = 'kafka'
@@ -308,6 +315,7 @@ bigtop {
       url     { download_path = "/$name/$name-${version.base}/"
                 site = "${apache.APACHE_MIRROR}/${download_path}"
                 archive = "${apache.APACHE_ARCHIVE}/${download_path}" }
+      maven_parallel_build = true
     }
     'gpdb' {
       name    = 'gpdb'
@@ -327,6 +335,7 @@ bigtop {
       url     { download_path = "incubator/livy/${version.base}-incubating/"
                 site = "${apache.APACHE_MIRROR}/${download_path}"
                 archive = "${apache.APACHE_ARCHIVE}/${download_path}" }
+      maven_parallel_build = true
     }
     'ranger' {
       name    = 'ranger'

--- a/packages.gradle
+++ b/packages.gradle
@@ -76,6 +76,27 @@ def safeDelete = { fileName ->
 def getDate() {
   new Date().format('E, dd MMM yyyy HH:mm:ss Z')
 }
+
+def generatePatch(String threadCount, String path) {
+    def patchContent = """
+        diff --git a/.mvn/maven.config b/.mvn/maven.config
+        new file mode 100644
+        index 00000000..e69de29b
+        diff --git a/.mvn/maven.config b/.mvn/maven.config
+        index e69de29b..0bea21c9 100644
+        --- a/.mvn/maven.config
+        +++ b/.mvn/maven.config
+        @@ -0,0 +1 @@
+        +-T${threadCount}
+        \\ No newline at end of file
+    """.stripIndent()
+
+    new File(path, "patch0-maven-parallel-build.diff").with {
+        write(patchContent)
+        println "Patch file created at: ${absolutePath}"
+    }
+}
+
 /**
  * To avoid breaking the compat with existing packages let's use the old style names
  */
@@ -137,6 +158,7 @@ task "bom-json" (description: "List the components of the stack in json format")
         pkg: it.value.pkg,
         relNotes: it.value.relNotes,
         packaging: it.value.packaging,
+        maven_parallel_build: it.value.maven_parallel_build
       ],
       tarball: [
         destination: it.value.tarball.destination,
@@ -394,6 +416,8 @@ def genTasks = { target ->
     delete ("$PKG_BUILD_DIR/deb")
     def final DEB_BLD_DIR = "$PKG_BUILD_DIR/deb/$NAME-${PKG_VERSION}"
     def final DEB_PKG_DIR = "$PKG_BUILD_DIR/deb/$PKG_NAME-${PKG_VERSION}-${BIGTOP_BUILD_STAMP}"
+    def final ENABLE_MAVEN_PARALLEL_BUILD = config.bigtop.components[target].maven_parallel_build
+    def final MAVEN_BUILD_THREADS = project.hasProperty('buildThreads') ? project.property('buildThreads') : null
     mkdir (DEB_BLD_DIR)
     copy {
       from SEED_TAR
@@ -427,6 +451,12 @@ def genTasks = { target ->
         include '**/*'
       }
       into "$DEB_BLD_DIR/debian"
+    }
+    if (MAVEN_BUILD_THREADS && ENABLE_MAVEN_PARALLEL_BUILD) {
+      if (!MAVEN_BUILD_THREADS.matches("\\d+C")) {
+        throw new GradleException("Invalid MAVEN_BUILD_THREADS parameter. It must be a combination of numbers and 'C', such as '2C'.")
+      }
+      generatePatch(MAVEN_BUILD_THREADS, "$DEB_BLD_DIR/debian")
     }
     // Prepeare bom file with all the versions
     def bomWriter = new File("$DEB_BLD_DIR/debian/bigtop.bom").newWriter()
@@ -575,6 +605,8 @@ def genTasks = { target ->
     def final PKG_VERSION = config.bigtop.components[target].version.pkg
     def final BASE_VERSION = config.bigtop.components[target].version.base
     def final PKG_OUTPUT_DIR = config.bigtop.components[target].outputdir
+    def final ENABLE_MAVEN_PARALLEL_BUILD = config.bigtop.components[target].maven_parallel_build
+    def final MAVEN_BUILD_THREADS = project.hasProperty('buildThreads') ? project.property('buildThreads') : null
     safeDelete ("$PKG_BUILD_DIR/rpm")
     ['INSTALL','SOURCES','BUILD','SRPMS','RPMS'].each { rpmdir ->
       mkdir("$PKG_BUILD_DIR/rpm/$rpmdir")
@@ -608,6 +640,12 @@ def genTasks = { target ->
         include '**/*'
       }
       into "$PKG_BUILD_DIR/rpm/SOURCES"
+    }
+    if (MAVEN_BUILD_THREADS && ENABLE_MAVEN_PARALLEL_BUILD) {
+      if (!MAVEN_BUILD_THREADS.matches("\\d+C")) {
+        throw new GradleException("Invalid MAVEN_BUILD_THREADS parameter. It must be a combination of numbers and 'C', such as '2C'.")
+      }
+      generatePatch(MAVEN_BUILD_THREADS, "$PKG_BUILD_DIR/rpm/SOURCES")
     }
     // Writing bigtop.bom files with all the versions
     def bomWriter = new File("$PKG_BUILD_DIR/rpm/SOURCES/bigtop.bom").newWriter()


### PR DESCRIPTION
…dditional Components

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Background:
Within the components maintained by Bigtop, a significant portion is built using Java and relies on Maven as the build tool.

Rationale:
Compiling components that consist of numerous modules can be a time-consuming process. For instance, some components contain hundreds of modules, and compiling them one by one consumes a substantial amount of time. Even when all dependencies are pre-downloaded for a second compilation, the process remains slow due to the sequential nature of compilation. Additionally, compiling all components together still results in sequential compilation, making it challenging to fully leverage CPU resources and reduce compilation time significantly. Consequently, repetitive compilation and testing phases impose prolonged waiting periods.

Proposal:
I propose the introduction of a new parameter that allows users to toggle parallel compilation for components built using Maven, thus empowering them to align compilation practices with their specific needs.

Related Pull Requests (PRs):
This discussion can be divided into two main parts:

The first part entails adding parallel compilation functionality and enabling it for components that have undergone testing without encountering additional issues related to parallel compilation. **These components include Hive, HBase, Flink, ZooKeeper, Alluxio, Phoenix, Livy, Zeppelin**

The second part involves enabling parallel compilation for components that face challenges with parallel compilation and necessitate additional patches to address Maven's parallel compilation capabilities. These components include **Ranger, Tez, Hadoop, Spark**


Compilation Environment: CentOS 7 x86_64, 16C, SSD

**The following table shows the time comparison for repeated compilations, where dependencies are already downloaded, before and after using parallel compilation.

As can be seen, there is an overall performance improvement of about 2-3 times. If it's the first compilation, given the massive dependencies that need to be downloaded, the advantage of parallel compilation becomes even more apparent. For example, the first compilation of Hadoop 3 was reduced from nearly 3 hours to about 1 hour.**

| Component | Time Before | Time After |
|-----------|-------------|------------|
| Alluxio   | 21min       | 07:43min   |
| Hive      | 05:33min    | 03:04min   |
| HBase     | 06:18min    | 02:55min   |
| Zookeeper | 01:25min    | 35s        |
| Livy      | 03:29min    | 03:12min   |
| Phoenix   | 05:32min    | 11:23min   |
| Zeppelin  | 14:15min    | 13:19min   |
| Flink     | 14:16min    | 36:27min   |

### How was this patch tested?
manual test
test compile apache hbase in parallel on ubuntu22 x8664
![image](https://github.com/apache/bigtop/assets/18082602/fd2a541b-9688-4256-a783-a15e0d2bc83c)

test hive on centos7 x86_64
![image](https://github.com/apache/bigtop/assets/18082602/b73b54ad-787f-4031-bb5d-1def63faae5e)


On CentOS 7 x86_64, the parallel compilation speed of Alluxio is one-third of the non-parallel compilation speed, taking only 7 minutes.
![image](https://github.com/apache/bigtop/assets/18082602/406a0613-8a4f-4ae1-ac14-2ad9a6862c66)


 phoenix  centos7 x86_64
![image](https://github.com/apache/bigtop/assets/18082602/519605e7-dfc3-4dd2-94e0-58de0ca71492)

livy centos7 x86_64
![image](https://github.com/apache/bigtop/assets/18082602/f621b743-2ccc-4760-a1d4-a2a9861beb69)

zeppelin on  centos7 x86_64 
 
![image](https://github.com/apache/bigtop/assets/18082602/322b4f9e-8a69-41fa-81a9-a763d38f994a)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/