### PR TITLE
BIGTOP-4109: Fix deployment failure of Spark on Fedora 38 due to manifest incompatible with Puppet 8

### DIFF
--- a/bigtop-deploy/puppet/modules/spark/templates/spark-defaults.conf
+++ b/bigtop-deploy/puppet/modules/spark/templates/spark-defaults.conf
@@ -16,7 +16,7 @@
 <% if @master_url -%>
 spark.master <%= @master_url %>
 <% else -%>
-<% if (scope['spark::deploy::roles'] & ['spark-master', 'spark-worker']) != [] -%>
+<% if (@roles & ['spark-master', 'spark-worker']) != [] -%>
 spark.master spark://<%= @master_host %>:<%= @master_port %>
 <% else -%>
 spark.master yarn

--- a/bigtop-deploy/puppet/modules/spark/templates/spark-env.sh
+++ b/bigtop-deploy/puppet/modules/spark/templates/spark-env.sh
@@ -27,7 +27,7 @@ export SPARK_MASTER_IP=$STANDALONE_SPARK_MASTER_HOST
 <% if @master_url -%>
 export SPARK_MASTER_URL=<%= @master_url %>
 <% else -%>
-<% if (scope['spark::deploy::roles'] & ['spark-master', 'spark-worker']) != [] -%>
+<% if (@roles & ['spark-master', 'spark-worker']) != [] -%>
 export SPARK_MASTER_URL=spark://<%= @master_host %>:<%= @master_port %>
 <% else -%>
 export SPARK_MASTER_URL=yarn


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This Error may be caused by a version change in Pupput.
Puppet manifest of livy include spark::common class, but it can not refers to spark::deploy::roles in template files.

This PR changes spark::deploy::roles reference to @roles.


### How was this patch tested?


$./docker-hadoop.sh -dcp -F docker-compose-cgroupv2.yml -C config_fedora-38.yaml -m 6g -c 3 -k "hdfs, yarn, spark, livy" -s "spark,livy"    

...

> Task :bigtop-tests:smoke-tests:livy:test
Finished generating test XML results (0.001 secs) into: /bigtop-home/bigtop-tests/smoke-tests/livy/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.004 secs) into: /bigtop-home/bigtop-tests/smoke-tests/livy/build/reports/tests/testNow testing...
:bigtop-tests:smoke-tests:livy:test (Thread[Execution worker for ':' Thread 7,5,main]) completed. Took 35.789 secs.


$./docker-hadoop.sh -dcp -e 1 bash

[root@d2fec4e7e071 /]# cat /etc/spark/conf/spark-defaults.conf

spark.master spark://d2fec4e7e071.bigtop.apache.org:7077
