### PR TITLE
BIGTOP-4073: spark support python3 in rockylinux 9

### DIFF
--- a/bigtop-packages/src/rpm/spark/SPECS/spark.spec
+++ b/bigtop-packages/src/rpm/spark/SPECS/spark.spec
@@ -116,8 +116,9 @@ Server for Spark worker
 %package -n %{spark_pkg_name}-python
 Summary: Python client for Spark
 Group: Development/Libraries
+# BIGTOP-4073 rockylinux 8 use python2, rockylinux 9 use python3
 %if 0%{?rhel} >= 8 || 0%{?openEuler}
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} == 8
 Requires: %{spark_pkg_name}-core = %{version}-%{release}, python2
 %else
 Requires: %{spark_pkg_name}-core = %{version}-%{release}, python3


### PR DESCRIPTION

Spark smoketest need python3 in rockylinux9.

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-4073)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/