### PR TITLE
BIGTOP-4112. Don't specify PYSPARK_PYTHON

### DIFF
--- a/bigtop-packages/src/common/spark/install_spark.sh
+++ b/bigtop-packages/src/common/spark/install_spark.sh
@@ -182,8 +182,6 @@ cat > $PREFIX/$BIN_DIR/pyspark <<EOF
 # Autodetect JAVA_HOME if not defined
 . /usr/lib/bigtop-utils/bigtop-detect-javahome
 
-export PYSPARK_PYTHON=python
-
 exec $LIB_DIR/bin/pyspark "\$@"
 EOF
 chmod 755 $PREFIX/$BIN_DIR/pyspark

--- a/bigtop-packages/src/rpm/spark/SPECS/spark.spec
+++ b/bigtop-packages/src/rpm/spark/SPECS/spark.spec
@@ -181,19 +181,6 @@ bash $RPM_SOURCE_DIR/do-component-build
 %__rm -rf $RPM_BUILD_ROOT
 %__install -d -m 0755 $RPM_BUILD_ROOT/%{initd_dir}/
 
-%if 0%{?rhel} >= 8
-PYSPARK_PYTHON=python2 bash $RPM_SOURCE_DIR/install_spark.sh \
-          --build-dir=`pwd`         \
-          --source-dir=$RPM_SOURCE_DIR \
-          --prefix=$RPM_BUILD_ROOT  \
-          --doc-dir=%{doc_spark} \
-          --lib-dir=%{usr_lib_spark} \
-          --var-dir=%{var_lib_spark} \
-          --bin-dir=%{bin_dir} \
-          --man-dir=%{man_dir} \
-          --etc-default=%{etc_default} \
-          --etc-spark=%{etc_spark}
-%else
 bash $RPM_SOURCE_DIR/install_spark.sh \
           --build-dir=`pwd`         \
           --source-dir=$RPM_SOURCE_DIR \
@@ -205,7 +192,6 @@ bash $RPM_SOURCE_DIR/install_spark.sh \
           --man-dir=%{man_dir} \
           --etc-default=%{etc_default} \
           --etc-spark=%{etc_spark}
-%endif
 
 %__rm -f $RPM_BUILD_ROOT/%{usr_lib_spark}/jars/hadoop-*.jar
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4112

We don't have to specify `PYSPARK_PYTHON` in `/usr/bin/pyspark` as it just execute `exec /usr/lib/spark/bin/pyspark` and
`/usr/lib/spark/bin/pyspark` handles `PYSPARK_PYTHON` like this.

https://github.com/apache/spark/blob/v3.3.4/bin/pyspark#L41-L43

```
if [[ -z "$PYSPARK_PYTHON" ]]; then
  PYSPARK_PYTHON=python3
fi
```

### How was this patch tested?

On rocky-8
```
$ ./gradlew  spark-clean spark-pkg
$ (install built rpm packages)
$ pyspark
[GCC 8.5.0 20210514 (Red Hat 8.5.0-20)] on linux
Type "help", "copyright", "credits" or "license" for more information.
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/lib/spark/jars/log4j-slf4j-impl-2.17.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/lib/hadoop/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
24/05/27 14:56:57 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.3.4
      /_/

Using Python version 3.6.8 (default, Jan 15 2024 23:09:02)
Spark context Web UI available at http://ip-172-31-4-21.ap-northeast-1.compute.internal:4040
Spark context available as 'sc' (master = local[*], app id = local-1716821818171).
SparkSession available as 'spark'.
>>>
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/