### PR TITLE
BIGTOP-4065: Fixing BUG caused by the lack of preun logic in Flink spec

### DIFF
--- a/bigtop-packages/src/rpm/flink/SPECS/flink.spec
+++ b/bigtop-packages/src/rpm/flink/SPECS/flink.spec
@@ -154,6 +154,11 @@ getent passwd flink >/dev/null || useradd -c "Flink" -s /sbin/nologin -g flink -
 %post
 %{alternatives_cmd} --install %{np_etc_flink}/conf %{flink_name}-conf %{etc_flink}/conf.dist 30
 
+%preun
+if [ "$1" = 0 ]; then
+        %{alternatives_cmd} --remove %{flink_name}-conf %{etc_flink}/conf.dist || :
+fi
+
 ###### FILES ###########
 
 %files


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

The Flink RPM lacks preun logic, causing the alternative symbolic link to persist even after uninstalling Flink.

For example, if Flink was initially installed under /usr/bigtop/3.2.0 and then installed again with a different version under /usr/bigtop/3.3.0, the alternative symbolic link /etc/alternatives/flink-conf -> /usr/bigtop/3.3.0/etc/flink/conf.dist will not be correctly created due to the old alternatives not being uninstalled.

Upon checking other components, they all include preun uninstallation logic, which is why they do not have this issue.

 
![image](https://github.com/apache/bigtop/assets/18082602/829937f1-fb0d-404f-a9fa-4909cc22e7f7)

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/