### PR TITLE
BIGTOP-4281. Upgrade Spark to 3.5.3.

### DIFF
--- a/bigtop-packages/src/common/spark/patch0-SPARK-41063.diff
+++ b/bigtop-packages/src/common/spark/patch0-SPARK-41063.diff
@@ -1,0 +1,18 @@
+diff --git a/pom.xml b/pom.xml
+index c005af470cc..db404288adf 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -2931,6 +2931,13 @@
+           <groupId>net.alchim31.maven</groupId>
+           <artifactId>scala-maven-plugin</artifactId>
+           <version>${scala-maven-plugin.version}</version>
++          <dependencies>
++            <dependency>
++              <groupId>org.scala-sbt</groupId>
++              <artifactId>zinc_2.13</artifactId>
++              <version>1.8.1</version>
++            </dependency>
++          </dependencies>
+           <executions>
+             <execution>
+               <id>eclipse-add-source</id>

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -222,7 +222,7 @@ bigtop {
        * when upgrading spark version.
        * See comments in [bigtop-packages/src/common/spark/install_spark.sh] for details.
        */
-      version { base = '3.3.4'; pkg = base; release = 1 }
+      version { base = '3.5.3'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}.tgz" }
       url     { download_path = "/$name/$name-${version.base}"

--- a/bigtop_toolchain/manifests/maven.pp
+++ b/bigtop_toolchain/manifests/maven.pp
@@ -18,7 +18,7 @@ class bigtop_toolchain::maven {
   require bigtop_toolchain::gnupg
   require bigtop_toolchain::packages
 
-  $mvnversion = latest_maven_binary("3.8.[0-9]*")
+  $mvnversion = latest_maven_binary("3.9.[0-9]*")
   $mvn = "apache-maven-$mvnversion"
 
   $apache_prefix = nearest_apache_mirror()


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Spark to 3.5.3 for the Bigtop 3.4.0 release.

### How was this patch tested?

After applying #1310 and this PR, Spark 3.5.3 was successfully built on Debian 11 and Rocky 9 (x86_64).

```
$ ./gradlew toolchain
$ mvn -version
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)

(snip)

$ ./gradlew spark-clean spark-pkg repo -Dbuildwithdeps=true

(snip)

BUILD SUCCESSFUL in 46m 8s
34 actionable tasks: 34 executed
```

The smoke test also passed on Debian 11.

```
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_debian-11.yaml -F docker-compose-cgroupv2.yml -G -L -k hdfs,yarn,spark -s spark -c 3

(snip)

> Task :bigtop-tests:smoke-tests:spark:test
Finished generating test XML results (0.016 secs) into: /bigtop-home/bigtop-tests/smoke-tests/spark/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.023 secs) into: /bigtop-home/bigtop-tests/smoke-tests/spark/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:spark:test (Thread[Execution worker for ':',5,main]) completed. Took 50.167 secs.

BUILD SUCCESSFUL in 1m 15s
27 actionable tasks: 7 executed, 20 up-to-date
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/