### PR TITLE
BIGTOP-4082: Fix installation failure or R by bigtop_toolchain on openEuler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ Properties:
   -Pmemory=[4g|8g|...]
   -Pnum_instances=[NUM_INSTANCES]
   -Pnexus=[NEXUS_URL] (NEXUS_URL is optional)
-  -POS=[centos-7|fedora-35|ubuntu-18.04|opensuse-42.3|openeuler-22.03]
+  -POS=[centos-7|fedora-35|ubuntu-18.04|opensuse-42.3|openeuler-22.03-lts-sp1]
   -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...]
   -Prepository=[REPO_URL]
   -Prun_smoke_tests (run test components defined in config file)
@@ -562,7 +562,7 @@ task "bigtop-puppet"(type:Exec,
     description: '''
 Build bigtop/puppet images
 Usage:
-  $ ./gradlew -POS=[centos-7|fedora-35|debian-11|ubuntu-18.04|opensuse-42.3|openeuler-22.03] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-puppet
+  $ ./gradlew -POS=[centos-7|fedora-35|debian-11|ubuntu-18.04|opensuse-42.3|openeuler-22.03-lts-sp1] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-puppet
 Example:
   $ ./gradlew -POS=debian-11 -Pprefix=3.0.0 bigtop-puppet
   The built image name: bigtop/puppet:3.0.0-debian-11
@@ -581,7 +581,7 @@ task "bigtop-slaves"(type:Exec,
     description: '''
 Build bigtop/slaves images
 Usage:
-  $ ./gradlew -POS=[centos-7|fedora-35|debian-11|ubuntu-18.04|opensuse-42.3|openeuler-22.03] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-slaves
+  $ ./gradlew -POS=[centos-7|fedora-35|debian-11|ubuntu-18.04|opensuse-42.3|openeuler-22.03-lts-sp1] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-slaves
 Example:
   $ ./gradlew -POS=debian-11 -Pprefix=3.0.0 bigtop-slaves
   The built image name: bigtop/slaves:3.0.0-debian-11

--- a/docker/bigtop-puppet/build.sh
+++ b/docker/bigtop-puppet/build.sh
@@ -61,7 +61,8 @@ case "${OS}-${VERSION}" in
     ;;
   openeuler-22.03*)
     OPENEULER_OS="${OS}/${OS}"
-    sed -i -e "s|${OS}:${VERSION}|$OPENEULER_OS:${VERSION}|" ./Dockerfile
+    # BIGTOP-4082 specify the openEuler OS version is : 22.03-lts-sp1
+    sed -i -e "s|${OS}:${VERSION}|$OPENEULER_OS:${VERSION}-lts-sp1|" ./Dockerfile
     ;;
   *)
     ;;

--- a/docker/bigtop-puppet/build.sh
+++ b/docker/bigtop-puppet/build.sh
@@ -29,7 +29,14 @@ fi
 
 PREFIX=$(echo "$1" | cut -d '-' -f 1)
 OS=$(echo "$1" | cut -d '-' -f 2)
+
+# BIGTOP-4082 get the openEuler OS version
+if [ "${OS}" == "openeuler" ];then
+VERSION=$(echo "$1" | cut -d '-' -f 3-5)
+else
 VERSION=$(echo "$1" | cut -d '-' -f 3)
+fi
+
 ARCH=$(uname -m)
 if [ "${ARCH}" != "x86_64" ];then
 ARCH="-${ARCH}"
@@ -61,8 +68,7 @@ case "${OS}-${VERSION}" in
     ;;
   openeuler-22.03*)
     OPENEULER_OS="${OS}/${OS}"
-    # BIGTOP-4082 specify the openEuler OS version is : 22.03-lts-sp1
-    sed -i -e "s|${OS}:${VERSION}|$OPENEULER_OS:${VERSION}-lts-sp1|" ./Dockerfile
+    sed -i -e "s|${OS}:${VERSION}|$OPENEULER_OS:${VERSION}|" ./Dockerfile
     ;;
   *)
     ;;

--- a/docker/bigtop-puppet/build.sh
+++ b/docker/bigtop-puppet/build.sh
@@ -29,14 +29,7 @@ fi
 
 PREFIX=$(echo "$1" | cut -d '-' -f 1)
 OS=$(echo "$1" | cut -d '-' -f 2)
-
-# BIGTOP-4082 get the openEuler OS version
-if [ "${OS}" == "openeuler" ];then
-VERSION=$(echo "$1" | cut -d '-' -f 3-5)
-else
-VERSION=$(echo "$1" | cut -d '-' -f 3)
-fi
-
+VERSION=$(echo "$1" | cut -d '-' -f 3-)
 ARCH=$(uname -m)
 if [ "${ARCH}" != "x86_64" ];then
 ARCH="-${ARCH}"

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -29,7 +29,12 @@ fi
 
 PREFIX=$(echo "$1" | cut -d '-' -f 1)
 OS=$(echo "$1" | cut -d '-' -f 2)
+# BIGTOP-4082 get the openEuler OS version
+if [ "${OS}" == "openeuler" ];then
+VERSION=$(echo "$1" | cut -d '-' -f 3-5)
+else
 VERSION=$(echo "$1" | cut -d '-' -f 3)
+fi
 ARCH=$(uname -m)
 
 ## Workaround for docker defect on linaros cloud

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -29,12 +29,7 @@ fi
 
 PREFIX=$(echo "$1" | cut -d '-' -f 1)
 OS=$(echo "$1" | cut -d '-' -f 2)
-# BIGTOP-4082 get the openEuler OS version
-if [ "${OS}" == "openeuler" ];then
-VERSION=$(echo "$1" | cut -d '-' -f 3-5)
-else
-VERSION=$(echo "$1" | cut -d '-' -f 3)
-fi
+VERSION=$(echo "$1" | cut -d '-' -f 3-)
 ARCH=$(uname -m)
 
 ## Workaround for docker defect on linaros cloud

--- a/provisioner/docker/config_openeuler-22.03-lts-sp1.yaml
+++ b/provisioner/docker/config_openeuler-22.03-lts-sp1.yaml
@@ -15,7 +15,7 @@
 
 docker:
         memory_limit: "4g"
-        image: "bigtop/puppet:trunk-openeuler-22.03"
+        image: "bigtop/puppet:trunk-openeuler-22.03-lts-sp1"
 
 repo: "http://repios.bigtop.apache.org/releases/3.2.0/openEuler/22.03/$basearch"
 distro: centos


### PR DESCRIPTION
The cmd are:
    gradlew  bigtop-puppet  -POS=openeuler-22.03-lts-sp1 -Pprefix=3.3.0
    gradlew  bigtop-slaves  -POS=openeuler-22.03-lts-sp1 -Pprefix=3.3.0

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-4082)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/