### PR TITLE
BIGTOP-4068: fix the alluxio in rockylinux9 bug

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -70,7 +70,7 @@ case ${ID}-${VERSION_ID} in
         # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.
         # As a workaround for that, enable the former here in advance of running the Puppet manifests.
         dnf config-manager --set-enabled crb devel
-        dnf install -y redhat-lsb
+        dnf install -y redhat-lsb initscripts
         ;;
     rhel-8*)
         rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -70,7 +70,6 @@ case ${ID}-${VERSION_ID} in
         # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.
         # As a workaround for that, enable the former here in advance of running the Puppet manifests.
         dnf config-manager --set-enabled crb devel
-        dnf install -y redhat-lsb initscripts
         ;;
     rhel-8*)
         rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -69,7 +69,8 @@ case ${ID}-${VERSION_ID} in
         puppet module install puppetlabs-stdlib --version 4.12.0
         # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.
         # As a workaround for that, enable the former here in advance of running the Puppet manifests.
-        dnf config-manager --set-enabled crb
+        dnf config-manager --set-enabled crb devel
+        dnf install -y redhat-lsb
         ;;
     rhel-8*)
         rpm -Uvh https://yum.puppet.com/puppet5-release-el-8.noarch.rpm


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4068

The bug is alluxio smoketest failed in rockylinux 9, the test cmd
     ./docker-hadoop.sh -d -c 3 -C config_rockylinux-9.yaml

 **redhat-lsb** should be installed by dnf when alluxio somketest in  rockylinux 9


- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-4068)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/