### PR TITLE
BIGTOP-4275. Upgrade Flink to 1.20.0.

### DIFF
--- a/bigtop-packages/src/common/flink/do-component-build
+++ b/bigtop-packages/src/common/flink/do-component-build
@@ -42,6 +42,6 @@ fi
 sed -i "s/$repl_from/$repl_to/" flink-runtime-web/web-dashboard/package.json
 
 # Use Maven to build Flink from source
-${BUILD_ENV} mvn install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"
+${BUILD_ENV} ./mvnw install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"
 cd flink-dist
-${BUILD_ENV} mvn install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"
+${BUILD_ENV} ../mvnw install $FLINK_BUILD_OPTS -Drat.skip=true -DskipTests -Dhadoop.version=$HADOOP_VERSION "$@"

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -234,7 +234,7 @@ bigtop {
       name    = 'flink'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Flink'
-      version { base = '1.17.2'; pkg = base; release = 1 }
+      version { base = '1.20.0'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Flink to 1.20.0 for the Bigtop 3.4.0 release.

### How was this patch tested?

I ensured that building Flink 1.20.0 succeeded on Debian 12 and Rocky 9.

```
$ ./gradlew flink-clean flink-pkg repo -Dbuildwithdeps=true
```

I also ensured its smoke test was successful on Debian 12.

```
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_debian-12.yaml -F docker-compose-cgroupv2.yml -G -L -k hdfs,yarn,flink -s flink -c 3

...

org.apache.bigtop.itest.hadoop.flink.TestFlink STANDARD_ERROR
    24/11/22 05:27:40 INFO lang.Object: hadoop fs -rm -r /flink
    24/11/22 05:27:41 INFO lang.Object: hadoop fs -mkdir /flink
    24/11/22 05:27:42 INFO lang.Object: hadoop fs -put test.data /flink/

org.apache.bigtop.itest.hadoop.flink.TestFlink > testCheckRestfulAPI STANDARD_ERROR
    24/11/22 05:27:43 INFO lang.Object: awk '{if(/jobmanager.rpc.address:/) print $2}' < /etc/flink/conf/flink-conf.yaml
    24/11/22 05:27:43 INFO lang.Object: awk '{if(/rest.port:/) print $2}' < /etc/flink/conf/flink-conf.yaml
    24/11/22 05:27:43 INFO lang.Object: curl http://85e9cefc76a9.bigtop.apache.org:8081/config

org.apache.bigtop.itest.hadoop.flink.TestFlink > testWordCountBatch STANDARD_ERROR
    24/11/22 05:27:43 INFO lang.Object: hdfs getconf -confKey fs.defaultFS
    24/11/22 05:27:44 INFO lang.Object: flink run $FLINK_HOME/examples/batch/WordCount.jar --input hdfs://85e9cefc76a9.bigtop.apache.org:8020/flink/test.data --output hdfs://85e9cefc76a9.bigtop.apache.org:8020/tmp/result.txt
    24/11/22 05:27:46 INFO lang.Object: hadoop fs -cat /tmp/result.txt

org.apache.bigtop.itest.hadoop.flink.TestFlink STANDARD_ERROR
    24/11/22 05:27:47 INFO lang.Object: hadoop fs -rm -r /flink

Gradle Test Executor 2 finished executing tests.

> Task :bigtop-tests:smoke-tests:flink:test
Finished generating test XML results (0.004 secs) into: /bigtop-home/bigtop-tests/smoke-tests/flink/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.008 secs) into: /bigtop-home/bigtop-tests/smoke-tests/flink/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:flink:test (Thread[Execution worker for ':',5,main]) completed. Took 9.009 secs.

BUILD SUCCESSFUL in 25s
27 actionable tasks: 7 executed, 20 up-to-date
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/