### PR TITLE
BIGTOP-4268. Add libtirpc-dev to the toolchain for Ubuntu 24.04.

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -232,7 +232,7 @@ class bigtop_toolchain::packages {
        "yasm"
     ] }
     /(Ubuntu|Debian)/: {
-      $pkgs = [
+      $_pkgs = [
         "unzip",
         "curl",
         "wget",
@@ -289,6 +289,11 @@ class bigtop_toolchain::packages {
         "nasm",
         "yasm"
       ]
+      if ($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemmajrelease, '24.04') >= 0) {
+        $pkgs = concat($_pkgs, ["libtirpc-dev"])
+      } else {
+        $pkgs = $_pkgs
+      }
 
       file { '/etc/apt/apt.conf.d/01retries':
         content => 'Aquire::Retries "5";'


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR add the libtirpc-dev package to the Bigtop toolchain so that Hadoop can be built on Ubuntu 24.04.

### How was this patch tested?

Ran `./gradlew toolchain` then `./gradlew hadoop-clean hadoop-pkg` after applying this PR on Ubuntu 24.04.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/