### PR TITLE
BIGTOP-4093. Avoid oepkgs for installing R on openEuler.

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -82,11 +82,6 @@ case ${ID}-${VERSION_ID} in
         ;;
     openEuler-*)
         dnf -y install hostname curl sudo unzip wget ruby ruby-devel vim systemd-devel findutils 'dnf-command(config-manager)' nc initscripts openeuler-lsb openssl-devel make gcc-c++ openEuler-rpm-config python3-pip python3-devel dbus
-        dnf config-manager --add-repo https://repo.oepkgs.net/openeuler/rpm/openEuler-22.03-LTS/extras/$HOSTTYPE
-        echo "gpgcheck=0" >> /etc/yum.repos.d/repo.oepkgs.net_openeuler_rpm_openEuler-22.03-LTS_extras_$HOSTTYPE.repo
-        sed -i "s|enabled=1|enabled=1 \npriority=10|g" /etc/yum.repos.d/openEuler.repo
-        dnf clean all
-        dnf makecache
         # openEuler ruby version is 3.X,so use puppet-7.22.0.
         gem install puppet:7.22.0 xmlrpc sync sys-filesystem
         puppet module install puppetlabs-stdlib --version 4.12.0

--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -49,34 +49,22 @@ class bigtop_toolchain::renv {
         ]
       }
     }
-    /openEuler/: {
-      $pkgs = [
-        "R",
-        "R-devel",
-      ]
-    }
   }
 
   #BIGTOP-3967: openEuler not support PowerPC currently.
   if ($operatingsystem == 'openEuler'){
     if ($architecture == "aarch64") {
-        $url = "https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-linux-arm64.tar.gz"
+        $pandocurl = "https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-linux-arm64.tar.gz"
         $pandoctar = "pandoc-2.19.2-linux-arm64.tar.gz"
     } else{
-        $url = "https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-linux-amd64.tar.gz"
+        $pandocurl = "https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-linux-amd64.tar.gz"
         $pandoctar = "pandoc-2.19.2-linux-amd64.tar.gz"
     }
 
     exec {"down_pandoc":
       cwd => "/usr/src",
-      command => "/usr/bin/wget $url && /bin/tar -xvzf $pandoctar && ln -s /usr/src/pandoc-2.19.2/bin/pandoc /usr/bin/pandoc",
+      command => "/usr/bin/wget $pandocurl && /bin/tar -xvzf $pandoctar && ln -s /usr/src/pandoc-2.19.2/bin/pandoc /usr/bin/pandoc",
     }
-  }
-
-
-  package { $pkgs:
-    ensure => installed,
-    before => [Exec["install_r_packages"]]
   }
 
 
@@ -85,14 +73,15 @@ class bigtop_toolchain::renv {
   #
   # Then Install required R packages dependency
   if (($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemmajrelease, '18.04') <= 0) or
-      ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') <= 0)) {
-    $url = "https://cran.r-project.org/src/base/R-3/"
+      ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') <= 0) or
+      ($operatingsystem == 'openEuler')) {
+    $rurl = "https://cran.r-project.org/src/base/R-3/"
     $rfile = "R-3.6.3.tar.gz"
     $rdir = "R-3.6.3"
 
     exec { "download_R":
       cwd  => "/usr/src",
-      command => "/usr/bin/wget $url/$rfile && mkdir -p $rdir && /bin/tar -xvzf $rfile -C $rdir --strip-components=1 && cd $rdir",
+      command => "/usr/bin/wget $rurl/$rfile && mkdir -p $rdir && /bin/tar -xvzf $rfile -C $rdir --strip-components=1 && cd $rdir",
       creates => "/usr/src/$rdir",
     }
     exec { "install_R":

--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ Properties:
   -Pmemory=[4g|8g|...]
   -Pnum_instances=[NUM_INSTANCES]
   -Pnexus=[NEXUS_URL] (NEXUS_URL is optional)
-  -POS=[centos-7|fedora-35|ubuntu-18.04|opensuse-42.3|openeuler-22.03-lts-sp1]
+  -POS=[centos-7|fedora-35|ubuntu-18.04|opensuse-42.3|openeuler-22.03]
   -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...]
   -Prepository=[REPO_URL]
   -Prun_smoke_tests (run test components defined in config file)
@@ -562,7 +562,7 @@ task "bigtop-puppet"(type:Exec,
     description: '''
 Build bigtop/puppet images
 Usage:
-  $ ./gradlew -POS=[centos-7|fedora-35|debian-11|ubuntu-18.04|opensuse-42.3|openeuler-22.03-lts-sp1] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-puppet
+  $ ./gradlew -POS=[centos-7|fedora-35|debian-11|ubuntu-18.04|opensuse-42.3|openeuler-22.03] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-puppet
 Example:
   $ ./gradlew -POS=debian-11 -Pprefix=3.0.0 bigtop-puppet
   The built image name: bigtop/puppet:3.0.0-debian-11
@@ -581,7 +581,7 @@ task "bigtop-slaves"(type:Exec,
     description: '''
 Build bigtop/slaves images
 Usage:
-  $ ./gradlew -POS=[centos-7|fedora-35|debian-11|ubuntu-18.04|opensuse-42.3|openeuler-22.03-lts-sp1] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-slaves
+  $ ./gradlew -POS=[centos-7|fedora-35|debian-11|ubuntu-18.04|opensuse-42.3|openeuler-22.03] -Pprefix=[trunk|1.2.1|1.2.0|1.1.0|...] bigtop-slaves
 Example:
   $ ./gradlew -POS=debian-11 -Pprefix=3.0.0 bigtop-slaves
   The built image name: bigtop/slaves:3.0.0-debian-11

--- a/provisioner/docker/config_openeuler-22.03.yaml
+++ b/provisioner/docker/config_openeuler-22.03.yaml
@@ -15,7 +15,7 @@
 
 docker:
         memory_limit: "4g"
-        image: "bigtop/puppet:trunk-openeuler-22.03-lts-sp1"
+        image: "bigtop/puppet:trunk-openeuler-22.03"
 
 repo: "http://repios.bigtop.apache.org/releases/3.2.0/openEuler/22.03/$basearch"
 distro: centos


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4093

This PR replace R packaged by oepkgs with R installed from source code. We do not need to be bound to 22.03 LTS SP1.

Since the manifest before BIGTOP-3967 did not work due to conflicting `$url` variables for pandoc an R, this PR fixed the part.

bigtop/slaves:openeuler-22.03 was successfully built with R installation and packaging of Spark succeeded in the image.

```
$ ./gradlew spark-pkg-ind -Pprefix=trunk -POS=openeuler-22.03 -Pdocker-run-option="--privileged"
```