### PR TITLE
BIGTOP-4215. Upgrade ZooKeeper to 3.8.4

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -137,7 +137,7 @@ bigtop {
       pkg     = name
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       version {
-        base  = '3.7.2'
+        base  = '3.8.4'
         pkg   = base
         release = 1
       }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
The latest Hadoop uses 3.8.4 so we can update to that version.

https://github.com/apache/hadoop/blob/trunk/hadoop-project/pom.xml#L106

### How was this patch tested?

Built & test with Ubuntu-22.04
```
$ ./gradlew allclean zookeeper-pkg repo -Dbuildwithdeps=true
$ ./docker-hadoop.sh -c 1 --image bigtop/puppet:trunk-ubuntu-22.04 --docker-compose-yml docker-compose-cgroupv2.yml -dcp --memory 8g --repo file:///bigtop-home/output/apt --disable-gpg-check --stack zookeeper --smoke-tests zookeeper 
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/