### PR TITLE
BIGTOP-4282. Upgrade Zeppelin to 0.11.2.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -315,7 +315,7 @@ bigtop {
       name    = 'zeppelin'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Zeppelin'
-      version { base = '0.11.0'; pkg = base; release = 2 }
+      version { base = '0.11.2'; pkg = base; release = 1 }
       tarball { source      = "$name-${version.base}.tgz"
                 destination = "$name-${version.base}.tar.gz" }
       url     { download_path = "/$name/$name-${version.base}/"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Zeppelin to 0.11.2 for the Bigtop 3.4.0 release.

### How was this patch tested?

After applying #1305, #1307, #1309, #1310, #1311 and this PR, ran the following commands on Debian 12 and Rocky 9 (x86_64).

```
$ ./gradlew zeppelin-clean zeppelin-pkg repo -Dbuildwithdeps=true

...

BUILD SUCCESSFUL in 51m 14s
49 actionable tasks: 49 executed
```

I also tested the smoke test passed on Debian 12.

```
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_debian-12.yaml -F docker-compose-cgroupv2.yml -G -L -k hdfs,yarn,flink,spark,zeppelin -s zeppelin -c 3

...

> Task :bigtop-tests:smoke-tests:zeppelin:test
Finished generating test XML results (0.003 secs) into: /bigtop-home/bigtop-tests/smoke-tests/zeppelin/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.009 secs) into: /bigtop-home/bigtop-tests/smoke-tests/zeppelin/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:zeppelin:test (Thread[Daemon worker,5,main]) completed. Took 3 mins 32.418 secs.

BUILD SUCCESSFUL in 3m 47s
27 actionable tasks: 7 executed, 20 up-to-date
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/