### PR TITLE
BIGTOP-4263. Add systemd-tmpfiles for zookeeper-server RPM

### DIFF
--- a/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
+++ b/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
@@ -89,9 +89,10 @@ Source6: zoo.cfg
 Source7: zookeeper.default
 Source8: init.d.tmpl
 Source9: zookeeper-rest.svc
-Source10: zookeeper-server.service
+Source10: %{svc_zookeeper}.service
+Source11: %{svc_zookeeper}.tmpfile
 #BIGTOP_PATCH_FILES
-BuildRequires: autoconf, automake, cppunit-devel, systemd
+BuildRequires: autoconf, automake, cppunit-devel, systemd, systemd-rpm-macros
 Requires(pre): coreutils, /usr/sbin/groupadd, /usr/sbin/useradd
 Requires(post): %{alternatives_dep}
 Requires(preun): %{alternatives_dep}
@@ -184,7 +185,10 @@ init_file=$RPM_BUILD_ROOT/%{initd_dir}/zookeeper-rest
 bash $RPM_SOURCE_DIR/init.d.tmpl $RPM_SOURCE_DIR/zookeeper-rest.svc rpm $init_file
 
 # Install ZooKeeper Server systemd service file
-%__install -D -m 0644 %{SOURCE10} $RPM_BUILD_ROOT/%{_unitdir}/zookeeper-server.service
+%__install -D -m 0644 %{SOURCE10} $RPM_BUILD_ROOT/%{_unitdir}/%{svc_zookeeper}.service
+
+# Install ZooKeeper Server systemd-tmpfile file
+%__install -D -m 0644 %{SOURCE11} $RPM_BUILD_ROOT/%{_tmpfilesdir}/%{svc_zookeeper}.conf
 
 %pre
 getent group zookeeper >/dev/null || groupadd -r zookeeper
@@ -254,6 +258,7 @@ fi
 
 %files server
 %attr(0644,root,root) %{_unitdir}/zookeeper-server.service
+%attr(0644,root,root) %{_tmpfilesdir}/zookeeper-server.conf
 
 %files rest
 %attr(0755,root,root) %{initd_dir}/%{svc_zookeeper_rest}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4263

We need to recreate `/run/zookeeper` directory when the OS restarted.

### How was this patch tested?

Applied this patch, built RPM files and install it on Rocky Linux 8(container).
Restarted the OS (container), then check if `systemctl start zookeeper-server` works.

On Ubuntu 24.04 (aarch64): 
```
$ ./gradlew allclean zookeeper-pkg-ind repo-ind -POS=rockylinux-8
$ cd provisioner/docker/
$ ./docker-hadoop.sh --enable-local-repo --disable-gpg-check --docker-compose-plugin -C config_rockylinux-8.yaml -F docker-compose-cgroupv2.yml --stack zookeeper -c 1
$ # `docker ps` to get container_id, and `docker restart $container_id` to restart it.
$ ./docker-hadoop.sh -dcp --exec 1 systemctl status zookeeper-server
● zookeeper-server.service - ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization>
   Loaded: loaded (/usr/lib/systemd/system/zookeeper-server.service; static; vendor preset: disabled)
   Active: inactive (dead)
     Docs: https://zookeeper.apache.org/
$ ./docker-hadoop.sh -dcp --exec 1 systemctl start  zookeeper-server
$ ./docker-hadoop.sh -dcp --exec 1 systemctl status zookeeper-server
● zookeeper-server.service - ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization>
   Loaded: loaded (/usr/lib/systemd/system/zookeeper-server.service; static; vendor preset: disabled)
   Active: active (running) since Tue 2024-11-12 21:45:44 UTC; 5s ago
     Docs: https://zookeeper.apache.org/
  Process: 43 ExecStart=/usr/bin/zookeeper-server start (code=exited, status=0/SUCCESS)
 Main PID: 76 (java)
    Tasks: 41 (limit: 5099)
   Memory: 139.7M
   CGroup: /system.slice/zookeeper-server.service
           └─76 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dzookeeper.datadir.autocreate=false -Dzookeeper.log.dir=/var/log/z>

Nov 12 21:45:43 ddb379a52eb1 systemd[1]: Starting ZooKeeper is a centralized service for maintaining configuration information, naming, providing distri>
Nov 12 21:45:43 ddb379a52eb1 zookeeper-server[58]: ZooKeeper JMX enabled by default
Nov 12 21:45:43 ddb379a52eb1 zookeeper-server[58]: Using config: /etc/zookeeper/conf/zoo.cfg
Nov 12 21:45:44 ddb379a52eb1 zookeeper-server[58]: Starting zookeeper ... STARTED
Nov 12 21:45:44 ddb379a52eb1 systemd[1]: Started ZooKeeper is a centralized service for maintaining configuration information, naming, providing distrib
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/