### PR TITLE
BIGTOP-4072: Add pkg-suffix to Alluxio to support Ambari installation and deployment

### DIFF
--- a/bigtop-packages/src/common/alluxio/install_alluxio.sh
+++ b/bigtop-packages/src/common/alluxio/install_alluxio.sh
@@ -38,9 +38,9 @@ OPTS=$(getopt \
   -l 'prefix:' \
   -l 'bin-dir:' \
   -l 'libexec-dir:' \
-  -l 'var-dir:' \
   -l 'lib-dir:' \
   -l 'data-dir:' \
+  -l 'conf-dist-dir:' \
   -l 'build-dir:' -- "$@")
 
 if [ $? != 0 ] ; then
@@ -65,11 +65,11 @@ while true ; do
         --bin-dir)
         BIN_DIR=$2 ; shift 2
         ;;
-        --var-dir)
-        VAR_DIR=$2 ; shift 2
-        ;;
         --data-dir)
         DATA_DIR=$2 ; shift 2
+        ;;
+        --conf-dist-dir)
+        CONF_DIST_DIR=$2 ; shift 2
         ;;
         --)
         shift ; break
@@ -95,7 +95,11 @@ OS="$ID"
 LIB_DIR=${LIB_DIR:-/usr/lib/alluxio}
 LIBEXEC_DIR=${INSTALLED_LIB_DIR:-/usr/libexec}
 BIN_DIR=${BIN_DIR:-/usr/bin}
-CONF_DIST_DIR=/etc/alluxio/conf.dist/
+ETC_ALLUXIO=${ETC_ALLUXIO:-/etc/alluxio}
+# No prefix
+NP_ETC_ALLUXIO=/etc/alluxio
+CONF_DIST_DIR=${CONF_DIST_DIR:-/etc/alluxio/conf.dist}
+NP_VAR_DIR=/var
 
 install -d -m 0755 $PREFIX/$LIB_DIR
 install -d -m 0755 $PREFIX/$LIB_DIR/assembly/client/target
@@ -109,18 +113,18 @@ install -d -m 0755 $PREFIX/$LIB_DIR/webui/worker
 install -d -m 0755 $PREFIX/$LIB_DIR/integration
 install -d -m 0755 $PREFIX/$LIB_DIR/share
 install -d -m 0755 $PREFIX/$LIB_DIR/core/server/common/src/main/webapp
+install -d -m 0755 $PREFIX/$LIB_DIR/journal
 install -d -m 0755 $PREFIX/$DATA_DIR
 install -d -m 0755 $PREFIX/$DATA_DIR/alluxio
-install -d -m 0755 $PREFIX/etc
-install -d -m 0755 $PREFIX/etc/alluxio
-install -d -m 0755 $PREFIX/etc/alluxio/conf
-install -d -m 0755 $PREFIX/$VAR_DIR/log/alluxio
-install -d -m 0755 $PREFIX/$VAR_DIR/lib/alluxio/journal
-install -d -m 0755 $PREFIX/$VAR_DIR/run/alluxio
+install -d -m 0755 $PREFIX/$NP_ETC_ALLUXIO
+install -d -m 0755 $PREFIX/$NP_VAR_DIR/run/alluxio
+install -d -m 0755 $PREFIX/$NP_VAR_DIR/log/alluxio
+
+
 install -d -m 0755 $PREFIX/$CONF_DIST_DIR
 
-ln -s $CONF_DIST_DIR $PREFIX/$LIB_DIR/conf
-ln -s $VAR_DIR/log/alluxio $PREFIX/$LIB_DIR/logs
+ln -s $NP_ETC_ALLUXIO/conf $PREFIX/$LIB_DIR/conf
+ln -s $NP_VAR_DIR/log/alluxio $PREFIX/$LIB_DIR/logs
 
 cp assembly/server/target/alluxio*dependencies.jar $PREFIX/$LIB_DIR/assembly/server/target
 cp assembly/client/target/alluxio*dependencies.jar $PREFIX/$LIB_DIR/assembly/client/target

--- a/bigtop-packages/src/common/bigtop-select/distro-select
+++ b/bigtop-packages/src/common/bigtop-select/distro-select
@@ -69,7 +69,10 @@ leaves = {
            "spark-historyserver" : "spark",
            "ranger-admin" : "ranger-admin",
            "ranger-usersync" : "ranger-usersync",
-           "ranger-tagsync" : "ranger-tagsync"
+           "ranger-tagsync" : "ranger-tagsync",
+           "alluxio": "alluxio",
+           "alluxio-master": "alluxio",
+           "alluxio-worker": "alluxio"
 }
 
 # Define the aliases and the list of leaves they correspond to
@@ -131,7 +134,8 @@ command_symlinks = {
   "spark-shell" : "spark-client/../../bin/spark-shell",
   "spark-sql" : "spark-client/../../bin/spark-sql",
   "spark-submit" : "spark-client/../../bin/spark-submit",
-  "pyspark" : "spark-client/../../bin/pyspark"
+  "pyspark" : "spark-client/../../bin/pyspark",
+  "alluxio" : "alluxio/bin/alluxio"
 }
 
 

--- a/bigtop-packages/src/deb/alluxio/rules
+++ b/bigtop-packages/src/deb/alluxio/rules
@@ -36,7 +36,6 @@ override_dh_auto_install:
     --bin-dir=/usr/bin \
     --data-dir=/usr/share \
     --libexec-dir=/usr/lib/alluxio/libexec \
-    --var-dir=/var \
     --prefix=debian/tmp
 	mkdir -p debian/alluxio/etc/init.d/
 	bash debian/init.d.tmpl debian/alluxio-master.svc deb debian/alluxio/etc/init.d/alluxio-master

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -291,6 +291,7 @@ bigtop {
     'alluxio' {
       name    = "alluxio"
       pkg     = "alluxio"
+      rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = "Alluxio: a memory-centric distributed file system"
       version { base = '2.9.3'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Add pkg-suffix to Alluxio to support Ambari installation and deployment
why change journal dir?
 because default journal dir is located under alluxio work dir
![image](https://github.com/apache/bigtop/assets/18082602/98092edd-0a0b-40e3-af55-0410c8ebcd39)

### How was this patch tested?
manual test
![image](https://github.com/apache/bigtop/assets/18082602/530b1eb8-b64b-45be-a531-16e18dc5cba9)
![image](https://github.com/apache/bigtop/assets/18082602/eeffc668-56cc-40ac-9c94-1110a00fad1b)
![image](https://github.com/apache/bigtop/assets/18082602/894678e9-f3cd-48f5-a41c-9c93b7a9f570)

smote test on rocky linux 8
![image](https://github.com/apache/bigtop/assets/18082602/f3dbff50-b1c6-44df-898d-2c119af617b3)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/