### PR TITLE
BIGTOP-4111. Fix compilation error of GPDB on CentOS 7 aarch64.

### DIFF
--- a/bigtop-packages/src/common/gpdb/do-component-build
+++ b/bigtop-packages/src/common/gpdb/do-component-build
@@ -18,4 +18,10 @@ set -ex
 
 rm -f gpdb
 
-PYTHON=/usr/bin/python3 make MAKELEVEL=0
+. /etc/os-release
+
+if [[ ${HOSTTYPE} = "aarch64" && ${ID} = "centos" && ${VERSION_ID} = "7" ]] ; then
+  BUILD_ENV="scl enable devtoolset-9 -- "
+fi
+
+${BUILD_ENV} make MAKELEVEL=0 PYTHON=/usr/bin/python3

--- a/bigtop-packages/src/common/gpdb/do-component-configure
+++ b/bigtop-packages/src/common/gpdb/do-component-configure
@@ -16,4 +16,10 @@
 
 set -ex
 
-PYTHON=/usr/bin/python3 ./configure --prefix=$1 --with-python --with-libxml --with-gssapi --disable-orca CFLAGS='-fcommon -Wno-implicit-fallthrough'
+. /etc/os-release
+
+if [[ ${HOSTTYPE} = "aarch64" && ${ID} = "centos" && ${VERSION_ID} = "7" ]] ; then
+  BUILD_ENV="scl enable devtoolset-9 -- "
+fi
+
+${BUILD_ENV} ./configure --prefix=$1 --with-python --with-libxml --with-gssapi --disable-orca PYTHON=/usr/bin/python3 CFLAGS='-fcommon -Wno-implicit-fallthrough'

--- a/bigtop-packages/src/common/gpdb/install_gpdb.sh
+++ b/bigtop-packages/src/common/gpdb/install_gpdb.sh
@@ -16,4 +16,10 @@
 
 set -ex
 
-PYTHON=/usr/bin/python3 make install DESTDIR=$1
+. /etc/os-release
+
+if [[ ${HOSTTYPE} = "aarch64" && ${ID} = "centos" && ${VERSION_ID} = "7" ]] ; then
+  BUILD_ENV="scl enable devtoolset-9 -- "
+fi
+
+${BUILD_ENV} make install DESTDIR=$1 PYTHON=/usr/bin/python3


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4111

```
gcc -std=gnu99 -Wall -Wmissing-prototypes -Wpointer-arith -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-but-set-variable -fcommon -Wno-implicit-fallthrough  -Werror=uninitialized -Werror=implicit-function-declaration -I. -I. -I../../../../src/interfaces/libpq -I../../../../src/include   -D_GNU_SOURCE -I/usr/include/libxml2   -c -o timestamp.o timestamp.c
timestamp.c: In function 'interval_div_internal':
timestamp.c:2753:21: error: incompatible types when initializing type 'TimeOffset' using type 'INT128'
  TimeOffset span1 = interval_cmp_value(interval1);
                     ^
timestamp.c:2754:21: error: incompatible types when initializing type 'TimeOffset' using type 'INT128'
  TimeOffset span2 = interval_cmp_value(interval2);
                     ^
timestamp.c: At top level:
cc1: warning: unrecognized command line option "-Wno-implicit-fallthrough" [enabled by default]
make: *** [timestamp.o] Error 1
make: *** [adt-recursive] Error 2
make: *** [utils-recursive] Error 2
make: *** [all-backend-recurse] Error 2
make: *** [all-src-recurse] Error 2
error: Bad exit status from /var/tmp/rpm-tmp.rsGOoz (%build)
```

The cause [seems to be GCC bug on aarch64](https://www.postgresql.org/message-id/5487.1516294381%40sss.pgh.pa.us). While passing ` -Wmaybe-uninitialized -O1` as CFLAGS fixes this, using new gcc is better solution since [our toolchain already has GCC 9 of devtoolset on CentOS 7 aarch6](https://github.com/apache/bigtop/blob/e63d43512b7ad1da3e5467e2e00a35db6e23783e/bigtop_toolchain/manifests/packages.pp#L331-L339)