### PR TITLE
BIGTOP-4101. Fix undefined variable in toolchain manifest for openEuler.

### DIFF
--- a/bigtop_toolchain/manifests/renv.pp
+++ b/bigtop_toolchain/manifests/renv.pp
@@ -49,6 +49,9 @@ class bigtop_toolchain::renv {
         ]
       }
     }
+    default: {
+      $pkgs = []
+    }
   }
 
   package { $pkgs:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4101

[BIGTOP-4097](https://issues.apache.org/jira/browse/BIGTOP-4097) broke the manifest in openEuler due to missing `pkgs` variable.