### PR TITLE
BIGTOP-3990 - Add Debian 12 (bookworm) as a development environment

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -40,7 +40,7 @@ case ${ID}-${VERSION_ID} in
         apt-get -y install wget curl sudo unzip puppet software-properties-common puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv
         echo 'include_legacy_facts=true' >> /etc/puppet/puppet.conf
         ;;
-    debian-11*)
+    debian-11*|debian-12)
         apt-get update
         apt-get -y install wget curl sudo unzip puppet puppet-module-puppetlabs-apt puppet-module-puppetlabs-stdlib systemd-sysv gnupg procps
         ;;

--- a/bigtop_toolchain/manifests/jdk.pp
+++ b/bigtop_toolchain/manifests/jdk.pp
@@ -16,18 +16,8 @@
 class bigtop_toolchain::jdk {
   case $::operatingsystem {
     /Debian/: {
-      # We need JDK 8, but Debian 10+ only provides the openjdk-11-jdk package (or greater) in the official repo.
-      # So we use Eclipse Temurin instead, following the steps described on:
-      # https://adoptium.net/installation/linux/#_deb_installation_on_debian_or_ubuntu
       include apt
 
-      apt::source { 'adoptium':
-        location => 'https://packages.adoptium.net/artifactory/deb/',
-        key      => {
-          id     => '3B04D753C9050D9A5D343F39843C48A565F8F04B',
-          source => 'https://packages.adoptium.net/artifactory/api/gpg/key/public',
-        },
-      } ->
       package { 'temurin-8-jdk' :
         ensure => present,
       }

--- a/bigtop_toolchain/manifests/jdk11.pp
+++ b/bigtop_toolchain/manifests/jdk11.pp
@@ -15,7 +15,30 @@
 
 class bigtop_toolchain::jdk11 {
   case $::operatingsystem {
-    /(Debian|Ubuntu)/: {
+    /Debian/: {
+      # We need JDK 11, but Debian 12 only provides the openjdk-17-jdk package (or greater) in the official repo.
+      # So we use Eclipse Temurin instead, following the steps described on:
+      # https://adoptium.net/installation/linux/#_deb_installation_on_debian_or_ubuntu
+      include apt
+
+      apt::source { 'adoptium':
+        location => 'https://packages.adoptium.net/artifactory/deb/',
+        key      => {
+          id     => '3B04D753C9050D9A5D343F39843C48A565F8F04B',
+          source => 'https://packages.adoptium.net/artifactory/api/gpg/key/public',
+        },
+      } -> if $::operatingsystemmajrelease =~ /^1[^1\D]$/ {
+        package { 'temurin-11-jdk' :
+          ensure => present,
+        }
+      }
+      else {
+        package { 'openjdk-11-jdk' :
+          ensure => present,
+        }
+      }
+    }
+    /(Ubuntu)/: {
       include apt
 
       package { 'openjdk-11-jdk' :


### PR DESCRIPTION
### Description of PR
This adds Debian 12 support.

### How was this patch tested?
```
cd docker/bigtop-puppet
./build.sh trunk-debian-12

cd ../bigtop-slaves
./build.sh trunk-debian-12

cd ../../
docker run -it --rm -v `pwd`:/ws --workdir /ws bigtop/slaves:trunk-debian-12 bash -c '. /etc/profile.d/bigtop.sh; ./gradlew allclean deb'
```
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/