### PR TITLE
BIGTOP-4155: Add support for openEuler OS in bigtop web

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -42,7 +42,7 @@
 			</table>
 			<br />
 			<p>
-					Bigtop support many Operating Systems, including Debian, Ubuntu, CentOS, Fedora, openSUSE and many others.
+					Bigtop support many Operating Systems, including Debian, Ubuntu, CentOS, Fedora, openSUSE, openEuler and many others.
 
 			</p>
 			<p>


### PR DESCRIPTION
The bigtop 3.3.0 support openEuler OS : https://bigtop.apache.org/release-notes.html
Update the information in the bigtop web.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (BIGTOP-4155)
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/