### PR TITLE
BIGTOP-4051: Drop python dependency in Phoenix Package

### DIFF
--- a/bigtop-packages/src/deb/phoenix/control
+++ b/bigtop-packages/src/deb/phoenix/control
@@ -23,7 +23,7 @@ Homepage: http://phoenix.apache.org
 
 Package: phoenix
 Architecture: all
-Depends: bigtop-utils (>= 0.7),  python (>= 2.6) | python2 (>= 2.6)
+Depends: bigtop-utils (>= 0.7),  python (>= 2.6) | python2 (>= 2.6) | python3
 Description: Phoenix is a SQL skin over HBase and client-embedded JDBC driver.
  Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
  The Phoenix query engine transforms an SQL query into one or more HBase scans,

--- a/bigtop-packages/src/deb/phoenix/control
+++ b/bigtop-packages/src/deb/phoenix/control
@@ -23,7 +23,7 @@ Homepage: http://phoenix.apache.org
 
 Package: phoenix
 Architecture: all
-Depends: bigtop-utils (>= 0.7),  python (>= 2.6) | python2 (>= 2.6) | python3
+Depends: bigtop-utils (>= 0.7)
 Description: Phoenix is a SQL skin over HBase and client-embedded JDBC driver.
  Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
  The Phoenix query engine transforms an SQL query into one or more HBase scans,

--- a/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
+++ b/bigtop-packages/src/rpm/phoenix/SPECS/phoenix.spec
@@ -94,12 +94,6 @@ Requires: bsh-utils
 Requires: coreutils
 %endif
 
-%if  0%{?rhel} >= 8 || 0%{?openEuler}
-Requires: python3
-%else
-Requires: python
-%endif
-
 %description
 Phoenix is a SQL skin over HBase, delivered as a client-embedded JDBC driver.
 The Phoenix query engine transforms an SQL query into one or more HBase scans,
@@ -129,10 +123,6 @@ getent passwd phoenix >/dev/null || useradd -c "Phoenix" -s /sbin/nologin -g pho
 
 %post
 %{alternatives_cmd} --install %{etc_phoenix_conf} %{name}-conf %{etc_phoenix_conf_dist} 30
-
-%if  0%{?rhel} >= 8
-%{alternatives_cmd} --set python /usr/bin/python3
-%endif
 
 
 %preun


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Drop python dependency in Phoenix Package

### How was this patch tested?

smoke test in rocky 8
test cmd: 
```
./docker-hadoop.sh -d -dcp --create 3 --image bigtop/puppet:trunk-rockylinux-8 --docker-compose-plugin --memory 8g --repo file:///bigtop-home/output --disable-gpg-check --stack hdfs,hbase,phoenix --smoke-tests phoenix 
```
![image](https://github.com/apache/bigtop/assets/18082602/3ce09e24-3623-4372-ac97-36f507aab018)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/