### PR TITLE
BIGTOP-4239. Add Ubuntu24.04 as a development enviornment

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -35,6 +35,11 @@ case ${ID}-${VERSION_ID} in
         apt-get update
         apt-get -y install wget curl sudo unzip puppet software-properties-common puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv
         ;;
+    ubuntu-24.04)
+        apt-get update
+        apt-get -y install wget curl sudo unzip puppet software-properties-common puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv
+        echo 'include_legacy_facts=true' >> /etc/puppet/puppet.conf
+        ;;
     debian-11*)
         apt-get update
         apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv gnupg procps

--- a/bigtop_toolchain/manifests/gnupg.pp
+++ b/bigtop_toolchain/manifests/gnupg.pp
@@ -30,7 +30,9 @@ class bigtop_toolchain::gnupg {
     }
   }
 
-  package { $pkg:
-    ensure => installed
+  if !defined(Package[$pkg]) {
+    package { $pkg:
+      ensure => installed
+    }
   }
 }

--- a/bigtop_toolchain/manifests/python.pp
+++ b/bigtop_toolchain/manifests/python.pp
@@ -24,13 +24,20 @@ class bigtop_toolchain::python {
       package { 'dh-python' :
         ensure => present
       }
-      package { 'python-setuptools' :
-        ensure => present
-      }
       package { 'python3-dev' :
         ensure => present
       }
     }
+  }
+
+  package { 'python3-setuptools' :
+    ensure => present
+  }
+  package { 'python3-wheel' :
+    ensure => present
+  }
+  package { 'python3-flake8' :
+    ensure => present
   }
 
   if ($architecture in ['aarch64']) {
@@ -50,26 +57,6 @@ class bigtop_toolchain::python {
     }
   }
 
-  # BIGTOP-3364: Failed to install setuptools by pip/pip2
-  # on Ubuntu-16.04/18.04 and centos-7.
-  # From https://packaging.python.org/tutorials/installing-packages/#requirements-for-installing-packages,
-  # it suggests to leverage python3/pip3 to install setuptools.
-  #
-  # "provider => 'pip3'" is not available for puppet 3.8.5,
-  #  Workaround: Exec {pip3 install setuptools} directly insead of Package{}.
-  package { 'python3-pip':
-    ensure => installed
-  }
-
-  exec { "Setuptools Installation":
-    command => "/usr/bin/pip3 install -q --upgrade setuptools",
-    require => Package['python3-pip']
-  }
-
-  exec { "flake8 and whell Installation":
-    command => "/usr/bin/pip3 freeze --all; /usr/bin/pip3 --version; /usr/bin/pip3 install -q flake8 wheel",
-    require => Package['python3-pip']
-  }
 
   # The rpm-build package had installed brp-python-bytecompile
   # just under /usr/lib/rpm until Fedora 34,

--- a/packages.gradle
+++ b/packages.gradle
@@ -144,7 +144,7 @@ def devNull = new OutputStream() {
 def nativePackaging = {
   def result = exec {
     commandLine "/bin/bash", "-c",
-    """dpkg-query -S /bin/sh && exit 1
+    """(dpkg-query -S `realpath /bin/sh` || dpkg-query -S /bin/sh) && exit 1
        rpm -qf /bin/sh && exit 2
        exit 0
     """


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4239

I think it should always be possible to develop in a new development environment.

### How was this patch tested?

I ran those commands on both Ubuntu 22.04, Ubuntu 24.04 & Rocky-8 and got BUILD SUCCESSFUL.

```
$ sudo bigtop_toolchain/bin/puppetize.sh
$ sudo apt install openjdk-8-jdk
$ ./gradlew toolchain
```

<details>
<summary>The reason for code changes.</summary>

#### gnupg.pp

As of Puppet 8.4.0 (the latest version on Ubuntu 24.04), Package['gnupg'] already declares in `/usr/share/puppet/modules/apt/manifests/init.pp` like below:

```
(snip)
  case $facts['os']['name'] {
    'Debian': {
      stdlib::ensure_packages(['gnupg'])
    }
    'Ubuntu': {
      stdlib::ensure_packages(['gnupg'])
    }
    default: {
      # Nothing in here
    }
  }
(snip)
```

Without the workaround, we got the error below:

```
Error: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Package[gnupg] is already declared at (file: /usr/share/puppet/modules/apt/manifests/init.pp, line: 399); cannot redeclare (file: /home/ubuntu/bigtop/bigtop_toolchain/manifests/gnupg.pp, line: 34) (file: /home/ubuntu/bigtop/bigtop_toolchain/manifests/gnupg.pp, line: 34, column: 5) on node ip-172-31-41-39.ap-northeast-1.compute.internal
```

#### packages.gradle

Theare is a behavior changes between Ubuntu 22.04 and Ubuntu 24.04. We have to use realpath as a workaround.

* Ubuntu 22.04

```
ubuntu@ip-172-31-30-135:~$ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
ubuntu@ip-172-31-30-135:~$ dpkg-query -S `realpath /bin/sh`
dpkg-query: no path found matching pattern /usr/bin/dash
ubuntu@ip-172-31-30-135:~$ dpkg-query -S /bin/sh
diversion by dash from: /bin/sh
diversion by dash to: /bin/sh.distrib
dash: /bin/sh
```

* Ubuntu 24.04

```
ubuntu@ip-172-31-41-39:~/bigtop$ cat /etc/os-release
PRETTY_NAME="Ubuntu 24.04.1 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.1 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
ubuntu@ip-172-31-41-39:~/bigtop$ dpkg-query -S `realpath /bin/sh`
dash: /usr/bin/dash
ubuntu@ip-172-31-41-39:~/bigtop$ dpkg-query -S /bin/sh
dpkg-query: no path found matching pattern /bin/sh
```

</details>

I think [this change](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=989632) ([MR](https://salsa.debian.org/debian/dash/-/merge_requests/19/diffs)) may have something to do with this behavior.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/