### PR TITLE
BIGTOP-4283. Upgrade Solr to 8.11.4.

### DIFF
--- a/bigtop-tests/smoke-tests/solr/delete.xml
+++ b/bigtop-tests/smoke-tests/solr/delete.xml
@@ -1,0 +1,3 @@
+<delete>
+    <query>*:*</query>
+</delete>

--- a/bigtop-tests/smoke-tests/solr/indexing.json
+++ b/bigtop-tests/smoke-tests/solr/indexing.json
@@ -1,0 +1,10 @@
+[
+      {
+            "id": "doc1",
+            "name": "first test document"
+      },
+      {
+            "id": "doc2",
+            "name": "second test document"
+      }
+]

--- a/bigtop-tests/smoke-tests/solr/simple.xml
+++ b/bigtop-tests/smoke-tests/solr/simple.xml
@@ -1,0 +1,10 @@
+<add>
+  <doc>
+    <field name="id">doc1</field>
+    <field name="name">first test document</field>
+  </doc>
+  <doc>
+    <field name="id">doc2</field>
+    <field name="name">second test document</field>
+  </doc>
+</add>

--- a/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/SolrTestBase.groovy
+++ b/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/SolrTestBase.groovy
@@ -15,20 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.bigtop.itest.solr.smoke;
+package org.apache.bigtop.itest.solr.smoke
 
 import groovy.json.JsonSlurper
 import org.junit.AfterClass
 import org.junit.BeforeClass
+import org.apache.bigtop.itest.shell.Shell
 import org.apache.commons.logging.Log
 import org.apache.commons.logging.LogFactory
 
 public class SolrTestBase {
-  static private Log LOG = LogFactory.getLog(SolrTestBase.class);
-  static public final String _updatePathJSON = "/update/json?stream.body="
+  static private Log LOG = LogFactory.getLog(SolrTestBase.class)
+  static public final Shell sh = new Shell("/bin/bash -s")
   static public final String _adminPath = "/admin"
-
-  static public final String _baseURL = System.getProperty("org.apache.bigtop.itest.solr_url", "http://localhost:8983/");
+  static public final String _baseURL = System.getProperty("org.apache.bigtop.itest.solr_url", "http://localhost:8983/")
 
   @BeforeClass
   static void before() {
@@ -39,7 +39,7 @@ public class SolrTestBase {
 
     // The pattern should be to index everything in the local BeforeClass perhaps?
     if (doReq("/select?q=*:*").response.numFound != 0) {
-      LOG.warn("There's a bad citizen in the tests");
+      LOG.warn("There's a bad citizen in the tests")
     }
 
     deleteAllDocs() // guard against bad citizens
@@ -52,8 +52,7 @@ public class SolrTestBase {
 
   private static void deleteAllDocs() {
     // Insure that the index is empty
-    doReq("/update?stream.body=<delete><query>*:*</query></delete>")
-    doReq("/update?stream.body=<commit/>")
+    sh.exec("/usr/lib/solr/bin/post -c smoke delete.xml")
     // Best check to insure we're empty!
     testEquals(doReq("/select?q=*:*"), "response.numFound", "0")
   }

--- a/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestIndexing.groovy
+++ b/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestIndexing.groovy
@@ -24,10 +24,7 @@ class TestIndexing extends SolrTestBase {
   @BeforeClass
   static void before() {
     // Index a couple of documents
-    def builder = new groovy.json.JsonBuilder()
-    builder([["id": "doc1", "name": URLEncoder.encode("first test document")],
-      ["id": "doc2", "name": URLEncoder.encode("second test document")]])
-    doReq(_updatePathJSON + builder.toString() + "&commit=true")
+    sh.exec("/usr/lib/solr/bin/post -c smoke indexing.json")
   }
 
   @Test

--- a/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestPing.groovy
+++ b/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestPing.groovy
@@ -24,6 +24,6 @@ import org.junit.Test
 class TestPing extends SolrTestBase {
   @Test
   void testPing() {
-    testEquals(doReq("/admin/ping"), "status", "OK");
+    testEquals(doReq("/admin/ping"), "status", "OK")
   }
 }

--- a/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestSimple.groovy
+++ b/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestSimple.groovy
@@ -16,24 +16,19 @@
  */
 package org.apache.bigtop.itest.solr.smoke
 
+import org.junit.BeforeClass
 import org.junit.Test
 
 class TestSimple extends SolrTestBase {
-  static public final String _updatePathXML = "/update?commit=true&stream.body="
+
+  @BeforeClass
+  static void before() {
+    // Index a couple of documents
+    sh.exec("/usr/lib/solr/bin/post -c smoke simple.xml")
+  }
 
   @Test
   public void testSearch() {
-    // Index a couple of documents, move to beforeClass?
-    // NOTE: JSON update handler isn't enabled in this distro, should it be?
-    //def builder = new groovy.json.JsonBuilder()
-    //builder([["id": "doc1", "name": URLEncoder.encode("first test document")],
-    //        ["id": "doc2", "name": URLEncoder.encode("second test document")]])
-    //doReq(_updatePathJSON + builder.toString())
-    StringBuilder sb = new StringBuilder()
-    sb.append("<add><doc><field name=\"id\">doc1</field><field name=\"name\">first test document").
-      append("</field></doc><doc><field name=\"id\">doc2</field><field name=\"name\">second test document").
-      append("</field></doc></add>")
-    doReq(_updatePathXML + URLEncoder.encode(sb.toString()))
     testEquals(doReq("/select?q=*:*"), "response.numFound", "2")
     testEquals(doReq("/select?q=name:\"first+test+document\""), "response.numFound", "1")
     testEquals(doReq("/select?q=none"), "response.numFound", "0")

--- a/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestStatistics.groovy
+++ b/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestStatistics.groovy
@@ -31,7 +31,7 @@ class TestStatistics extends SolrTestBase {
       if (beans[idx] instanceof String && "CACHE".equals(beans[idx])) {
         // Next object is the stats data for caches.
         Object hits = beans[idx + 1].filterCache.stats.hits
-        break;
+        break
       }
     }
   }

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -205,7 +205,7 @@ bigtop {
       name    = 'solr'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Solr'
-      version { base = '8.11.2'; pkg = base; release = 2 }
+      version { base = '8.11.4'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tgz"
                 source      = destination }
       url     { download_path = "lucene/$name/${version.base}"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Solr to 8.11.4 for the Bigtop 3.4.0 release.

### How was this patch tested?

Tested on Debian 11 and Rocky 9 (x86_64).

```
$ ./gradlew solr-clean solr-pkg repo -Dbuildwithdeps=true

...

BUILD SUCCESSFUL in 21m 57s
34 actionable tasks: 34 executed
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_debian-11.yaml -F docker-compose-cgroupv2.yml -G -L -k zookeeper,solr -s solr -c 3

...

> Task :bigtop-tests:smoke-tests:solr:test
Finished generating test XML results (0.008 secs) into: /bigtop-home/bigtop-tests/smoke-tests/solr/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.01 secs) into: /bigtop-home/bigtop-tests/smoke-tests/solr/build/reports/tests/test
Now testing...
Starting process 'command '/usr/bin/solrctl''. Working directory: /bigtop-home/bigtop-tests/smoke-tests/solr Command: /usr/bin/solrctl collection --delete smoke
Successfully started process 'command '/usr/bin/solrctl''
Starting process 'command '/usr/bin/solrctl''. Working directory: /bigtop-home/bigtop-tests/smoke-tests/solr Command: /usr/bin/solrctl instancedir --delete smoke
Successfully started process 'command '/usr/bin/solrctl''
Starting process 'command '/bin/rm''. Working directory: /bigtop-home/bigtop-tests/smoke-tests/solr Command: /bin/rm -rf /tmp/smoke_data
Successfully started process 'command '/bin/rm''
:bigtop-tests:smoke-tests:solr:test (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 8.707 secs.

BUILD SUCCESSFUL in 33s
27 actionable tasks: 7 executed, 20 up-to-date
```

```
$ ./gradlew solr-clean solr-pkg repo -Dbuildwithdeps=true

...

BUILD SUCCESSFUL in 3m 3s
34 actionable tasks: 34 executed
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_rockylinux-9.yaml -F docker-compose-cgroupv2.yml -r file:///bigtop-home/output -L -G -k zookeeper,solr -s solr -c 1

...

> Task :bigtop-tests:smoke-tests:solr:test
Finished generating test XML results (0.005 secs) into: /bigtop-home/bigtop-tests/smoke-tests/solr/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.01 secs) into: /bigtop-home/bigtop-tests/smoke-tests/solr/build/reports/tests/test
Now testing...
Starting process 'command '/usr/bin/solrctl''. Working directory: /bigtop-home/bigtop-tests/smoke-tests/solr Command: /usr/bin/solrctl collection --delete smoke
Successfully started process 'command '/usr/bin/solrctl''
/usr/bin/solrctl: line 118: warning: command substitution: ignored null byte in input
Starting process 'command '/usr/bin/solrctl''. Working directory: /bigtop-home/bigtop-tests/smoke-tests/solr Command: /usr/bin/solrctl instancedir --delete smoke
Successfully started process 'command '/usr/bin/solrctl''
Starting process 'command '/usr/bin/rm''. Working directory: /bigtop-home/bigtop-tests/smoke-tests/solr Command: /usr/bin/rm -rf /tmp/smoke_data
Successfully started process 'command '/usr/bin/rm''
:bigtop-tests:smoke-tests:solr:test (Thread[Daemon worker,5,main]) completed. Took 8.069 secs.

BUILD SUCCESSFUL in 24s
27 actionable tasks: 6 executed, 21 up-to-date
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/