### PR TITLE
BIGTOP-4183: Docker provisioner can't destroy when container is stopped

### DIFF
--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -215,7 +215,11 @@ destroy() {
         echo "No cluster exists!"
     else
         get_nodes
-        docker exec ${NODES[0]} bash -c "umount /etc/hosts; rm -f /etc/hosts"
+        if [ -z ${NODES} ]; then
+          echo "No cluster running, but provision id is exists."
+        else
+          docker exec ${NODES[0]} bash -c "umount /etc/hosts; rm -f /etc/hosts"
+        fi
         NETWORK_ID=`docker network ls --quiet --filter name=${PROVISION_ID}_default`
 
         if [ -n "$PROVISION_ID" ]; then

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -216,7 +216,7 @@ destroy() {
     else
         get_nodes
         if [ -z ${NODES} ]; then
-          echo "No cluster running, but provision id is exists."
+          echo "No cluster is running but .provision_id is exists."
         else
           docker exec ${NODES[0]} bash -c "umount /etc/hosts; rm -f /etc/hosts"
         fi


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Prevent docker-hadoop.sh from exec bash command when Node is not running.

See details in [BIGTOP-4183 ](https://issues.apache.org/jira/projects/BIGTOP/issues/BIGTOP-4183)

### How was this patch tested?
```
$docker ps -a
CONTAINER ID   IMAGE                              COMMAND        CREATED         STATUS                       PORTS     NAMES
f2820557a644   bigtop/puppet:trunk-ubuntu-22.04   "/sbin/init"   6 seconds ago   Exited (255) 5 seconds ago             20240806_231134_r8527-bigtop-2
074d34a452aa   bigtop/puppet:trunk-ubuntu-22.04   "/sbin/init"   6 seconds ago   Exited (255) 5 seconds ago             20240806_231134_r8527-bigtop-1
719f5d15c605   bigtop/puppet:trunk-ubuntu-22.04   "/sbin/init"   6 seconds ago   Exited (255) 4 seconds ago             20240806_231134_r8527-bigtop-3

$./docker-hadoop.sh -dcp -d
No cluster running, but provision id is exists.
[+] Stopping 3/0
 ✔ Container 20240806_231134_r8527-bigtop-3  Stopped                                                                   0.0s  ✔ Container 20240806_231134_r8527-bigtop-2  Stopped                                                                   0.0s  ✔ Container 20240806_231134_r8527-bigtop-1  Stopped                                                                   0.0s Going to remove 20240806_231134_r8527-bigtop-2, 20240806_231134_r8527-bigtop-1, 20240806_231134_r8527-bigtop-3
[+] Removing 3/0
 ✔ Container 20240806_231134_r8527-bigtop-3  Removed                                                                   0.0s  ✔ Container 20240806_231134_r8527-bigtop-2  Removed                                                                   0.0s  ✔ Container 20240806_231134_r8527-bigtop-1  Removed                                                                   0.0s 20240806_231134_r8527_default
removed './config/hosts'
removed './config/hieradata/site.yaml'
removed './config/hieradata/bigtop/cluster.yaml'
removed './config/hieradata/bigtop/repo.yaml'
removed directory './config/hieradata/bigtop'
removed directory './config/hieradata'
removed './config/hiera.yaml'
removed directory './config'
removed '.provision_id'
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/