### PR TITLE
BIGTOP-4272. Upgrade Alluxio to 2.9.6.

### DIFF
--- a/bigtop-deploy/puppet/modules/alluxio/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/alluxio/manifests/init.pp
@@ -64,6 +64,7 @@ class alluxio {
         hasrestart => true,
         hasstatus => true,
       }
+      Exec<| title == "init hdfs" |> -> Service["alluxio-master"]
     }
 
   }

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -293,7 +293,7 @@ bigtop {
       pkg     = "alluxio"
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = "Alluxio: a memory-centric distributed file system"
-      version { base = '2.9.3'; pkg = base; release = 1 }
+      version { base = '2.9.6'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "v${version.base}.tar.gz" }
       url     { site = "https://github.com/Alluxio/alluxio/archive"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Alluxio to 2.9.6 for the Bigtop 3.4.0 release.

### How was this patch tested?

Ran smoke test on Debian 12 and Rocky 9 (x86_64).
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/