### PR TITLE
BIGTOP-4121. Fix test failure of Phoenix on rockylinux-8 due to deployment issue of python3

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -60,7 +60,7 @@ case ${ID}-${VERSION_ID} in
         puppet module install puppetlabs-stdlib --version 4.12.0
         # Enabling the PowerTools and EPEL repositories via Puppet doesn't seem to work in some cases.
         # As a workaround for that, enable the former here in advance of running the Puppet manifests.
-        dnf config-manager --set-enabled powertools
+        dnf config-manager --set-enabled powertools devel
         ;;
     rocky-9*)
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Phoenix smoke test failed due to lack of a python package as the smoke test execute python script.
We need to enable `devel` repo on Rocky Linux 8 because the `python3-devel`  package is in there.

### How was this patch tested?

1. Create custom docker images by `./gradlew -POS=rockylinux-8 bigtop-puppet`
2. Prepare custom docker provision yaml file to use the docker image w/ phoenix smoke test setting
3. Run `./docker-hadoop.sh  -dcp -C config_rockylinux-8.yaml -s -c 3`

Test successed on my local machine.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/