### PR TITLE
BIGTOP-4077: Fix error on deploying Spark due to missing log4j.properties.template

### DIFF
--- a/bigtop-deploy/puppet/modules/spark/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/spark/manifests/init.pp
@@ -255,7 +255,6 @@ class spark {
       require => Package['spark-core'],
     }
 
-    # BIGTOP-4077 modify from log4j.properties.template to log4j2.properties.template
     file { '/etc/spark/conf/log4j2.properties':
       source  => '/etc/spark/conf/log4j2.properties.template',
       require => Package['spark-core'],

--- a/bigtop-deploy/puppet/modules/spark/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/spark/manifests/init.pp
@@ -255,8 +255,9 @@ class spark {
       require => Package['spark-core'],
     }
 
-    file { '/etc/spark/conf/log4j.properties':
-      source  => '/etc/spark/conf/log4j.properties.template',
+    # BIGTOP-4077 modify from log4j.properties.template to log4j2.properties.template
+    file { '/etc/spark/conf/log4j2.properties':
+      source  => '/etc/spark/conf/log4j2.properties.template',
       require => Package['spark-core'],
     }
   }


### PR DESCRIPTION
The smoketest cmd: ./docker-hadoop.sh –d –c 3 –s spark

The error log:
![image](https://github.com/apache/bigtop/assets/11262916/e949de59-67d6-468b-a6df-996844859ff6)

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-4077)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/