### PR TITLE
BIGTOP-4102. Fix failure of toolchain manifest on Fedora 38 due to unresolved facter variable

### DIFF
--- a/bigtop-deploy/puppet/hiera.yaml
+++ b/bigtop-deploy/puppet/hiera.yaml
@@ -3,6 +3,5 @@
   :datadir: /etc/puppet/hieradata
 :hierarchy:
   - site
-  - "bigtop/%{hadoop_hiera_ha_path}"
   - bigtop/cluster
   - bigtop/repo

--- a/bigtop-deploy/puppet/hieradata/bigtop/ha.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/ha.yaml
@@ -1,7 +1,0 @@
----
-hadoop::common_hdfs::ha: "manual"
-hadoop::common_hdfs::hadoop_namenode_host:
-  - "%{hiera('bigtop::hadoop_head_node')}"
-  - "%{hiera('bigtop::standby_head_node')}"
-hadoop::common_hdfs::hadoop_ha_nameservice_id: "ha-nn-uri"
-hadoop_cluster_node::hadoop_namenode_uri: "hdfs://%{hiera('hadoop_ha_nameservice_id')}:8020"

--- a/bigtop-deploy/puppet/hieradata/bigtop/noha.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/noha.yaml
@@ -1,2 +1,0 @@
----
-# all done via defaults

--- a/bigtop-deploy/puppet/hieradata/site.yaml
+++ b/bigtop-deploy/puppet/hieradata/site.yaml
@@ -11,6 +11,12 @@ hadoop::hadoop_storage_dirs:
   - /data/3
   - /data/4
 
+#hadoop::common_hdfs::ha: "auto"
+#hadoop::common_hdfs::hadoop_namenode_host:
+#  - "%{hiera('bigtop::hadoop_head_node')}"
+#  - "%{hiera('bigtop::standby_head_node')}"
+#hadoop_cluster_node::hadoop_namenode_uri: "hdfs://ha-nn-uri:8020"
+
 #hadoop_cluster_node::cluster_components:
 #  - alluxio
 #  - flink

--- a/bigtop-deploy/puppet/manifests/cluster.pp
+++ b/bigtop-deploy/puppet/manifests/cluster.pp
@@ -154,13 +154,6 @@ class hadoop_cluster_node (
     ""      => false,
     default => true,
   }
-
-  # look into alternate hiera datasources configured using this path in
-  # hiera.yaml
-  $hadoop_hiera_ha_path = $ha_enabled ? {
-    false => "noha",
-    true  => "ha",
-  }
 }
 
 class node_with_roles ($roles = hiera("bigtop::roles")) inherits hadoop_cluster_node {

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -29,6 +29,7 @@ case ${ID}-${VERSION_ID} in
         # into /usr/share/puppet/modules, but it's not recognized as the default module path.
         # So we install that module in the same way as CentOS 7.
         puppet module install puppetlabs-stdlib --version 4.12.0
+        echo 'include_legacy_facts=true' >> /etc/puppet/puppet.conf
         ;;
     ubuntu-18.04|ubuntu-22.04)
         apt-get update


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4102

```
[91m[1;31mError: Evaluation Error: Unknown variable: '::operatingsystem'. (file: /etc/puppet/code/modules/bigtop_toolchain/manifests/jdk11.pp, line: 17, column: 8) on node bigtop-slave-arm5.novalocal[0m
[0mThe command '/bin/sh -c if [ -f ~/.bash_profile ]; then . ~/.bash_profile; fi &&     dnf clean all && dnf updateinfo &&     puppet apply -e "include bigtop_toolchain::installer" || if [ $? -ne 2 ]; then exit 1; fi' returned a non-zero code: 1
```

[Legacy facts are disabled by default in Puppet 8](https://www.puppet.com/docs/pe/2023.5/osp/upgrading-from-puppet7-to-puppet8.html#upgrading-from-puppet7-to-puppet8-legacy-facts-deprecation). include_legacy_facts=true in puppet.conf will re-enable it.

This PR is quick fix only targeting fedora-38. I filed [BIGTOP-4103](https://issues.apache.org/jira/browse/BIGTOP-4103) as a follow-up.