### PR TITLE
BIGTOP-4096: Fix CVE Vulnerabilities in Hadoop Dependencies: common-compress and common-configuration2

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch11-HADOOP-19123-HADOOP-19114.diff
+++ b/bigtop-packages/src/common/hadoop/patch11-HADOOP-19123-HADOOP-19114.diff
@@ -1,0 +1,59 @@
+diff --git a/LICENSE-binary b/LICENSE-binary
+index 834eeb2625b5..02dd142cc14e 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -306,8 +306,8 @@ net.java.dev.jna:jna:5.2.0
+ net.minidev:accessors-smart:2.4.7
+ org.apache.avro:avro:1.7.7
+ org.apache.commons:commons-collections4:4.2
+-org.apache.commons:commons-compress:1.21
+-org.apache.commons:commons-configuration2:2.8.0
++org.apache.commons:commons-compress:1.26.1
++org.apache.commons:commons-configuration2:2.10.1
+ org.apache.commons:commons-csv:1.9.0
+ org.apache.commons:commons-digester:1.8.1
+ org.apache.commons:commons-lang3:3.12.0
+diff --git a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/src/main/java/org/apache/hadoop/mapred/uploader/FrameworkUploader.java b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/src/main/java/org/apache/hadoop/mapred/uploader/FrameworkUploader.java
+index 8509e829f489..baca9ac14513 100644
+--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/src/main/java/org/apache/hadoop/mapred/uploader/FrameworkUploader.java
++++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/src/main/java/org/apache/hadoop/mapred/uploader/FrameworkUploader.java
+@@ -22,7 +22,7 @@
+ import org.apache.commons.cli.HelpFormatter;
+ import org.apache.commons.cli.OptionBuilder;
+ import org.apache.commons.cli.Options;
+-import org.apache.commons.compress.archivers.ArchiveEntry;
++import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+ import org.apache.hadoop.conf.Configuration;
+ import org.apache.hadoop.fs.BlockLocation;
+@@ -335,7 +335,7 @@ void buildPackage()
+         LOG.info("Adding " + fullPath);
+         File file = new File(fullPath);
+         try (FileInputStream inputStream = new FileInputStream(file)) {
+-          ArchiveEntry entry = out.createArchiveEntry(file, file.getName());
++          TarArchiveEntry entry = out.createArchiveEntry(file, file.getName());
+           out.putArchiveEntry(entry);
+           IOUtils.copyBytes(inputStream, out, 1024 * 1024);
+           out.closeArchiveEntry();
+diff --git a/hadoop-project/pom.xml b/hadoop-project/pom.xml
+index f1ac43ed5b38..732a47f5bcb7 100644
+--- a/hadoop-project/pom.xml
++++ b/hadoop-project/pom.xml
+@@ -119,7 +119,7 @@
+     <commons-cli.version>1.2</commons-cli.version>
+     <commons-codec.version>1.15</commons-codec.version>
+     <commons-collections.version>3.2.2</commons-collections.version>
+-    <commons-compress.version>1.21</commons-compress.version>
++    <commons-compress.version>1.26.1</commons-compress.version>
+     <commons-csv.version>1.9.0</commons-csv.version>
+     <commons-io.version>2.8.0</commons-io.version>
+     <commons-lang3.version>3.12.0</commons-lang3.version>
+@@ -1200,7 +1200,7 @@
+       <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-configuration2</artifactId>
+-        <version>2.8.0</version>
++        <version>2.10.1</version>
+         <exclusions>
+           <exclusion>
+             <groupId>org.apache.commons</groupId>

--- a/bigtop-packages/src/common/hadoop/patch12-HADOOP-18916.diff
+++ b/bigtop-packages/src/common/hadoop/patch12-HADOOP-18916.diff
@@ -1,0 +1,37 @@
+diff --git a/hadoop-client-modules/hadoop-client-minicluster/pom.xml b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+index 2619603c0f87..9a9b0c126996 100644
+--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
++++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+@@ -763,6 +763,14 @@
+                       </excludes>
+                     </filter>
+ 
++                    <filter>
++                      <artifact>*:*</artifact>
++                      <excludes>
++                        <exclude>META-INF/versions/9/module-info.class</exclude>
++                        <exclude>META-INF/versions/11/module-info.class</exclude>
++                      </excludes>
++                    </filter>
++
+                     <!-- Mockito tries to include its own unrelocated copy of hamcrest. :( -->
+                     <filter>
+                       <artifact>org.mockito:mockito-core</artifact>
+diff --git a/hadoop-client-modules/hadoop-client-runtime/pom.xml b/hadoop-client-modules/hadoop-client-runtime/pom.xml
+index 440bbfcdc04a..933e68353c52 100644
+--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
++++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
+@@ -242,6 +242,13 @@
+                         <exclude>google/protobuf/**/*.proto</exclude>
+                       </excludes>
+                     </filter>
++                    <filter>
++                      <artifact>*:*</artifact>
++                      <excludes>
++                        <exclude>META-INF/versions/9/module-info.class</exclude>
++                        <exclude>META-INF/versions/11/module-info.class</exclude>
++                      </excludes>
++                    </filter>
+                     <filter>
+                       <artifact>com.fasterxml.jackson.*:*</artifact>
+                       <excludes>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

fix commons-configuration2 CVE
HADOOP-19123. Update to commons-configuration2 2.10.1 due to CVE #6661
https://github.com/apache/hadoop/pull/6661

fix commons-compress CVE
HADOOP-19114. Upgrade to commons-compress 1.26.1 due to CVEs. #6636
https://github.com/apache/hadoop/pull/6636/files

This PR is to resolve the compilation failure issue caused by the modification of a CVE.
HADOOP-18929. Exclude commons-compress module-info.class #6169
https://github.com/apache/hadoop/pull/6169

This PR aims to solve the inconvenience of having to exclude dependencies every time a modification is made, such as after modifying the two CVEs above, by excluding all of them.
HADOOP-18916. Exclude all module-info classes from uber jars (#6131) #6188
https://github.com/apache/hadoop/pull/6188



This is divided into two patches. The reason why the two CVEs were combined into one patch is that the code merged for the two CVEs is only separated by one line (LicenseBinary). After applying the first patch, the second patch would report a conflict. The modifications for HADOOP-18929 were reverted in HADOOP-18916, which adopted a better implementation, hence HADOOP-18916 is used.


### How was this patch tested?
manual test ,smoke test

tested on rocky8
./docker-hadoop.sh -d -dcp --create 3 --image bigtop/puppet:trunk-rockylinux-8 --docker-compose-plugin --memory 8g --repo file:///bigtop-home/output --disable-gpg-check --stack hdfs,yarn,mapreduce --smoke-tests hdfs,yarn,mapreduce
![image](https://github.com/apache/bigtop/assets/18082602/757579f7-6ef8-43ae-9610-853208613b37)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/