### PR TITLE
BIGTOP-4274. Upgrade Phoenix to 5.2.1.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -247,7 +247,7 @@ bigtop {
     'phoenix' {
       name    = 'phoenix'
       relNotes = 'Apache Phoenix: A SQL skin over HBase'
-      version { base = "5.1.3"; pkg = base; release = 1 }
+      version { base = "5.2.1"; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Phoenix to 5.2.1 for the Bigtop 3.4.0 release.

### How was this patch tested?

After building HBase with #1307 and applying this PR, I made sure that Phoenix is successfully built and its smoke test succeeded with Debian 12 and Rocky 9 on x86_64.

```
./gradlew phoenix-clean phoenix-pkg repo -Dbuildwithdeps=true
cd provisioner/docker
./docker-hadoop.sh -d -dcp -C config_debian-12.yaml -F docker-compose-cgroupv2.yml -G -L -k hdfs,hbase,phoenix -s phoenix -c 3
```

```
./gradlew phoenix-clean phoenix-pkg repo -Dbuildwithdeps=true
cd provisioner/docker
./docker-hadoop.sh -d -dcp -C config_rockylinux-9.yaml -F docker-compose-cgroupv2.yml -G -L -r file:///bigtop-home/output -k hdfs,hbase,phoenix -s phoenix -c 3
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/