### PR TITLE
BIGTOP-3991 add rockylinux 9 support

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -64,7 +64,6 @@ case ${ID}-${VERSION_ID} in
     rocky-9*)
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
         dnf -y check-update
-        #dnf -y install glibc-langpack-en hostname diffutils curl sudo unzip wget puppet procps-ng 'dnf-command(config-manager)'
         dnf -y install glibc-langpack-en hostname diffutils sudo unzip wget puppet procps-ng 'dnf-command(config-manager)'
         # Install the module in the same way as Fedora 31 and CentOS 7 for compatibility issues.
         puppet module install puppetlabs-stdlib --version 4.12.0

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -61,6 +61,17 @@ case ${ID}-${VERSION_ID} in
         # As a workaround for that, enable the former here in advance of running the Puppet manifests.
         dnf config-manager --set-enabled powertools
         ;;
+    rocky-9*)
+        rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+        dnf -y check-update
+        #dnf -y install glibc-langpack-en hostname diffutils curl sudo unzip wget puppet procps-ng 'dnf-command(config-manager)'
+        dnf -y install glibc-langpack-en hostname diffutils sudo unzip wget puppet procps-ng 'dnf-command(config-manager)'
+        # Install the module in the same way as Fedora 31 and CentOS 7 for compatibility issues.
+        puppet module install puppetlabs-stdlib --version 4.12.0
+        # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.
+        # As a workaround for that, enable the former here in advance of running the Puppet manifests.
+        dnf config-manager --set-enabled crb
+        ;;
     rhel-8*)
         rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm
         dnf -y check-update

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -70,16 +70,12 @@ class bigtop_toolchain::packages {
         "yasm"
       ]
 
-		notify{"$operatingsystem and $operatingsystemmajrelease":}
       if (/redhat|centos|rocky/ in downcase($operatingsystem) and Integer($operatingsystemmajrelease) >= 9) {
         $pkgs = $_pkgs + ['cmake']
-        notify{"# redhat and derivatives": before => Package[$pkgs]}
       } elsif ($operatingsystem == 'Fedora' or $operatingsystemmajrelease !~ /^[0-7]$/) {
         $pkgs = concat($_pkgs, ["python2-devel", "libtirpc-devel", "cmake"])
-        notify{"# Fedora": before => Package[$pkgs]}
       } else {
         $pkgs = concat($_pkgs, ["python-devel", "cmake3"])
-        notify{"# all else": before => Package[$pkgs]}
       }
     }
     /(?i:(SLES|opensuse))/: { $pkgs = [

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -69,8 +69,13 @@ case ${OS} in
         fi
         ;;
     rockylinux)
-        PUPPET_MODULES="/etc/puppetlabs/code/environments/production/modules/bigtop_toolchain"
-        UPDATE_SOURCE="dnf clean all \&\& dnf updateinfo"
+        if [ "${VERSION_INT}" -ge "9" ]; then
+           PUPPET_MODULES="/etc/puppet/code/environments/production/modules/bigtop_toolchain"
+           UPDATE_SOURCE="dnf clean all \&\& dnf updateinfo"
+        else
+           PUPPET_MODULES="/etc/puppetlabs/code/environments/production/modules/bigtop_toolchain"
+           UPDATE_SOURCE="dnf clean all \&\& dnf updateinfo"
+        fi
         ;;
     opensuse)
         PUPPET_MODULES="/etc/puppet/modules/bigtop_toolchain"

--- a/provisioner/docker/config_rockylinux-9.yaml
+++ b/provisioner/docker/config_rockylinux-9.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker:
+        memory_limit: "4g"
+        image: "bigtop/puppet:trunk-rockylinux-9"
+
+repo: "http://repos.bigtop.apache.org/releases/3.2.1/rockylinux/9/$basearch"
+distro: centos
+components: [hdfs, yarn, mapreduce]
+enable_local_repo: false
+smoke_test_components: [hdfs, yarn, mapreduce]


### PR DESCRIPTION
### Description of PR
This change allows the creation of Rocky Linux 9 packages.  (Presumably compatible with AlmaLinux 9, Centos 9, and RHEL 9 also.)

### How was this patch tested?
After patching packages for Centos 7, Rocky Linux 8, and Rocky Linux 9 were built in the following ways:
(container only builds)
./gradlew clean -POS=$DISTRO bigtop-groovy-pkg-ind bigtop-jsvc-pkg-ind bigtop-utils-pkg-ind zookeeper-pkg-ind hadoop-pkg-ind
(also on bare metal)
./gradlew clean -POS=$DISTRO hadoop-pkg

Building for other distros and task were not tested.  (Let me know if there is a command to test the full gamut.  I will be happy to test it.)