### PR TITLE
BIGTOP-4171. fix the docker repo of openeuler

### DIFF
--- a/provisioner/docker/config_openeuler-22.03.yaml
+++ b/provisioner/docker/config_openeuler-22.03.yaml
@@ -17,7 +17,7 @@ docker:
         memory_limit: "4g"
         image: "bigtop/puppet:trunk-openeuler-22.03"
 
-repo: "http://repios.bigtop.apache.org/releases/3.3.0/openEuler/22.03/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.3.0/openEuler/22.03/$basearch"
 distro: centos
 components: [hdfs ,yarn ,mapreduce]
 enable_local_repo: false


### PR DESCRIPTION
Fix the docker repo of openeuler:

repo: "http://**_repios_**.bigtop.apache.org/releases/3.3.0/openEuler/22.03/$basearch"
--->
repo: "http://**_repos_**.bigtop.apache.org/releases/3.3.0/openEuler/22.03/$basearch"

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/