### PR TITLE
BIGTOP-4108. Add support for openEuler to the manifest of bigtop-deploy to set up Bigtop Yum repository

### DIFF
--- a/bigtop-deploy/puppet/manifests/bigtop_repo.pp
+++ b/bigtop-deploy/puppet/manifests/bigtop_repo.pp
@@ -20,7 +20,7 @@ class bigtop_repo {
   $default_repo = "http://repos.bigtop.apache.org/releases/${bigtop_repo_default_version}/${lower_os}/${operatingsystemmajrelease}/${architecture}"
 
   case $::operatingsystem {
-    /(OracleLinux|Amazon|CentOS|Fedora|RedHat|Rocky)/: {
+    /(OracleLinux|Amazon|CentOS|Fedora|RedHat|Rocky|openEuler)/: {
       $baseurls_array = any2array(hiera("bigtop::bigtop_repo_uri", $default_repo))
       each($baseurls_array) |$count, $baseurl| {
         notify { "Baseurl: $baseurl": }

--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -86,6 +86,7 @@ case ${ID}-${VERSION_ID} in
         # openEuler ruby version is 3.X,so use puppet-7.22.0.
         gem install puppet:7.22.0 xmlrpc sync sys-filesystem
         puppet module install puppetlabs-stdlib --version 4.12.0
+        puppet module install puppetlabs-yumrepo_core --version 2.1.0
         #openEuler dnf defaulted is not use module,so comment module in puppet-7.22.0
         sed -i "91c execute([command(:dnf), 'install', '-d', '0', '-e', self.class.error_level, '-y', args])" /usr/local/share/gems/gems/puppet-7.22.0/lib/puppet/provider/package/dnfmodule.rb
         ;;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4108

* Currently openEuler is not supported in [the bigtop_repo class for setting up repository of Bigtop](https://github.com/apache/bigtop/blob/5355eac396d70e1c170195851ccbd9e3d62637ad/bigtop-deploy/puppet/manifests/bigtop_repo.pp#L22-L23).
* The manifests is required for the [CI job for release process](https://ci.bigtop.apache.org/job/Bigtop-3.3.0-smoke-tests/).
* [yumrepo is a part of the module hosted in forge](https://forge.puppet.com/modules/puppetlabs/yumrepo_core/readme) in recent puppet. It must be installed by `puppet module` since puppet is installed by gem instead of RPM in openEuler.