### PR TITLE
BIGTOP-4064. Fix Bigtop toolchain to work with Puppet 3.x.

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -70,7 +70,7 @@ class bigtop_toolchain::packages {
         "yasm"
       ]
 
-      if (/redhat|centos|rocky/ in downcase($operatingsystem) and Integer($operatingsystemmajrelease) >= 9) {
+      if ($osfamily == 'RedHat' and 0 <= versioncmp($operatingsystemmajrelease, '9')) {
         $pkgs = $_pkgs + ['cmake']
       } elsif ($operatingsystem == 'Fedora' or $operatingsystemmajrelease !~ /^[0-7]$/) {
         $pkgs = concat($_pkgs, ["python2-devel", "libtirpc-devel", "cmake"])
@@ -401,7 +401,7 @@ class bigtop_toolchain::packages {
   # download python 2.7.14 for openEuler docker slaves
   # and RHEL9 based distros
   if $operatingsystem == 'openEuler'
-     or (/redhat|centos|rocky/ in $operatingsystem and Integer($operatingsystemmajrelease) >= 9) {
+     or ($osfamily == 'RedHat' and 0 <= versioncmp($operatingsystemmajrelease, '9')) {
     exec { "download_python2.7":
       cwd => "/usr/src",
       command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.14 && /bin/tar -xvzf Python-2.7.14.tgz -C Python-2.7.14 --strip-components=1 && cd Python-2.7.14",

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -72,7 +72,7 @@ class bigtop_toolchain::packages {
 
       if ($operatingsystem == 'Fedora') {
         $pkgs = concat($_pkgs, ["python2-devel", "libtirpc-devel", "cmake"])
-      } else { # RHEL, CentOS, Fedora
+      } else { # RedHat, CentOS, Rocky
         if (0 <= versioncmp($operatingsystemmajrelease, '9')) {
           $pkgs = concat($_pkgs, ["libtirpc-devel", "cmake"])
         } elsif (0 == versioncmp($operatingsystemmajrelease, '8')) {

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -70,7 +70,7 @@ class bigtop_toolchain::packages {
         "yasm"
       ]
 
-      if ($osfamily == 'RedHat' and 0 <= versioncmp($operatingsystemmajrelease, '9')) {
+      if (0 == versioncmp($operatingsystemmajrelease, '9')) {
         $pkgs = $_pkgs + ['cmake']
       } elsif ($operatingsystem == 'Fedora' or $operatingsystemmajrelease !~ /^[0-7]$/) {
         $pkgs = concat($_pkgs, ["python2-devel", "libtirpc-devel", "cmake"])
@@ -401,7 +401,7 @@ class bigtop_toolchain::packages {
   # download python 2.7.14 for openEuler docker slaves
   # and RHEL9 based distros
   if $operatingsystem == 'openEuler'
-     or ($osfamily == 'RedHat' and 0 <= versioncmp($operatingsystemmajrelease, '9')) {
+     or ($osfamily == 'RedHat' and 0 == versioncmp($operatingsystemmajrelease, '9')) {
     exec { "download_python2.7":
       cwd => "/usr/src",
       command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.14 && /bin/tar -xvzf Python-2.7.14.tgz -C Python-2.7.14 --strip-components=1 && cd Python-2.7.14",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4064

Fix Puppet manifest syntax unusable in Puppet 3 used by CentOS 7. (broken by https://github.com/apache/bigtop/pull/1235)