### PR TITLE
BIGTOP-4045: Enable Parallel Compilation for Multiple Modules in TEZ

### DIFF
--- a/bigtop-packages/src/common/tez/patch8-TEZ-4520.diff
+++ b/bigtop-packages/src/common/tez/patch8-TEZ-4520.diff
@@ -1,0 +1,17 @@
+diff --git a/tez-dist/pom.xml b/tez-dist/pom.xml
+index 8b7f445ef..14ae62f27 100644
+--- a/tez-dist/pom.xml
++++ b/tez-dist/pom.xml
+@@ -49,6 +49,12 @@
+       <version>${project.version}</version>
+       <type>test-jar</type>
+     </dependency>
++    <dependency>
++        <groupId>org.apache.tez</groupId>
++        <artifactId>tez-job-analyzer</artifactId>
++        <version>${project.version}</version>
++        <scope>provided</scope>
++    </dependency>
+   </dependencies>
+ 
+   <properties>

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -195,6 +195,7 @@ bigtop {
       url     { download_path = "/$name/${version.base}/"
                 site = "${apache.APACHE_MIRROR}/${download_path}"
                 archive = "${apache.APACHE_ARCHIVE}/${download_path}" }
+      maven_parallel_build = true
     }
     'solr' {
       name    = 'solr'


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

test on centos7, ubuntu22
./gradlew tez-clean tez-pkg -PbuildThreads=2C

Parallel compilation for Tez requires the introduction of a Tez patch, which can be found at [TEZ-4520](https://issues.apache.org/jira/browse/TEZ-4520). This patch is designed to address the issue of Tez not being able to compile in parallel.

### How was this patch tested?
<img width="824" alt="image" src="https://github.com/apache/bigtop/assets/18082602/55eb82a7-36f2-4f48-a0f3-ee2f88fb8623">

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/