### PR TITLE
BIGTOP-4088: Refactor PKG_NAME_SUFFIX and PARENT_DIR

### DIFF
--- a/packages.gradle
+++ b/packages.gradle
@@ -101,6 +101,25 @@ def isValidMavenBuildThreads(threads) {
     return threads.matches("\\d+C") || threads.matches("\\d+")
 }
 
+def getPkgNameSuffix(component, type) {
+    def originalSuffix = type.equalsIgnoreCase("deb") ? component.deb_pkg_suffix : component.rpm_pkg_suffix
+    def defaultSuffix = type.equalsIgnoreCase("deb") ?  "" : "%{nil}"
+    def pkgNameSuffix = project.hasProperty("pkgSuffix")? originalSuffix : defaultSuffix
+    def gradlePkgNameSuffix = pkgNameSuffix == defaultSuffix ? "" : pkgNameSuffix
+
+    return [pkgNameSuffix: pkgNameSuffix, gradlePkgNameSuffix: gradlePkgNameSuffix]
+}
+
+def getParentDir(bigtopBaseVersion, type) {
+    def defaultParentDirValue = type.equalsIgnoreCase("deb") ? "" : "%{nil}"
+    def parentDir = project.hasProperty("parentDir") ? project.property('parentDir') : defaultParentDirValue
+    if (parentDir && parentDir != "%{nil}") {
+        parentDir = "${parentDir}/${bigtopBaseVersion}"
+    }
+    return parentDir
+}
+
+
 /**
  * To avoid breaking the compat with existing packages let's use the old style names
  */
@@ -422,6 +441,7 @@ def genTasks = { target ->
     def final DEB_PKG_DIR = "$PKG_BUILD_DIR/deb/$PKG_NAME-${PKG_VERSION}-${BIGTOP_BUILD_STAMP}"
     def final ENABLE_MAVEN_PARALLEL_BUILD = config.bigtop.components[target].maven_parallel_build
     def final MAVEN_BUILD_THREADS = project.hasProperty('buildThreads') ? project.property('buildThreads') : null
+
     mkdir (DEB_BLD_DIR)
     copy {
       from SEED_TAR
@@ -510,13 +530,11 @@ def genTasks = { target ->
     }
     def final BIGTOP_BASE_VERSION = "${config.bigtop.base_version}"
 
-    def final PKG_NAME_SUFFIX = config.bigtop.components[target].rpm_pkg_suffix
-    def RPM_PKG_NAME_SUFFIX = PKG_NAME_SUFFIX
-    def GRADLE_PKG_NAME_SUFFIX = PKG_NAME_SUFFIX
-    if (!project.hasProperty("pkgSuffix") || !PKG_NAME_SUFFIX) {
-      RPM_PKG_NAME_SUFFIX = "%{nil}"
-      GRADLE_PKG_NAME_SUFFIX = ""
-    }
+
+    def suffixes = getPkgNameSuffix(config.bigtop.components[target], "rpm")
+    def RPM_PKG_NAME_SUFFIX =  suffixes.pkgNameSuffix
+    def GRADLE_PKG_NAME_SUFFIX = suffixes.gradlePkgNameSuffix
+    def final FULL_PARENT_DIR = getParentDir(BIGTOP_BASE_VERSION, "rpm")
 
     def final BIGTOP_BUILD_STAMP = System.getenv('BIGTOP_BUILD_STAMP') ?:
             config.bigtop.components[target].version.release
@@ -535,11 +553,6 @@ def genTasks = { target ->
     def final MAVEN_REPO_ID = project.hasProperty('mavenRepoId') ? project.property('mavenRepoId') : 'default'
     def final MAVEN_REPO_URI = project.hasProperty('mavenRepoUri') ? project.property('mavenRepoUri') : null
 
-    def final PARENT_DIR = project.hasProperty("parentDir") ? project.property('parentDir') : "%{nil}"
-    def FULL_PARENT_DIR = "${PARENT_DIR}"
-    if (PARENT_DIR != "%{nil}") {
-      FULL_PARENT_DIR = "${PARENT_DIR}/${BIGTOP_BASE_VERSION}"
-    }
 
     def command = [
         '--define', "_topdir $PKG_BUILD_DIR/rpm/",
@@ -592,13 +605,11 @@ def genTasks = { target ->
     }
     def final BIGTOP_BASE_VERSION = "${config.bigtop.base_version}"
 
-    def final PKG_NAME_SUFFIX = config.bigtop.components[target].rpm_pkg_suffix
-    def RPM_PKG_NAME_SUFFIX = PKG_NAME_SUFFIX
-    def GRADLE_PKG_NAME_SUFFIX = PKG_NAME_SUFFIX
-    if (!project.hasProperty("pkgSuffix") || !PKG_NAME_SUFFIX) {
-      RPM_PKG_NAME_SUFFIX = "%{nil}"
-      GRADLE_PKG_NAME_SUFFIX = ""
-    }
+
+    def suffixes = getPkgNameSuffix(config.bigtop.components[target], "rpm")
+    def RPM_PKG_NAME_SUFFIX =  suffixes.pkgNameSuffix
+    def GRADLE_PKG_NAME_SUFFIX = suffixes.gradlePkgNameSuffix
+
     def final BIGTOP_BUILD_STAMP = System.getenv('BIGTOP_BUILD_STAMP') ?:
             config.bigtop.components[target].version.release
     def final NAME = config.bigtop.components[target].name


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
While working on adding pkgSuffix and parent directory to BigTop DEBs, it became necessary to pass these two variables to the DEB rules file. Upon inspection, I found that the code logic for pkgSuffix and parent directory in RPMs shared similarities in several places and was repetitive. The DEB logic appeared similar too. Instead of following the previous practice that resulted in significant code duplication, I have refactored this part and conducted tests.

Below are some comments regarding the modifications added.

```
getPkgNameSuffix(component, type) {
    def originalSuffix = type.equalsIgnoreCase("deb") ? component.deb_pkg_suffix : component.rpm_pkg_suffix
    
#In RPMs, the Suffix is in the form of a macro and cannot be an empty string, as it would result in a "macro empty body" 
error. However, in DEB packaging, an empty string can be used.

    def defaultSuffix = type.equalsIgnoreCase("deb") ?  "" : "%{nil}"
    def pkgNameSuffix = project.hasProperty("pkgSuffix")? originalSuffix : defaultSuffix
    #The gradlePkgNameSuffix is solely used for concatenating package names, thus it must be empty if the originalSuffix does not exist.
    def gradlePkgNameSuffix = pkgNameSuffix == defaultSuffix ? "" : pkgNameSuffix

    return [pkgNameSuffix: pkgNameSuffix, gradlePkgNameSuffix: gradlePkgNameSuffix]
}
def getParentDir(bigtopBaseVersion, type) {
    #In RPMs, the Suffix is in the form of a macro and cannot be an empty string, as it would result in a "macro empty body" error. However, in DEB packaging, an empty string can be used.
    def defaultParentDirValue = type.equalsIgnoreCase("deb") ? "" : "%{nil}"
    def parentDir = project.hasProperty("parentDir") ? project.property('parentDir') : defaultParentDirValue
    if (parentDir && parentDir != "%{nil}") {
        parentDir = "${parentDir}/${bigtopBaseVersion}"
    }
    return parentDir

```

### How was this patch tested?
manual test and smoke test
test without suffix
. /etc/profile.d/bigtop.sh;./gradlew zookeeper-clean zookeeper-pkg  -PbuildThreads=2C repo 
![image](https://github.com/apache/bigtop/assets/18082602/d58db023-ac9c-44b8-bce4-9565b7fd8eda)

smoke test
./docker-hadoop.sh -d -dcp -C config_rockylinux-8.yaml -F docker-compose-cgroupv2.yml -G -L -k zookeeper -s zookeeper -c 1
![image](https://github.com/apache/bigtop/assets/18082602/1795cf62-a825-4472-a29b-2f99594a7bf5)



test with suffix 
. /etc/profile.d/bigtop.sh;./gradlew zookeeper-clean zookeeper-pkg -PparentDir=/usr/bigtop -PpkgSuffix -PbuildThreads=2C repo 
![image](https://github.com/apache/bigtop/assets/18082602/34dc6750-2457-4288-9314-888715059bc6)
![image](https://github.com/apache/bigtop/assets/18082602/307e126c-04d2-4c17-8544-64fe0b39c64c)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/