### PR TITLE
BIGTOP-4100: Set default python to python3 in bigtop deploy

### DIFF
--- a/bigtop-deploy/puppet/manifests/python.pp
+++ b/bigtop-deploy/puppet/manifests/python.pp
@@ -29,7 +29,7 @@ class python {
                     '8': {
                         exec { 'set-python3':
                           command => '/usr/sbin/update-alternatives --set python /usr/bin/python3',
-                          unless  => "/usr/sbin/update-alternatives --display python | grep  '/usr/bin/python3'",
+                          unless  => "/usr/sbin/update-alternatives --display python | grep  'link currently points to /usr/bin/python3'",
                           path    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
                         }
                     }

--- a/bigtop-deploy/puppet/manifests/python.pp
+++ b/bigtop-deploy/puppet/manifests/python.pp
@@ -14,66 +14,46 @@
 # limitations under the License.
 
 class python {
-
-    define set_python_alternatives($command) {
-        exec { $name:
-          command => $command,
-          unless  => "/usr/sbin/update-alternatives --display python | grep '/usr/bin/python3'",
-          path    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
-        }
-    }
-
-    define change_python_interpreter($file, $interpreter) {
-        file_line { "change_interpreter_in_${name}":
-          path  => $file,
-          line  => "#!${interpreter}",
-          match => '^#!.*python.*$',
-        }
-    }
-
     case $operatingsystem {
         /(?i:(centos|fedora|redhat|rocky))/: {
+            package { 'python3-devel':
+              ensure => 'present',
+            }
             if ($operatingsystem != 'Fedora') {
                 case $operatingsystemmajrelease {
                     '9': {
-                        package { 'python3-unversioned-command':
+                        package { 'python-unversioned-command':
                           ensure => 'present',
                         }
                     }
                     '8': {
-                        set_python_alternatives { 'set-python3':
+                        exec { 'set-python3':
                           command => '/usr/sbin/update-alternatives --set python /usr/bin/python3',
-                        }
-                    }
-                    '7': {
-                        change_python_interpreter { 'yum':
-                          file        => '/usr/bin/yum',
-                          interpreter => '/usr/bin/python2.7',
-                        }
-                        change_python_interpreter { 'urlgrabber-ext-down':
-                          file        => '/usr/libexec/urlgrabber-ext-down',
-                          interpreter => '/usr/bin/python2.7',
-                        }
-
-                        set_python_alternatives { 'install-python3':
-                          command => '/usr/sbin/update-alternatives --install /usr/bin/python python /usr/bin/python3 1',
+                          unless  => "/usr/sbin/update-alternatives --display python | grep  '/usr/bin/python3'",
+                          path    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
                         }
                     }
                 }
             }else {
-                set_python_alternatives { 'install-python3':
-                  command => '/usr/sbin/update-alternatives --install /usr/bin/python python /usr/bin/python3 1',
+                package { 'python-unversioned-command':
+                  ensure => 'present',
                 }
             }
         }
 
         /(Ubuntu|Debian)/: {
-            set_python_alternatives { 'install-python3-debian':
-              command => '/usr/sbin/update-alternatives --install /usr/bin/python python /usr/bin/python3 1',
+            package { 'python3-dev':
+              ensure => 'present',
+            }
+            package { 'python-is-python3':
+              ensure => 'present',
             }
         }
 
         /openEuler/: {
+            package { 'python3-devel':
+              ensure => 'present',
+            }
             package { 'python3-unversioned-command':
               ensure => 'present',
             }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Set default python to python3 in bigtop deploy

Since CentOS 7's yum depends on Python 2, it's necessary to replace the Python interpreter in yum with Python 2.7.

Rocky 8 comes with /usr/libexec/no-python, so only an update-alternatives --set is needed.

Starting from Red Hat 9, the python3-unversioned-command package is provided, thus only the installation of this package is required.


Setting Python3 as the default Python version across various operating systems:

1. **CentOS 7:**
   - Install Python 3 development package:
     ```
     yum install python3-devel
     ```
   - Set Python 3 as the default:
     ```
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1
     ```

2. **Rocky Linux 8:**
   - Installation:
     ```
     yum install python3-devel
     ```
   - Due to the presence of `/etc/alternatives/python -> /usr/libexec/no-python`, the command to set Python 3 as the default is:
     ```
     update-alternatives --set python /usr/bin/python3
     ```

3. **Rocky Linux 9:**
   - Installation commands:
     ```
     yum install python3-devel 
     yum install python-unversioned-command
     ```

4. **Fedora 35 to Fedora 38:**
   - For all mentioned Fedora versions, the installation commands are:
     ```
     yum install python3-devel
     yum install python-unversioned-command
     ```

5. **Debian 10 (Buster):**
   - Installation commands:
     ```
     apt install python3-dev
     apt install python-is-python3
     ```

6. **Debian 11 (Bullseye):**
   - Installation commands:
     ```
     apt install python3-dev 
     apt install python-is-python3
     ```

7. **Ubuntu 20.04 (Focal Fossa)** and **Ubuntu 22.04 (Jammy Jellyfish):**
   - Installation commands for both versions:
     ```
     apt install python3-dev 
     apt install python-is-python3
     ```

**Results of Default Python Version Setting Across Operating Systems:**
- For CentOS 7 and 8, manual setting is required.
- CentOS 7 relies on Python 2 for yum, so it's necessary to replace Python within yum to Python 2.7.
- Rocky Linux 8 comes pre-configured with `/usr/libexec/no-python`, thus only requiring the `update-alternatives --set` command.
- Starting from Red Hat 9, the package `python-unversioned-command` is available, negating the need for additional settings beyond package installation.
  
- Testing revealed that Fedora versions 35 to 38 all include the `python-unversioned-command` package.
- Debian 10, Debian 11, Ubuntu 20.04, and Ubuntu 22.04 all include the `python-is-python3` package, facilitating the setting of Python 3 as the default version.

### How was this patch tested?

manual test by running puppet script
 
![image](https://github.com/apache/bigtop/assets/18082602/4601240f-112f-4d02-b645-22002983fa14)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/