### PR TITLE
BIGTOP-4070: Fix Compilation Failure of Ranger 2.4 on Maven 3.8

### DIFF
--- a/bigtop-packages/src/common/ranger/patch4-RANGER-4728.diff
+++ b/bigtop-packages/src/common/ranger/patch4-RANGER-4728.diff
@@ -1,0 +1,40 @@
+diff --git a/plugin-kylin/pom.xml b/plugin-kylin/pom.xml
+index 376f166d8..5e920f6aa 100644
+--- a/plugin-kylin/pom.xml
++++ b/plugin-kylin/pom.xml
+@@ -31,6 +31,15 @@
+         <version>2.4.0</version>
+         <relativePath>..</relativePath>
+     </parent>
++    <dependencyManagement>
++        <dependencies>
++          <dependency>
++            <groupId>org.apache.kafka</groupId>
++            <artifactId>kafka_2.11</artifactId>
++            <version>2.1.1</version>
++          </dependency>
++        </dependencies>
++    </dependencyManagement>
+     <dependencies>
+         <dependency>
+             <groupId>org.springframework.security</groupId>
+diff --git a/ranger-kylin-plugin-shim/pom.xml b/ranger-kylin-plugin-shim/pom.xml
+index b82616dc8..98aef7752 100644
+--- a/ranger-kylin-plugin-shim/pom.xml
++++ b/ranger-kylin-plugin-shim/pom.xml
+@@ -31,6 +31,15 @@
+         <version>2.4.0</version>
+         <relativePath>..</relativePath>
+     </parent>
++    <dependencyManagement>
++        <dependencies>
++          <dependency>
++            <groupId>org.apache.kafka</groupId>
++            <artifactId>kafka_2.11</artifactId>
++            <version>2.1.1</version>
++          </dependency>
++        </dependencies>
++    </dependencyManagement>
+     <dependencies>
+         <dependency>
+             <groupId>org.apache.calcite</groupId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Issue: ranegr 2.4 can be compiled successfully in Maven 3.6, but fails in Maven 3.8.
![image](https://github.com/apache/bigtop/assets/18082602/4a0bcd7d-bd4b-4a9b-9249-e5cf13ae61a7)

Due to improvements made in Maven versions after 3.6, the `kafka.version` setting can affect the versions of dependencies in the global JAR files.




Kylin-server-base ultimately depends on `org.apache.kafka`. When compiled in Maven 3.6, it resolves to `org.apache.kafka:kafka_2.11:2.1.1`. However, in Maven 3.8, it attempts to find `org.apache.kafka:kafka_2.11:2.8.2`, which does not exist in Maven repositories.

Maven 3.8 introduces a new feature that rigorously handles dependency versions defined in the global POM file. Dependency versions defined in the global POM file take precedence over project-specific versions, potentially overriding explicitly specified versions. This stricter version propagation rule can lead to different dependency resolution behavior in Maven 3.8 compared to Maven 3.6.

Therefore, in Maven 3.8, the `kafka.version` defined in the global POM affects the Kafka version in kylin-server-base, leading to compilation failure. Adding dependency management can resolve this issue.

### How was this patch tested?

![image](https://github.com/apache/bigtop/assets/18082602/034641b5-f73f-48ad-b713-e8581d0b95cc)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/