### PR TITLE
BITOP-4128: Docker compose plugin doesn't have '-v' option

### DIFF
--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -271,11 +271,11 @@ env-check() {
     echo "Check docker:"
     docker -v || exit 1
     echo "Check docker-compose:"
-	if [ "$DOCKER_COMPOSE_CMD" == "docker-compose" ]; then
+  if [ "$DOCKER_COMPOSE_CMD" == "docker-compose" ]; then
       $DOCKER_COMPOSE_CMD -v || exit 1
-	elif [ "$DOCKER_COMPOSE_CMD" == "docker compose" ]; then
+  elif [ "$DOCKER_COMPOSE_CMD" == "docker compose" ]; then
       $DOCKER_COMPOSE_CMD version || exit 1
-	fi 
+  fi
     echo "Check ruby:"
     ruby -v || exit 1
 }

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -271,11 +271,11 @@ env-check() {
     echo "Check docker:"
     docker -v || exit 1
     echo "Check docker-compose:"
-  if [ "$DOCKER_COMPOSE_CMD" == "docker-compose" ]; then
-      $DOCKER_COMPOSE_CMD -v || exit 1
-  elif [ "$DOCKER_COMPOSE_CMD" == "docker compose" ]; then
-      $DOCKER_COMPOSE_CMD version || exit 1
-  fi
+    if [ "$DOCKER_COMPOSE_CMD" == "docker-compose" ]; then
+        $DOCKER_COMPOSE_CMD -v || exit 1
+    elif [ "$DOCKER_COMPOSE_CMD" == "docker compose" ]; then
+        $DOCKER_COMPOSE_CMD version || exit 1
+    fi
     echo "Check ruby:"
     ruby -v || exit 1
 }

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -271,7 +271,11 @@ env-check() {
     echo "Check docker:"
     docker -v || exit 1
     echo "Check docker-compose:"
-    $DOCKER_COMPOSE_CMD -v || exit 1
+	if [ "$DOCKER_COMPOSE_CMD" == "docker-compose" ]; then
+      $DOCKER_COMPOSE_CMD -v || exit 1
+	elif [ "$DOCKER_COMPOSE_CMD" == "docker compose" ]; then
+      $DOCKER_COMPOSE_CMD version || exit 1
+	fi 
     echo "Check ruby:"
     ruby -v || exit 1
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4128

### How was this patch tested?
```
$./docker-hadoop.sh -dcp -c 3
Environment check...
Check docker:Environment check...
Check docker:
Docker version 26.1.3, build b72abbb
Check docker-compose:
Docker Compose version v2.27.0
Check ruby:
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]
...

```
