### PR TITLE
BIGTOP-4076. Fix compilation failure of Flink on centos 7 aarch64.

### DIFF
--- a/bigtop-packages/src/common/flink/do-component-build
+++ b/bigtop-packages/src/common/flink/do-component-build
@@ -16,9 +16,15 @@
 
 set -ex
 
-
 #load versions
 . `dirname $0`/bigtop.bom
+
+. /etc/os-release
+
+if [[ $ID = "centos" && $VERSION_ID = "7" && $HOSTTYPE = "aarch64" ]]; then
+  # BIGTOP-4076: newer g++ is required for rebuilding watcher used by flink-runtime-web    
+  BUILD_ENV="scl enable devtoolset-9 -- "
+fi
 
 # husky have to be executed from the path that .git exists
 git_path="$(cd $(dirname $0)/../../../.. && pwd)"
@@ -36,6 +42,6 @@ fi
 sed -i "s/$repl_from/$repl_to/" flink-runtime-web/web-dashboard/package.json
 
 # Use Maven to build Flink from source
-mvn install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"
+${BUILD_ENV} mvn install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"
 cd flink-dist
-mvn install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"
+${BUILD_ENV} mvn install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"

--- a/bigtop-packages/src/common/flink/do-component-build
+++ b/bigtop-packages/src/common/flink/do-component-build
@@ -21,7 +21,7 @@ set -ex
 
 . /etc/os-release
 
-if [[ $ID = "centos" && $VERSION_ID = "7" && $HOSTTYPE = "aarch64" ]]; then
+if [[ $ID = "centos" && $VERSION_ID = "7" && ( $HOSTTYPE = "aarch64" || $HOSTTYPE = "powerpc64le" ) ]]; then
   # BIGTOP-4076: newer g++ is required for rebuilding watcher used by flink-runtime-web    
   BUILD_ENV="scl enable devtoolset-9 -- "
 fi

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -338,6 +338,18 @@ class bigtop_toolchain::packages {
       package { 'ca-certificates':
         ensure => latest
       }
+
+      # BIGTOP-4076: newer g++ is required for rebuilding watcher used by flink-runtime-web
+      if ($architecture in ['aarch64']) {
+        package { 'centos-release-scl':
+          ensure => latest
+        }
+
+        package { 'devtoolset-9-gcc-c++':
+          ensure => latest,
+          require => Package['centos-release-scl']
+        }
+      }
     }
     if $operatingsystemmajrelease !~ /^[0-7]$/ {
       # On CentOS 8, EPEL requires that the PowerTools repository is enabled.

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -340,7 +340,7 @@ class bigtop_toolchain::packages {
       }
 
       # BIGTOP-4076: newer g++ is required for rebuilding watcher used by flink-runtime-web
-      if ($architecture in ['aarch64']) {
+      if ($architecture in ['aarch64', 'ppc64le']) {
         package { 'centos-release-scl':
           ensure => latest
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4076

We need newer version of g++ for rebuilding [@parcel/watcher](https://github.com/parcel-bundler/watcher) for aarch64. I added software collection resources to toolchain for this. Since scl is enabled on only CentOS 7 aarch64, other platforms should not be affected by this PR.