### PR TITLE
BIGTOP-4056. Support Detect Python Path

### DIFF
--- a/bigtop-packages/src/common/bigtop-utils/bigtop-detect-pythonpath
+++ b/bigtop-packages/src/common/bigtop-utils/bigtop-detect-pythonpath
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,14 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Override JAVA_HOME detection for all bigtop packages
-# export JAVA_HOME
 
-# Override PYTHON3_PATH detection for all bigtop packages
-# export PYTHON3_PATH
+# Override python3 in the file below if you want to disable
+# automatic python3 detection
+BIGTOP_DEFAULTS_DIR=${BIGTOP_DEFAULTS_DIR-/etc/default}
+[ -n "${BIGTOP_DEFAULTS_DIR}" -a -r ${BIGTOP_DEFAULTS_DIR}/bigtop-utils ] && . ${BIGTOP_DEFAULTS_DIR}/bigtop-utils
 
-# Provide a colon-delimited list of directories to search for native Java libraries (e.g. libjvm.so)
-# export JAVA_NATIVE_PATH
+PYTHON3_PATH_CANDIDATES=(
+    '/usr/bin/python3'
+    '/opt/python3/bin/python3'
+    '/usr/lib/python3/bin/python3'
+)
 
-# Add common dependencies to the classpath (/var/lib/bigtop will already be included)
-# export BIGTOP_CLASSPATH
+# attempt to find python3
+if [ -z "${PYTHON3_PATH}" ]; then
+  for candidate in ${PYTHON3_PATH_CANDIDATES[@]} ; do
+    if [ -e ${candidate} ]; then
+      export PYTHON3_PATH=${candidate}
+      break
+    fi
+  done
+fi

--- a/bigtop-packages/src/deb/bigtop-utils/rules
+++ b/bigtop-packages/src/deb/bigtop-utils/rules
@@ -35,6 +35,7 @@ override_dh_auto_install:
 	install -p -m 755 debian/bigtop-detect-javahome debian/bigtop-utils/usr/lib/bigtop-utils/
 	install -p -m 755 debian/bigtop-detect-javalibs debian/bigtop-utils/usr/lib/bigtop-utils/
 	install -p -m 755 debian/bigtop-detect-classpath debian/bigtop-utils/usr/lib/bigtop-utils/
+	install -p -m 755 debian/bigtop-detect-pythonpath debian/bigtop-utils/usr/lib/bigtop-utils/
 	install -p -m 755 debian/bigtop-monitor-service debian/bigtop-utils/usr/lib/bigtop-utils/
 	install -d -p -m 755 debian/bigtop-utils/etc/default
 	install -p -m 644 debian/bigtop-utils.default debian/bigtop-utils/etc/default/bigtop-utils

--- a/bigtop-packages/src/rpm/bigtop-utils/SPECS/bigtop-utils.spec
+++ b/bigtop-packages/src/rpm/bigtop-utils/SPECS/bigtop-utils.spec
@@ -32,6 +32,7 @@ Source2:    bigtop-utils.default
 Source3:    bigtop-detect-javalibs
 Source4:    bigtop-detect-classpath
 Source5:    bigtop-monitor-service
+Source6:    bigtop-detect-pythonpath
 Requires:   bash
 
 # "which" command is needed for a lot of projects.
@@ -54,6 +55,7 @@ install -p -m 644 %{SOURCE2} .
 install -p -m 644 %{SOURCE3} .
 install -p -m 644 %{SOURCE4} .
 install -p -m 644 %{SOURCE5} .
+install -p -m 644 %{SOURCE6} .
 
 %build
 
@@ -66,6 +68,7 @@ install -p -m 755 %{SOURCE0} $RPM_BUILD_ROOT%{lib_dir}/
 install -p -m 755 %{SOURCE3} $RPM_BUILD_ROOT%{lib_dir}/
 install -p -m 755 %{SOURCE4} $RPM_BUILD_ROOT%{lib_dir}/
 install -p -m 755 %{SOURCE5} $RPM_BUILD_ROOT%{lib_dir}/
+install -p -m 755 %{SOURCE6} $RPM_BUILD_ROOT%{lib_dir}/
 install -p -m 644 %{SOURCE2} $RPM_BUILD_ROOT/etc/default/bigtop-utils
 
 %clean


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

According to the descussion on the [email](https://www.mail-archive.com/dev@bigtop.apache.org/msg26765.html),we should add a python path detecting script for all bigtop componets.


### How was this patch tested?

1. build the bigtop-utils package
```shell
docker run --rm -v `pwd`:/ws --workdir /ws bigtop/slaves:trunk-centos-7 bash -l -c './gradlew allclean ; ./gradlew bigtop-utils'
```

2. make repo

```shell
./gradlew repo
```

3. test bigtop-utils package by docker-hadoop.sh

```shell
./docker-hadoop.sh -dcp -d -k 'bigtop-utils' -L -r file:///bigtop-home/output -c 1
```

4. login a container, and install python3 package from default distro repo or from source

1) install from default repo
```shell
yum install -y python3
```

2) install from source

```shell
# install build dependencies
yum install -y zlib-devel bzip2-devel openssl-devel ncurses-devel sqlite-devel readline-devel
yum install -y tk-devel gdbm-devel db4-devel libpcap-devel xz-devel libffi-devel
# get python3 source code
wget https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz
tar xzvf Python-3.7.6.tgz
cd Python-3.7.6
./configure --prefix=/opt/python3
make && make install
```

5. check the python3 path detecting

```shell
. /usr/lib/bigtop-utils/bigtop-detect-pythonpath
echo $PAYTHON3_PATH
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/