### PR TITLE
BIGTOP-4122. Fix test failure of SparkR on openEuler due to lack of R deployment.

### DIFF
--- a/bigtop-deploy/puppet/modules/spark/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/spark/manifests/init.pp
@@ -184,7 +184,7 @@ class spark {
 
       exec { "download_R":
         cwd  => "/usr/src",
-        command => "/usr/bin/wget $url/$rfile && mkdir -p $rdir && /bin/tar -xvzf $rfile -C $rdir --strip-components=1 && cd $rdir",
+        command => "/usr/bin/wget $rurl/$rfile && mkdir -p $rdir && /bin/tar -xvzf $rfile -C $rdir --strip-components=1 && cd $rdir",
         creates => "/usr/src/$rdir",
       }
       exec { "install_R":

--- a/bigtop-deploy/puppet/modules/spark/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/spark/manifests/init.pp
@@ -162,25 +162,20 @@ class spark {
   }
 
   class sparkr {
-    # BIGTOP-3579. On these distros, the default version of R is earlier than 3.5.0,
-    # which is required to run SparkR. So the newer version of R is installed here.
-    if (($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemmajrelease, '18.04') <= 0) or
-        ($operatingsystem == 'Debian' and versioncmp($operatingsystemmajrelease, '10') < 0)) {
-      $url = "http://cran.r-project.org/src/base/R-3/"
-      $rfile = "R-3.6.3.tar.gz"
-      $rdir = "R-3.6.3"
+    if ($operatingsystem == 'openEuler') {
+      $rurl = "https://cran.r-project.org/src/base/R-4/"
+      $rfile = "R-4.4.3.tar.gz"
+      $rdir = "R-4.4.3"
 
       $pkgs = [
-        "g++",
-        "gcc",
-        "gfortran",
-        "libbz2-dev",
-        "libcurl4-gnutls-dev",
-        "liblzma-dev",
-        "libpcre3-dev",
-        "libreadline-dev",
-        "libz-dev",
-        "make",
+        "bzip2-devel",
+        "gcc-c++",
+        "gcc-gfortran",
+        "libcurl-devel",
+        "perl-Digest-SHA",
+        "pcre-devel",
+        "readline-devel",
+        "xz-devel",
       ]
       package { $pkgs:
         ensure => installed,

--- a/bigtop-packages/src/rpm/spark/SPECS/spark.spec
+++ b/bigtop-packages/src/rpm/spark/SPECS/spark.spec
@@ -165,7 +165,12 @@ Spark YARN Shuffle Service
 %package -n %{spark_pkg_name}-sparkr
 Summary: R package for Apache Spark
 Group: Development/Libraries
+
+%if 0%{?openEuler}
+Requires: %{spark_pkg_name}-core = %{version}-%{release}
+%else
 Requires: %{spark_pkg_name}-core = %{version}-%{release}, R
+%endif
 
 %description -n %{spark_pkg_name}-sparkr
 SparkR is an R package that provides a light-weight frontend to use Apache Spark from R.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4122

testSparkR failed due to lack of R deployment on openEuler. Since R package is not provided for latest openEuler 22.03, we need to install R from source code. See [BIGTOP-4093](https://issues.apache.org/jira/browse/BIGTOP-4093) for back ground.

* removed RPM package dependency on R if OS is openEuler.
* added R deployment from source code to bigtop-deploy.
* removed obsolete conditionals for quite old distros as cleanup.