### PR TITLE
BIGTOP-4269. Add provisioner config for Debian 12 and Ubuntu 24.04.

### DIFF
--- a/bigtop-deploy/puppet/manifests/bigtop_repo.pp
+++ b/bigtop-deploy/puppet/manifests/bigtop_repo.pp
@@ -77,7 +77,7 @@ class bigtop_repo {
 
       if ($bigtop_repo_gpg_check) {
         apt::conf { "remove_disable_keys":
-          content => "APT::Get::AllowUnauthenticated 1;\nAcquire::AllowInsecureRepositories \"true\";",
+          content => "APT::Get::AllowUnauthenticated 1;\nAcquire::AllowInsecureRepositories \"true\";\nAPT::AllowInsecureRepositories \"true\";",
           ensure  => absent
         }
         apt::key { "add_key":
@@ -93,7 +93,7 @@ class bigtop_repo {
         }
       } else {
         apt::conf { "disable_keys":
-          content => "APT::Get::AllowUnauthenticated 1;\nAcquire::AllowInsecureRepositories \"true\";",
+          content => "APT::Get::AllowUnauthenticated 1;\nAcquire::AllowInsecureRepositories \"true\";\nAPT::AllowInsecureRepositories \"true\";",
           ensure  => present
         }
       }

--- a/bigtop-deploy/puppet/manifests/cluster.pp
+++ b/bigtop-deploy/puppet/manifests/cluster.pp
@@ -187,7 +187,7 @@ class node_with_roles ($roles = hiera("bigtop::roles")) inherits hadoop_cluster_
 class node_with_components inherits hadoop_cluster_node {
 
   # Ensure (even if a single value) that the type is an array.
-  if (is_array($cluster_components)) {
+  if ($cluster_components =~ Array) {
     $components_array = $cluster_components
   } else {
     if ($cluster_components == undef) {

--- a/provisioner/docker/config_debian-12.yaml
+++ b/provisioner/docker/config_debian-12.yaml
@@ -13,33 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require jdk
-Class['jdk'] -> Service<||>
+docker:
+        memory_limit: "4g"
+        image: "bigtop/puppet:trunk-debian-12"
 
-$provision_repo = hiera("bigtop::provision_repo", true)
-if ($provision_repo) {
-   require bigtop_repo
-}
-
-node default {
-  $roles_enabled = hiera("bigtop::roles_enabled", false)
-
-  if ($roles_enabled !~ Boolean) {
-    fail("bigtop::roles hiera conf is not of type boolean. It should be set to either true or false")
-  }
-
-  if ($roles_enabled) {
-    include node_with_roles
-  } else {
-    include node_with_components
-  }
-
-  include python
-}
-
-if versioncmp($::puppetversion,'3.6.1') >= 0 {
-  $allow_virtual_packages = hiera('bigtop::allow_virtual_packages',false)
-  Package {
-    allow_virtual => $allow_virtual_packages,
-  }
-}
+repo: "http://repos.bigtop.apache.org/releases/3.3.0/debian/12/$(ARCH)"
+distro: debian
+components: [hdfs, yarn, mapreduce]
+enable_local_repo: false
+smoke_test_components: [hdfs, yarn, mapreduce]

--- a/provisioner/docker/config_ubuntu-24.04.yaml
+++ b/provisioner/docker/config_ubuntu-24.04.yaml
@@ -13,33 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require jdk
-Class['jdk'] -> Service<||>
+docker:
+        memory_limit: "4g"
+        image:  "bigtop/puppet:trunk-ubuntu-24.04"
 
-$provision_repo = hiera("bigtop::provision_repo", true)
-if ($provision_repo) {
-   require bigtop_repo
-}
-
-node default {
-  $roles_enabled = hiera("bigtop::roles_enabled", false)
-
-  if ($roles_enabled !~ Boolean) {
-    fail("bigtop::roles hiera conf is not of type boolean. It should be set to either true or false")
-  }
-
-  if ($roles_enabled) {
-    include node_with_roles
-  } else {
-    include node_with_components
-  }
-
-  include python
-}
-
-if versioncmp($::puppetversion,'3.6.1') >= 0 {
-  $allow_virtual_packages = hiera('bigtop::allow_virtual_packages',false)
-  Package {
-    allow_virtual => $allow_virtual_packages,
-  }
-}
+repo: "http://repos.bigtop.apache.org/releases/3.3.0/ubuntu/24.04/$(ARCH)"
+distro: debian
+components: [hdfs, yarn, mapreduce]
+enable_local_repo: false
+smoke_test_components: [hdfs, yarn, mapreduce]


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR adds configuration files of Debian 12 and Ubuntu 24.04 for the Docker provisioner.

### How was this patch tested?

After applying #1304, building Hadoop and registered it into the local repository, ran the following steps.

Built bigtop-puppet image for Ubuntu 24.04:

```
$ cd docker/bigtop-puppet
$ ./build.sh trunk-ubuntu-24.04
```

Ran smoke test with the new config file:

```
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_ubuntu-24.04.yaml -F docker-compose-cgroupv2.yml -G -L -k hdfs,yarn -s yarn -c 3
```

I also made sure the same steps for Debian 12.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/