### PR TITLE
BIGTOP-3896. Failed to deploy Alluxio on Arm64/ppc64le Fedora-38

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -45,7 +45,7 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
 
 else
   #need to manually compile the libjnifuse*.so in openEuler
-  if [ "${OS}" = "openEuler" ] ; then
+  if [ "${OS}" = "openEuler" ] || [ "${OS}" = "fedora" ]; then
     sed -i "s|<activeByDefault>false</activeByDefault>|<activeByDefault>true</activeByDefault>|g" integration/jnifuse/native/pom.xml
   fi
 

--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -44,7 +44,9 @@ if [ $HOSTTYPE = "powerpc64le" ] ; then
   mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dgrpc.version=1.28.0 -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"
 
 else
-  #need to manually compile the libjnifuse*.so in openEuler
+  #need to manually compile the libjnifuse*.so in openEuler and fedora.
+  #The libjnifuse*.so files which alluxio need is not compiled by default, and uses the x86 ARCH version
+  #so we need to compile libjnifuse*.so and copy it to the corresponding directory of alluxio
   if [ "${OS}" = "openEuler" ] || [ "${OS}" = "fedora" ]; then
     sed -i "s|<activeByDefault>false</activeByDefault>|<activeByDefault>true</activeByDefault>|g" integration/jnifuse/native/pom.xml
   fi

--- a/bigtop-packages/src/common/alluxio/install_alluxio.sh
+++ b/bigtop-packages/src/common/alluxio/install_alluxio.sh
@@ -89,6 +89,9 @@ for var in PREFIX BUILD_DIR ; do
   fi
 done
 
+. /etc/os-release
+OS="$ID"
+
 LIB_DIR=${LIB_DIR:-/usr/lib/alluxio}
 LIBEXEC_DIR=${INSTALLED_LIB_DIR:-/usr/libexec}
 BIN_DIR=${BIN_DIR:-/usr/bin}
@@ -131,7 +134,7 @@ cp -a integration/* $PREFIX/$LIB_DIR/integration
 cp integration/fuse/target/alluxio-integration-fuse-*-jar-with-dependencies.jar $PREFIX/$LIB_DIR/integration/fuse
 
 # replace the original libjnifuse*.so file with the manually compiled in openEuler
-if [ ${OS} = "openEuler" ]; then
+if [ ${OS} = "openEuler" ] || [ "${OS}" = "fedora" ]; then
   cp integration/jnifuse/native/src/main/resources/libjnifuse*.so $PREFIX/$LIB_DIR/integration/jnifuse/native/target/classes/
 fi
 

--- a/bigtop-packages/src/common/alluxio/install_alluxio.sh
+++ b/bigtop-packages/src/common/alluxio/install_alluxio.sh
@@ -133,7 +133,9 @@ cp -a client/* $PREFIX/$LIB_DIR/client
 cp -a integration/* $PREFIX/$LIB_DIR/integration
 cp integration/fuse/target/alluxio-integration-fuse-*-jar-with-dependencies.jar $PREFIX/$LIB_DIR/integration/fuse
 
-# replace the original libjnifuse*.so file with the manually compiled in openEuler
+# replace the original libjnifuse*.so file with the manually compiled in openEuler and fedora
+# The libjnifuse*.so files which alluxio need is not compiled by default, and uses the x86 ARCH version
+# so we need to compile libjnifuse*.so and copy it to the corresponding directory of alluxio
 if [ ${OS} = "openEuler" ] || [ "${OS}" = "fedora" ]; then
   cp integration/jnifuse/native/src/main/resources/libjnifuse*.so $PREFIX/$LIB_DIR/integration/jnifuse/native/target/classes/
 fi

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -29,6 +29,8 @@ class bigtop_toolchain::packages {
         "gcc",
         "gcc-c++",
         "fuse",
+        "fuse3",
+        "fuse3-devel",
         "createrepo",
         "lzo-devel",
         "fuse-devel",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3896

The so of alluxio is not compiled by default, and uses the x86 version, so we need to compile libjnifuse*.so and copy it to the corresponding directory of alluxio when building adaptation

Modify the bigtop-release-3.2.0/bigtop-packages/src/common/alluxio/do-component-build file to adapt Arm64 architecture code for fedora OS.
Modify the bigtop-release-3.2.0/bigtop-packages/src/common/alluxio/ install_alluxio.sh file to copy the libjnifuse*.so file.

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-3896)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/