### PR TITLE
BIGTOP-4061: Improve support for Maven parallel build parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,7 @@ __On all systems, Building Apache Bigtop requires certain set of tools__
 
 * __Enabling Parallel Build for packages(BIGTOP-4044)__
 
-  Apache Bigtop defaults to non-parallel builds. Use -PbuildThreads=2C to activate Maven's parallel build feature and expedite compilation for compatible components.
-  
-  Append a digit and 'C' to -PbuildThreads= to set the CPU core count for concurrent builds.
+  Apache Bigtop defaults to non-parallel builds. Use -PbuildThreads with a number or a combination of numbers followed by 'C', such as '-PbuildThreads=2' or '-PbuildThreads=2C', to specify the number of CPU cores for Maven's parallel build feature, which can speed up the compilation process for compatible components.
   
   Consult the bigtop.bom file to verify component compatibility with parallel builds; those marked with maven_parallel_build = true support this option.
 

--- a/packages.gradle
+++ b/packages.gradle
@@ -87,7 +87,7 @@ def generatePatch(String threadCount, String path) {
         --- a/.mvn/maven.config
         +++ b/.mvn/maven.config
         @@ -0,0 +1 @@
-        +-T${threadCount}
+        +-T ${threadCount}
         \\ No newline at end of file
     """.stripIndent()
 
@@ -95,6 +95,10 @@ def generatePatch(String threadCount, String path) {
         write(patchContent)
         println "Patch file created at: ${absolutePath}"
     }
+}
+
+def isValidMavenBuildThreads(threads) {
+    return threads.matches("\\d+C") || threads.matches("\\d+")
 }
 
 /**
@@ -453,8 +457,8 @@ def genTasks = { target ->
       into "$DEB_BLD_DIR/debian"
     }
     if (MAVEN_BUILD_THREADS && ENABLE_MAVEN_PARALLEL_BUILD) {
-      if (!MAVEN_BUILD_THREADS.matches("\\d+C")) {
-        throw new GradleException("Invalid MAVEN_BUILD_THREADS parameter. It must be a combination of numbers and 'C', such as '2C'.")
+      if (!isValidMavenBuildThreads(MAVEN_BUILD_THREADS)) {
+        throw new GradleException("Invalid MAVEN_BUILD_THREADS parameter. It must be either a number or a combination of numbers followed by 'C', such as '2' or '2C'.")
       }
       generatePatch(MAVEN_BUILD_THREADS, "$DEB_BLD_DIR/debian")
     }
@@ -642,8 +646,8 @@ def genTasks = { target ->
       into "$PKG_BUILD_DIR/rpm/SOURCES"
     }
     if (MAVEN_BUILD_THREADS && ENABLE_MAVEN_PARALLEL_BUILD) {
-      if (!MAVEN_BUILD_THREADS.matches("\\d+C")) {
-        throw new GradleException("Invalid MAVEN_BUILD_THREADS parameter. It must be a combination of numbers and 'C', such as '2C'.")
+      if (!isValidMavenBuildThreads(MAVEN_BUILD_THREADS)) {
+        throw new GradleException("Invalid MAVEN_BUILD_THREADS parameter. It must be either a number or a combination of numbers followed by 'C', such as '2' or '2C'.")
       }
       generatePatch(MAVEN_BUILD_THREADS, "$PKG_BUILD_DIR/rpm/SOURCES")
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Add a numeric type Maven parallel compilation parameter, and modify the corresponding documentation.

### How was this patch tested?
manual test on rocky8
![image](https://github.com/apache/bigtop/assets/18082602/4fcdae01-a230-4415-9626-c4c27ec8775e)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/