### PR TITLE
BIGTOP-4067. Fix build failure of Python 2.7 on Rocky Linux 9.

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -408,11 +408,23 @@ class bigtop_toolchain::packages {
       creates => "/usr/src/Python-2.7.14",
     }
 
-    exec { "install_python2.7":
-      cwd => "/usr/src/Python-2.7.14",
-      command => "/usr/src/Python-2.7.14/configure --prefix=/usr/local/python2.7.14 --enable-optimizations && /usr/bin/make -j8 && /usr/bin/make install -j8",
-      require => [Exec["download_python2.7"]],
-      timeout => 3000
+    case $operatingsystem {
+      'openEuler': {
+        exec { "install_python2.7":
+          cwd => "/usr/src/Python-2.7.14",
+          command => "/usr/src/Python-2.7.14/configure --prefix=/usr/local/python2.7.14 --enable-optimizations && /usr/bin/make -j8 && /usr/bin/make install -j8",
+          require => [Exec["download_python2.7"]],
+          timeout => 3000
+        }
+      }
+      default: {
+        exec { "install_python2.7":
+          cwd => "/usr/src/Python-2.7.14",
+          command => "/usr/src/Python-2.7.14/configure --prefix=/usr/local/python2.7.14 && /usr/bin/make -j8 && /usr/bin/make install -j8",
+          require => [Exec["download_python2.7"]],
+          timeout => 3000
+        }
+      }
     }
 
     exec { "ln python2.7":


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4067

The error is emitted on running tests. Since --enable-optimizations makes the tests mandatory, we can skip tests by removing [the configure option](https://github.com/apache/bigtop/blob/db4ddc1bfeeaa048658d7805e7f9dfbec09b0fec/bigtop_toolchain/manifests/packages.pp#L413).

```
0:08:41 load avg: 0.67 [256/399] test_poplib                                                                                                                                                                                       
Exception in thread Thread-332:                                                                                                                                                                                                    
Traceback (most recent call last):                                                                                                                                                                                                 
  File "/usr/src/Python-2.7.14/Lib/threading.py", line 801, in __bootstrap_inner                                                                                                                                                   
    self.run()                                                                                                                                                                                                                     
  File "/usr/src/Python-2.7.14/Lib/test/test_poplib.py", line 132, in run
    asyncore.loop(timeout=0.1, count=1)
...(snip)
  File "/usr/src/Python-2.7.14/Lib/ssl.py", line 554, in __init__
    self._context.load_cert_chain(certfile, keyfile)                                                                                                                                                                               
SSLError: [SSL: EE_KEY_TOO_SMALL] ee key too small (_ssl.c:2693)
```

Since --enable-optimizations makes the tests mandatory, we can skip tests by removing [the configure option](https://github.com/apache/bigtop/blob/db4ddc1bfeeaa048658d7805e7f9dfbec09b0fec/bigtop_toolchain/manifests/packages.pp#L413).

Since migrating to Python 3 is the right fix, just removing `--enable-optimizations` on Rocky Linux 9 should be enough as a short-term fix.