### PR TITLE
BIGTOP-4053. Remove Python as Spark Installation Dependency

### DIFF
--- a/bigtop-packages/src/deb/spark/control
+++ b/bigtop-packages/src/deb/spark/control
@@ -45,7 +45,7 @@ Description: Server for Spark worker
 
 Package: spark-python
 Architecture: all
-Depends: spark-core (= ${source:Version}), python | python2
+Depends: spark-core (= ${source:Version})
 Description: Python client for Spark
  Includes PySpark, an interactive Python shell for Spark, and related libraries
 

--- a/bigtop-packages/src/rpm/spark/SPECS/spark.spec
+++ b/bigtop-packages/src/rpm/spark/SPECS/spark.spec
@@ -116,16 +116,9 @@ Server for Spark worker
 %package -n %{spark_pkg_name}-python
 Summary: Python client for Spark
 Group: Development/Libraries
-# BIGTOP-4073 rockylinux 8 use python2, rockylinux 9 use python3
-%if 0%{?rhel} >= 8 || 0%{?openEuler}
-%if 0%{?rhel} == 8
-Requires: %{spark_pkg_name}-core = %{version}-%{release}, python2
-%else
-Requires: %{spark_pkg_name}-core = %{version}-%{release}, python3
-%endif
-%else
-Requires: %{spark_pkg_name}-core = %{version}-%{release}, python
-%endif
+# No python dependency. You might need to install Python by yourself.
+# See BIGTOP-4052 for details.
+Requires: %{spark_pkg_name}-core = %{version}-%{release}
 
 %description -n %{spark_pkg_name}-python
 Includes PySpark, an interactive Python shell for Spark, and related libraries

--- a/bigtop-tests/test-artifacts/spark/src/main/groovy/org/apache/bigtop/itest/spark/TestSparkExample.groovy
+++ b/bigtop-tests/test-artifacts/spark/src/main/groovy/org/apache/bigtop/itest/spark/TestSparkExample.groovy
@@ -66,14 +66,4 @@ public class TestSparkExample {
     }
   }
 
-  @Test
-  void testSparkPythonExample() {
-    def pyExamples = ["pi.py"];
-    pyExamples.each() {
-      sh.exec("cd ${SPARK_HOME} && ./bin/spark-submit --master ${SPARK_MASTER} " + SPARK_EXAMPLES_DIR + "/src/main/python/${it}");
-      logError(sh);
-      assertTrue("Running Spark Python example {it} failed", sh.getRet() == 0);
-    }
-  }
-
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4053

 As discussed in the JIRA issue, I have removed the python-releated spark tests in this PR.
Please feel free to comment on that.

### How was this patch tested?

On rocky-8
```
[rocky@ip-172-31-4-21 noarch]$ rpm -qp spark-python-3.3.4-1.el8.noarch.rpm --requires
/bin/bash
/usr/bin/env
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
spark-core = 3.3.4-1.el8
```

On Ubuntu-22.04
```
ubuntu@ip-172-31-12-120:~$ dpkg -I ./bigtop/output/spark/spark-python_3.3.4-1_all.deb
 new Debian package, version 2.0.
 size 3328910 bytes: control archive=12048 bytes.
     350 bytes,    12 lines      control
   43376 bytes,   474 lines      md5sums
 Package: spark-python
 Source: spark
 Version: 3.3.4-1
 Architecture: all
 Maintainer: Bigtop <dev@bigtop.apache.org>
 Installed-Size: 13506
 Depends: spark-core (= 3.3.4-1)
 Section: misc
 Priority: extra
 Homepage: http://spark.apache.org/
 Description: Python client for Spark
  Includes PySpark, an interactive Python shell for Spark, and related libraries
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/