### PR TITLE
BIGTOP-4097. Fix missing R package resource in toolchain manifest.

### DIFF
--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -51,6 +51,11 @@ class bigtop_toolchain::renv {
     }
   }
 
+  package { $pkgs:
+    ensure => installed,
+    before => [Exec["install_r_packages"]]
+  }
+
   #BIGTOP-3967: openEuler not support PowerPC currently.
   if ($operatingsystem == 'openEuler'){
     if ($architecture == "aarch64") {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4097

R can not be installed on OS distributions other than openEuler due to missing package resource definition unintentionally removed by [BIGTOP-4093](https://issues.apache.org/jira/browse/BIGTOP-4093).