### PR TITLE
BIGTOP-4249. Fix build failure of Hadoop 3.3.6 against ZooKeeper 3.8.4.

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch1-HADOOP-19116-3.3.6.diff
+++ b/bigtop-packages/src/common/hadoop/patch1-HADOOP-19116-3.3.6.diff
@@ -1,0 +1,50 @@
+commit da1e732026cb4811ffe78ff98dc069e61ef71eaa
+Author: PJ Fanning <pjfanning@users.noreply.github.com>
+Date:   Tue Jun 11 13:09:23 2024 +0100
+
+    HADOOP-19116. Update to zookeeper client 3.8.4 due to CVE-2024-23944. (#6638)
+    
+    Updated ZK client dependency to 3.8.4 to address  CVE-2024-23944.
+    
+    Contributed by PJ Fanning
+    
+    (cherry picked from commit bd63358c0bb53bb1097f38ebf6c125547fe5e547)
+    
+     Conflicts:
+            LICENSE-binary
+            hadoop-project/pom.xml
+
+diff --git a/hadoop-project/pom.xml b/hadoop-project/pom.xml
+index 1503a86f15c6..ffe339636716 100644
+--- a/hadoop-project/pom.xml
++++ b/hadoop-project/pom.xml
+@@ -1415,6 +1415,14 @@
+             <groupId>log4j</groupId>
+             <artifactId>log4j</artifactId>
+           </exclusion>
++          <exclusion>
++            <groupId>ch.qos.logback</groupId>
++            <artifactId>logback-core</artifactId>
++          </exclusion>
++          <exclusion>
++            <groupId>ch.qos.logback</groupId>
++            <artifactId>logback-classic</artifactId>
++          </exclusion>
+           <exclusion>
+             <groupId>org.slf4j</groupId>
+             <artifactId>slf4j-api</artifactId>
+@@ -1459,6 +1467,14 @@
+             <groupId>log4j</groupId>
+             <artifactId>log4j</artifactId>
+           </exclusion>
++          <exclusion>
++            <groupId>ch.qos.logback</groupId>
++            <artifactId>logback-core</artifactId>
++          </exclusion>
++          <exclusion>
++            <groupId>ch.qos.logback</groupId>
++            <artifactId>logback-classic</artifactId>
++          </exclusion>
+           <exclusion>
+             <groupId>org.slf4j</groupId>
+             <artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4249

We need backport of [HADOOP-19116](https://issues.apache.org/jira/browse/HADOOP-19116) to add exclusions to test invariants.

```
[ERROR] Found artifact with unexpected contents: '/root/bigtop/output/hadoop/hadoop-3.3.6/hadoop-client-modules/hadoop-client-minicluster/target/hadoop-client-minicluster-3.3.6.jar'
    Please check the following and either correct the build or update
    the allowed list with reasoning.

    ch/
    ch/qos/
    ch/qos/logback/
    ch/qos/logback/core/
    ch/qos/logback/core/Appender.class
    ...
```