### PR TITLE
BIGTOP-4288. Upgrade Commons Daemon to 1.4.0.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -281,7 +281,7 @@ bigtop {
     'bigtop-jsvc' {
       name    = "bigtop-jsvc"
       relNotes = "Apache Common Daemon (jsvc) service package"
-      version { base = '1.2.4'; pkg = base; release = 1 }
+      version { base = '1.4.0'; pkg = base; release = 1 }
       tarball { source      = "commons-daemon-${version.base}-native-src.tar.gz"
                 destination = "commons-daemon-${version.base}.tar.gz" }
       url     { download_path = "/commons/daemon/source"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades bigtop-jsvc to 1.4.0.

### How was this patch tested?

Ran `./gradlew bigtop-jsvc-clean bigtop-jsvc-pkg` on Fedora 40 (x86_64).

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/