### PR TITLE
BIGTOP-4055. Add Spark History Server Smoke Test

### DIFF
--- a/bigtop-deploy/puppet/manifests/cluster.pp
+++ b/bigtop-deploy/puppet/manifests/cluster.pp
@@ -66,6 +66,7 @@ $roles_map = {
     worker => ["solr-server"],
   },
   spark => {
+    master => ["spark-history-server"],
     worker => ["spark-on-yarn"],
     client => ["spark-client"],
     library => ["spark-yarn-slave"],

--- a/bigtop-tests/smoke-tests/spark/.gitignore
+++ b/bigtop-tests/smoke-tests/spark/.gitignore
@@ -1,0 +1,1 @@
+examples

--- a/bigtop-tests/smoke-tests/spark/TestSpark.groovy
+++ b/bigtop-tests/smoke-tests/spark/TestSpark.groovy
@@ -112,4 +112,35 @@ class TestSpark {
     logError(sh)
     assertTrue("Failed to execute SparkR script", sh.getRet() == 0);
   }
+
+  // parse spark-defaults.conf to properties object
+  def parseSparkDefaultsConf(String path) {
+
+    def file = new File(path)
+    def props = new Properties()
+    props.load(file.newDataInputStream())
+    return props
+
+  }
+
+  @Test
+  void testSparkHistoryServer() {
+
+    String SPARK_CONF_DIR = SPARK_HOME + File.separator + "conf"
+    String SPARK_DEFAULTS_CONF = SPARK_CONF_DIR + File.separator + "spark-defaults.conf"
+
+    def props = parseSparkDefaultsConf(SPARK_DEFAULTS_CONF)
+    String spark_history_server_port = props.getProperty("spark.history.ui.port")
+
+    sh.exec("hostname -f")
+    logError(sh)
+    String spark_history_server_host = sh.getOut()[0]
+
+    sh.exec("curl -s -o /dev/null -w'%{http_code}' --negotiate -u: -k http://" + spark_history_server_host + 
+                  ":" + spark_history_server_port + " | grep 200")
+    logError(sh)
+    assertTrue("Failed to check spark history server", sh.getOut()[0] == "200")
+
+  }
+
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Add Spark History Server Smoke Test

### How was this patch tested?

We can use docker-hadoop.sh to test it
1. modify the config_centos-7.yaml as following example
```yaml
docker:
        memory_limit: "4g"
        image: "bigtop/puppet:trunk-centos-7"

repo: "http://repos.bigtop.apache.org/releases/3.2.1/centos/7/$basearch"
distro: centos
components: [hdfs, yarn, mapreduce, spark]
enable_local_repo: false
smoke_test_components: [hdfs, yarn, mapreduce]
```

2. create hadoop cluster

```shell
./docker-hadoop.sh -dcp -c 3
```

3. smoke test spark

```shell
./docker-hadoop.sh -dcp -s spark
```
I have tested it on centos-7 and debian-11
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/