### PR TITLE
BIGTOP-4078: fix the solr smoketest failed in debian 11

### DIFF
--- a/bigtop-tests/smoke-tests/solr/build.gradle
+++ b/bigtop-tests/smoke-tests/solr/build.gradle
@@ -48,16 +48,10 @@ def delete_collection() {
 
 def clean() {
   if (file("/tmp/smoke_data").exists()) {
-    if (file("/usr/bin/rm").exists()) {
-      exec {
-        executable "/usr/bin/rm"
-        args "-rf", "/tmp/smoke_data"
-       }
-    }else{
-      exec {
-        executable "/bin/rm"
-        args "-rf", "/tmp/smoke_data"
-      }
+    String rmCmd = file("/usr/bin/rm").exists() ? "/usr/bin/rm" : "/bin/rm"
+    exec {
+      executable rmCmd
+      args "-rf", "/tmp/smoke_data"
     }
   }
 }

--- a/bigtop-tests/smoke-tests/solr/build.gradle
+++ b/bigtop-tests/smoke-tests/solr/build.gradle
@@ -48,9 +48,16 @@ def delete_collection() {
 
 def clean() {
   if (file("/tmp/smoke_data").exists()) {
-    exec {
-      executable "/usr/bin/rm"
-      args "-rf", "/tmp/smoke_data"
+    if (file("/usr/bin/rm").exists()) {
+      exec {
+        executable "/usr/bin/rm"
+        args "-rf", "/tmp/smoke_data"
+       }
+    }else{
+      exec {
+        executable "/bin/rm"
+        args "-rf", "/tmp/smoke_data"
+      }
     }
   }
 }

--- a/provisioner/utils/setup-env-debian.sh
+++ b/provisioner/utils/setup-env-debian.sh
@@ -43,3 +43,9 @@ else
     echo "local apt = $enable_local_repo ; NOT Enabling local apt. Packages will be pulled from remote..."
 fi
 
+# BIGTOP-4078 fix the solr smoketest need rm command
+. /etc/os-release
+OS="$ID"
+if [ "${OS}" == "debian" ]; then
+    ln -s /bin/rm /usr/bin/rm
+fi

--- a/provisioner/utils/setup-env-debian.sh
+++ b/provisioner/utils/setup-env-debian.sh
@@ -42,10 +42,3 @@ else
     apt-get install -y apt-transport-https gnupg
     echo "local apt = $enable_local_repo ; NOT Enabling local apt. Packages will be pulled from remote..."
 fi
-
-# BIGTOP-4078 fix the solr smoketest need rm command
-. /etc/os-release
-OS="$ID"
-if [ "${OS}" == "debian" ]; then
-    ln -s /bin/rm /usr/bin/rm
-fi


### PR DESCRIPTION
The test cmd: ./docker -d -c 3 -s solr

The error log:
![image](https://github.com/apache/bigtop/assets/11262916/2efe23fb-db59-498f-bc0f-7c19270c80c5)

It need the _**rm**_ command in /usr/bin.

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-4078)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/