### PR TITLE
BIGTOP-4062. Upgrade Spark to 3.3.4.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -222,7 +222,7 @@ bigtop {
        * when upgrading spark version.
        * See comments in [bigtop-packages/src/common/spark/install_spark.sh] for details.
        */
-      version { base = '3.3.3'; pkg = base; release = 1 }
+      version { base = '3.3.4'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}.tgz" }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4062

The latest maintenance release of Spark 3.3 series with security and correctness fixes is available.