### PR TITLE
BIGTOP-4105: Build fails when '-DpkgSuffix' is specified and '(rpm|deb)_pkg_suffix' is not specified in bigtop.bom

### DIFF
--- a/packages.gradle
+++ b/packages.gradle
@@ -102,7 +102,7 @@ def isValidMavenBuildThreads(threads) {
 }
 
 def getPkgNameSuffix(component, type) {
-    def originalSuffix = type.equalsIgnoreCase("deb") ? component.deb_pkg_suffix : component.rpm_pkg_suffix
+    def originalSuffix = type.equalsIgnoreCase("deb") ? component.deb_pkg_suffix?:"" : component.rpm_pkg_suffix?:"%{nil}"
     def defaultSuffix = type.equalsIgnoreCase("deb") ?  "" : "%{nil}"
     def pkgNameSuffix = project.hasProperty("pkgSuffix")? originalSuffix : defaultSuffix
     def gradlePkgNameSuffix = pkgNameSuffix == defaultSuffix ? "" : pkgNameSuffix

--- a/packages.gradle
+++ b/packages.gradle
@@ -102,7 +102,9 @@ def isValidMavenBuildThreads(threads) {
 }
 
 def getPkgNameSuffix(component, type) {
-    def originalSuffix = type.equalsIgnoreCase("deb") ? component.deb_pkg_suffix?:"" : component.rpm_pkg_suffix?:"%{nil}"
+    def originalSuffix = type.equalsIgnoreCase("deb") ?
+            component.deb_pkg_suffix ?: "" :
+            component.rpm_pkg_suffix ?: "%{nil}"
     def defaultSuffix = type.equalsIgnoreCase("deb") ?  "" : "%{nil}"
     def pkgNameSuffix = project.hasProperty("pkgSuffix")? originalSuffix : defaultSuffix
     def gradlePkgNameSuffix = pkgNameSuffix == defaultSuffix ? "" : pkgNameSuffix


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Build fails when '-DpkgSuffix' is specified when '(rpm|deb)_pkg_suffix'  is not specified in bigtop.bom
[Issue](https://issues.apache.org/jira/browse/BIGTOP-4088)/https://github.com/apache/bigtop/pull/1254 introduced this bug by not checking whether the '(rpm|deb)_pkg_suffix' has been specified in bigtop.bom.
When config '(rpm|deb)_pkg_suffix'  is not specified, groovy returns an empty map  '[:]' which breaks the build. 

``` bash
./gradlew clean bigtop-groovy-pkg bigtop-jsvc-pkg bigtop-select-pkg bigtop-utils-pkg  -Dbuildwithdeps=true -PparentDir=/usr/bigtop -PpkgSuffix
........
Task :bigtop-groovy-srpm
Wrote: /home/mathew/Projects/bigtop/build/bigtop-groovy/rpm/SRPMS/bigtop-groovy-2.5.4-1.el8.src.rpm> Task :bigtop-utils-srpm
Wrote: /home/mathew/Projects/bigtop/build/bigtop-utils/rpm/SRPMS/bigtop-utils-3.3.0-1.el8.src.rpm> Task :bigtop-utils-rpm FAILED
error: cannot open /home/mathew/Projects/bigtop/output/bigtop-utils/bigtop-utils[:]-3.3.0-1.el8.src.rpm: No such file or directoryFAILURE: Build failed with an exception.
```

Sample code to illustrate the source of bug. Below groovy sample is how packages.gradle access project config in bigtop.bom

``` groovy
def bom = """bigtop {
    name = "ambari"
}"""

def conf = new ConfigSlurper().parse(bom)

println('Output')
println(conf.bigtop.name)
println(conf.bigtop.not_exist) 

// Output
// ambari
// [:]
```
### How was this patch tested?
``` bash
./gradlew clean bigtop-groovy-pkg bigtop-jsvc-pkg bigtop-select-pkg bigtop-utils-pkg  -Dbuildwithdeps=true -PparentDir=/usr/bigtop -PpkgSuffix

Executing(--clean): /bin/sh -e /var/tmp/rpm-tmp.ZXB60E
+ umask 022
+ cd /home/mathew/Projects/bigtop/build/bigtop-select/rpm//BUILD
+ rm -rf bigtop-select-3.3.0
+ exit 0

BUILD SUCCESSFUL in 8s
48 actionable tasks: 24 executed, 24 up-to-date

```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/