### PR TITLE
BIGTOP-4051: Add python3 dependency for Phoenix deb

### DIFF
--- a/bigtop-packages/src/deb/phoenix/control
+++ b/bigtop-packages/src/deb/phoenix/control
@@ -23,7 +23,7 @@ Homepage: http://phoenix.apache.org
 
 Package: phoenix
 Architecture: all
-Depends: bigtop-utils (>= 0.7),  python (>= 2.6) | python2 (>= 2.6)
+Depends: bigtop-utils (>= 0.7),  python (>= 2.6) | python2 (>= 2.6) | python3
 Description: Phoenix is a SQL skin over HBase and client-embedded JDBC driver.
  Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
  The Phoenix query engine transforms an SQL query into one or more HBase scans,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
In the minimal Python code of phoenix 5.1.3, there is a handling for Python that allows it to support both Python 3 and Python 2. Therefore, a dependency on Python 3 is added in the Phoenix deb package because many systems only have Python 3 by default. Not adding this dependency would result in users being unable to install Phoenix properly.

The code related to Python 3 compatibility can be found at:
https://github.com/apache/phoenix/blob/5.1.3/bin/daemon.py#L66

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/