### PR TITLE
BIGTOP-4046: Enable Parallel Compilation for Multiple Modules in SPARK

### DIFF
--- a/bigtop-packages/src/common/spark/patch0-SPARK-44257.diff
+++ b/bigtop-packages/src/common/spark/patch0-SPARK-44257.diff
@@ -1,0 +1,22 @@
+diff --git a/pom.xml b/pom.xml
+index 7189fd2e093..fa4a8c1c987 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -3023,7 +3023,7 @@
+         <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-clean-plugin</artifactId>
+-          <version>3.1.0</version>
++          <version>3.3.1</version>
+           <configuration>
+             <filesets>
+               <fileset>
+@@ -3103,7 +3103,7 @@
+         <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-shade-plugin</artifactId>
+-          <version>3.2.4</version>
++          <version>3.5.0</version>
+           <dependencies>
+             <dependency>
+               <groupId>org.ow2.asm</groupId>

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -219,6 +219,7 @@ bigtop {
       url     { download_path = "/$name/$name-${version.base}"
                 site = "${apache.APACHE_MIRROR}/${download_path}"
                 archive = "${apache.APACHE_ARCHIVE}/${download_path}" }
+      maven_parallel_build = true
     }
 
     'flink' {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Spark 3.3 itself does support parallel compilation. However, Spark 3.3 uses Maven Shade Plugin version 3.2.4, which triggers an infinite loop bug during parallel compilation. You can find more details about this issue at [MSHADE-413](https://issues.apache.org/jira/browse/MSHADE-413).

A PR has been submitted for Spark 3.3 to upgrade the Maven Shade Plugin to version 3.5.0. This upgrade has already been applied in Spark 3.5,  [SPARK-44257](https://issues.apache.org/jira/browse/SPARK-44257).

Therefore, this PR primarily introduces the Maven patch and also includes the upgrade of the mvn-shade-plugin as part of [SPARK-44257](https://issues.apache.org/jira/browse/SPARK-44257). It's worth noting that [SPARK-44257](https://issues.apache.org/jira/browse/SPARK-44257) contains some code that doesn't exist in Spark 3.3 and has been ignored.

**depend on [BIGTOP-4044](https://issues.apache.org/jira/browse/BIGTOP-4044). Therefore, when testing [BIGTOP-4046](https://issues.apache.org/jira/browse/BIGTOP-4046) , it's necessary to include [BIGTOP-4044]**(https://issues.apache.org/jira/browse/BIGTOP-4044) in the merge as well.
### How was this patch tested?
manual test
![image](https://github.com/apache/bigtop/assets/18082602/33ab9f81-0733-494b-8d64-f01002b25ec7)
./gradlew spark-clean spark-pkg -PcompileThreads=2C
### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/