### PR TITLE
BIGTOP-4114. Fix build failure of Hadoop and Alluxio due to node-gyp error on rockylinux-8 and fedora-38 aarch64.

### DIFF
--- a/bigtop_toolchain/manifests/installer.pp
+++ b/bigtop_toolchain/manifests/installer.pp
@@ -21,6 +21,7 @@ class bigtop_toolchain::installer {
   include bigtop_toolchain::gradle
   include bigtop_toolchain::protobuf
   include bigtop_toolchain::packages
+  include bigtop_toolchain::python
   include bigtop_toolchain::env
   include bigtop_toolchain::user
   include bigtop_toolchain::renv

--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -68,7 +68,6 @@ class bigtop_toolchain::packages {
         "perl-Digest-SHA",
         "nasm",
         "yasm",
-        "python3-devel"
       ]
 
       if ($operatingsystem == 'Fedora') {
@@ -104,8 +103,6 @@ class bigtop_toolchain::packages {
         "rpm-build",
         "pkg-config",
         "gmp-devel",
-        "python3-devel",
-        "python3-pip",
         "libxml2-devel",
         "libxslt-devel",
         "cyrus-sasl-devel",
@@ -216,7 +213,6 @@ class bigtop_toolchain::packages {
        "krb5-devel",
        "net-tools",
        "perl-Digest-SHA",
-       "python3-devel",
        "libtirpc-devel",
        "libgit2-devel",
        "libgit2-glib-devel",
@@ -263,7 +259,6 @@ class bigtop_toolchain::packages {
         "devscripts",
         "build-essential",
         "dh-make",
-        "dh-python",
         "libfuse2",
         "libjansi-java",
         "libxml2-dev",
@@ -290,9 +285,7 @@ class bigtop_toolchain::packages {
         "libcurl4-gnutls-dev",
         "bison",
         "flex",
-        "python-setuptools",
         "libffi-dev",
-        "python3-dev",
         "nasm",
         "yasm"
       ]
@@ -357,27 +350,7 @@ class bigtop_toolchain::packages {
   }
 
 
-  # BIGTOP-3364: Failed to install setuptools by pip/pip2
-  # on Ubuntu-16.04/18.04 and centos-7.
-  # From https://packaging.python.org/tutorials/installing-packages/#requirements-for-installing-packages,
-  # it suggests to leverage python3/pip3 to install setuptools.
-  #
-  # "provider => 'pip3'" is not available for puppet 3.8.5,
-  #  Workaround: Exec {pip3 install setuptools} directly insead of Package{}.
-  package { 'python3-pip':
-    ensure => installed
-  }
-
-  exec { "Setuptools Installation":
-    command => "/usr/bin/pip3 install -q --upgrade setuptools",
-  }
-
-  exec { "flake8 and whell Installation":
-    command => "/usr/bin/pip3 freeze --all; /usr/bin/pip3 --version; /usr/bin/pip3 install -q flake8 wheel",
-  }
-
   if $osfamily == 'RedHat' {
-
     if ! (($operatingsystem == 'Fedora' and versioncmp($operatingsystemmajrelease, '31') >= 0) or
       ($operatingsystem != 'Fedora' and versioncmp($operatingsystemmajrelease, '8') >= 0)) {
       file { '/usr/bin/cmake':
@@ -385,17 +358,5 @@ class bigtop_toolchain::packages {
         target => '/usr/bin/cmake3',
       }
     }
-
-    # The rpm-build package had installed brp-python-bytecompile
-    # just under /usr/lib/rpm until Fedora 34,
-    # but it seems to have been removed in Fedora 35.
-    # So we manually create a symlink instead.
-    if ($operatingsystem == 'Fedora' and versioncmp($operatingsystemmajrelease, '35') >= 0) {
-      file { '/usr/lib/rpm/brp-python-bytecompile':
-        ensure => 'link',
-        target => '/usr/lib/rpm/redhat/brp-python-bytecompile',
-      }
-    }
   }
-
 }

--- a/bigtop_toolchain/manifests/python.pp
+++ b/bigtop_toolchain/manifests/python.pp
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class bigtop_toolchain::python {
+  case $operatingsystem{
+    /(?i:(centos|fedora|redhat|rocky|sles|opensuse|openeuler))/: {
+      package { 'python3-devel' :
+        ensure => present
+      }
+    }
+    /(Ubuntu|Debian)/: {
+      package { 'dh-python' :
+        ensure => present
+      }
+      package { 'python-setuptools' :
+        ensure => present
+      }
+      package { 'python3-dev' :
+        ensure => present
+      }
+    }
+  }
+
+  if ($architecture in ['aarch64']) {
+    case $operatingsystem{
+      /(?i:(fedora|ubuntu|debian))/: {
+        package { 'python2' :
+          ensure => present
+        }
+      }
+      /(?i:(centos|redhat|rocky))/: {
+        if (versioncmp($operatingsystemmajrelease, '8') == 0) {
+          package { 'python2' :
+            ensure => present
+          }
+        }
+      }
+    }
+  }
+
+  # BIGTOP-3364: Failed to install setuptools by pip/pip2
+  # on Ubuntu-16.04/18.04 and centos-7.
+  # From https://packaging.python.org/tutorials/installing-packages/#requirements-for-installing-packages,
+  # it suggests to leverage python3/pip3 to install setuptools.
+  #
+  # "provider => 'pip3'" is not available for puppet 3.8.5,
+  #  Workaround: Exec {pip3 install setuptools} directly insead of Package{}.
+  package { 'python3-pip':
+    ensure => installed
+  }
+
+  exec { "Setuptools Installation":
+    command => "/usr/bin/pip3 install -q --upgrade setuptools",
+    require => Package['python3-pip']
+  }
+
+  exec { "flake8 and whell Installation":
+    command => "/usr/bin/pip3 freeze --all; /usr/bin/pip3 --version; /usr/bin/pip3 install -q flake8 wheel",
+    require => Package['python3-pip']
+  }
+
+  # The rpm-build package had installed brp-python-bytecompile
+  # just under /usr/lib/rpm until Fedora 34,
+  # but it seems to have been removed in Fedora 35.
+  # So we manually create a symlink instead.
+  if ($operatingsystem == 'Fedora' and versioncmp($operatingsystemmajrelease, '35') >= 0) {
+    file { '/usr/lib/rpm/brp-python-bytecompile':
+      ensure => 'link',
+      target => '/usr/lib/rpm/redhat/brp-python-bytecompile',
+    }
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4114

Unfortunately we seem to need python2 for rebuilding native libraries required for (old?) node-spss by node-gyp. `/usr/bin/python` pointing to `/usr/bin/pytyon3` did not fix this. `/usr/bin/python` is not needed if `/usr/bin/python2` exists. Building Hadoop (with yarn-ui enabled) and Alluxio on rockylinux-8 and fedora-38 aarch \
64 is affected by this. While Alluxio on openeuler-22.03 on aarch64 seems to be affected too, I'm going to declare it as unsupported in Bigtop 3.3.0 since openeuler-22.03 does not provide python2 package.

By applying current bigtop_toolchain manifest, CentOS 7 has python2 since OS core packages depend on it. Debian 11 and Ubuntu 22.04 have python2 as dependency of installed packages.

I moved python related staffs to dedicated python.pp for ease of maintenance.