### PR TITLE
(WIP) BIGTOP-4279. Provide systemd service unit files: Hadoop(YARN)

### DIFF
--- a/bigtop-packages/src/common/hadoop/hadoop-mapreduce-historyserver.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-mapreduce-historyserver.service
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,27 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# postinst script for hadoop
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop MapReduce HistoryServer
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
 
-set -e
-
-case "$1" in
-    configure)
-	mkdir -p /var/log/hadoop-mapreduce /run/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache || :
-	chgrp -R hadoop /var/log/hadoop-mapreduce /run/hadoop-mapreduce
-	chmod g+w /run/hadoop-mapreduce /var/log/hadoop-mapreduce
-	chown mapred:hadoop /var/lib/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache
-	chmod 0755 /var/lib/hadoop-mapreduce
-	chmod 1777 /var/lib/hadoop-mapreduce/cache
-    ;;
-
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
-esac
-
-#DEBHELPER#
+[Service]
+User=mapred
+Group=mapred
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-mapreduce/hadoop-mapred-historyserver.pid
+RuntimeDirectory=hadoop-mapreduce
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/mapred --config /etc/hadoop/conf --daemon start historyserver
+ExecStop=/usr/bin/mapred --config /etc/hadoop/conf --daemon stop historyserver

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-nodemanager.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-nodemanager.service
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,27 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# postinst script for hadoop
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop NodeManager
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
 
-set -e
-
-case "$1" in
-    configure)
-	mkdir -p /var/log/hadoop-mapreduce /run/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache || :
-	chgrp -R hadoop /var/log/hadoop-mapreduce /run/hadoop-mapreduce
-	chmod g+w /run/hadoop-mapreduce /var/log/hadoop-mapreduce
-	chown mapred:hadoop /var/lib/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache
-	chmod 0755 /var/lib/hadoop-mapreduce
-	chmod 1777 /var/lib/hadoop-mapreduce/cache
-    ;;
-
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
-esac
-
-#DEBHELPER#
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-nodemanager.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop nodemanager

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-proxyserver.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-proxyserver.service
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,27 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# postinst script for hadoop
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop ProxyServer
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
 
-set -e
-
-case "$1" in
-    configure)
-	mkdir -p /var/log/hadoop-mapreduce /run/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache || :
-	chgrp -R hadoop /var/log/hadoop-mapreduce /run/hadoop-mapreduce
-	chmod g+w /run/hadoop-mapreduce /var/log/hadoop-mapreduce
-	chown mapred:hadoop /var/lib/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache
-	chmod 0755 /var/lib/hadoop-mapreduce
-	chmod 1777 /var/lib/hadoop-mapreduce/cache
-    ;;
-
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
-esac
-
-#DEBHELPER#
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-proxyserver.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop proxyserver

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-resourcemanager.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-resourcemanager.service
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,27 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# postinst script for hadoop
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop ResourceManager
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
 
-set -e
-
-case "$1" in
-    configure)
-	mkdir -p /var/log/hadoop-mapreduce /run/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache || :
-	chgrp -R hadoop /var/log/hadoop-mapreduce /run/hadoop-mapreduce
-	chmod g+w /run/hadoop-mapreduce /var/log/hadoop-mapreduce
-	chown mapred:hadoop /var/lib/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache
-	chmod 0755 /var/lib/hadoop-mapreduce
-	chmod 1777 /var/lib/hadoop-mapreduce/cache
-    ;;
-
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
-esac
-
-#DEBHELPER#
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-resourcemanager.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop resourcemanager

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-router.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-router.service
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,27 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# postinst script for hadoop
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop Router
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
 
-set -e
-
-case "$1" in
-    configure)
-	mkdir -p /var/log/hadoop-mapreduce /run/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache || :
-	chgrp -R hadoop /var/log/hadoop-mapreduce /run/hadoop-mapreduce
-	chmod g+w /run/hadoop-mapreduce /var/log/hadoop-mapreduce
-	chown mapred:hadoop /var/lib/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache
-	chmod 0755 /var/lib/hadoop-mapreduce
-	chmod 1777 /var/lib/hadoop-mapreduce/cache
-    ;;
-
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
-esac
-
-#DEBHELPER#
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-router.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop router

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-timelineserver.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-timelineserver.service
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,27 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# postinst script for hadoop
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop NodeManager
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
 
-set -e
-
-case "$1" in
-    configure)
-	mkdir -p /var/log/hadoop-mapreduce /run/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache || :
-	chgrp -R hadoop /var/log/hadoop-mapreduce /run/hadoop-mapreduce
-	chmod g+w /run/hadoop-mapreduce /var/log/hadoop-mapreduce
-	chown mapred:hadoop /var/lib/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache
-	chmod 0755 /var/lib/hadoop-mapreduce
-	chmod 1777 /var/lib/hadoop-mapreduce/cache
-    ;;
-
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
-esac
-
-#DEBHELPER#
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-timelineserver.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop timelineserver

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn.tmpfile
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn.tmpfile
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,27 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# postinst script for hadoop
-
-set -e
-
-case "$1" in
-    configure)
-	mkdir -p /var/log/hadoop-mapreduce /run/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache || :
-	chgrp -R hadoop /var/log/hadoop-mapreduce /run/hadoop-mapreduce
-	chmod g+w /run/hadoop-mapreduce /var/log/hadoop-mapreduce
-	chown mapred:hadoop /var/lib/hadoop-mapreduce /var/lib/hadoop-mapreduce/cache
-	chmod 0755 /var/lib/hadoop-mapreduce
-	chmod 1777 /var/lib/hadoop-mapreduce/cache
-    ;;
-
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
-esac
-
-#DEBHELPER#
+d /run/hadoop-yarn 0755 yarn hadoop -

--- a/bigtop-packages/src/common/hadoop/install_hadoop.sh
+++ b/bigtop-packages/src/common/hadoop/install_hadoop.sh
@@ -181,7 +181,7 @@ export PATH="/sbin/:$PATH"
 # Make bin wrappers
 mkdir -p $PREFIX/$BIN_DIR
 
-for component in $PREFIX/$HADOOP_DIR/bin/hadoop $PREFIX/$HDFS_DIR/bin/hdfs $PREFIX/$YARN_DIR/bin/yarn $PREFIX/$MAPREDUCE_DIR/bin/mapred ; do
+for component in $PREFIX/$HADOOP_DIR/bin/hadoop $PREFIX/$HDFS_DIR/bin/hdfs ; do
   wrapper=$PREFIX/$BIN_DIR/${component#*/bin/}
   cat > $wrapper <<EOF
 #!/bin/bash
@@ -195,6 +195,45 @@ exec ${component#${PREFIX}} "\$@"
 EOF
   chmod 755 $wrapper
 done
+
+# mapreduce
+component=$PREFIX/$MAPREDUCE_DIR/bin/mapred
+wrapper=$PREFIX/$BIN_DIR/${component#*/bin/}
+cat > $wrapper <<EOF
+#!/bin/bash
+
+# Autodetect JAVA_HOME if not defined
+. /usr/lib/bigtop-utils/bigtop-detect-javahome
+
+export HADOOP_IDENT_STRING=\${HADOOP_IDENT_STRING:-mapred}
+export HADOOP_PID_DIR=\${HADOOP_PID_DIR:-/run/hadoop-mapreduce}
+export HADOOP_LOG_DIR=\${HADOOP_LOG_DIR:-/var/log/hadoop-mapreduce}
+
+export HADOOP_LIBEXEC_DIR=/$HADOOP_DIR/libexec
+
+exec ${component#${PREFIX}} "\$@"
+EOF
+chmod 755 $wrapper
+
+#yarn
+component=$PREFIX/$YARN_DIR/bin/yarn
+wrapper=$PREFIX/$BIN_DIR/${component#*/bin/}
+cat > $wrapper <<EOF
+#!/bin/bash
+
+# Autodetect JAVA_HOME if not defined
+. /usr/lib/bigtop-utils/bigtop-detect-javahome
+
+export HADOOP_IDENT_STRING=\${HADOOP_IDENT_STRING:-yarn}
+export HADOOP_PID_DIR=\${HADOOP_PID_DIR:-/run/hadoop-yarn}
+export HADOOP_LOG_DIR=\${HADOOP_LOG_DIR:-/var/log/hadoop-yarn}
+export HADOOP_CONF_DIR=\${HADOOP_CONF_DIR:-/etc/hadoop/conf}
+
+export HADOOP_LIBEXEC_DIR=/$HADOOP_DIR/libexec
+
+exec ${component#${PREFIX}} "\$@"
+EOF
+chmod 755 $wrapper
 
 #libexec
 install -d -m 0755 $PREFIX/$HADOOP_DIR/libexec
@@ -414,8 +453,10 @@ install -d -m 0755 ${PREFIX}/${VAR_HDFS}
 install -d -m 0755 ${PREFIX}/${VAR_YARN}
 install -d -m 0755 ${PREFIX}/${VAR_MAPREDUCE}
 install -d -m 0755 $PREFIX/var/{log,run}/hadoop-hdfs
-install -d -m 0755 $PREFIX/var/{log,run}/hadoop-yarn
-install -d -m 0755 $PREFIX/var/{log,run}/hadoop-mapreduce
+install -d -m 0755 $PREFIX/var/log/hadoop-yarn
+install -d -m 0755 $PREFIX/run/hadoop-yarn
+install -d -m 0755 $PREFIX/var/log/hadoop-mapreduce
+install -d -m 0755 $PREFIX/run/hadoop-mapreduce
 
 # Remove all source and create version-less symlinks to offer integration point with other projects
 for DIR in $PREFIX/$HADOOP_DIR $PREFIX/$HDFS_DIR $PREFIX/$YARN_DIR $PREFIX/$MAPREDUCE_DIR ; do

--- a/bigtop-packages/src/common/hadoop/mapreduce.default
+++ b/bigtop-packages/src/common/hadoop/mapreduce.default
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 export HADOOP_IDENT_STRING=mapred
-export HADOOP_PID_DIR=/var/run/hadoop-mapreduce
+export HADOOP_PID_DIR=/run/hadoop-mapreduce
 export HADOOP_LOG_DIR=/var/log/hadoop-mapreduce

--- a/bigtop-packages/src/deb/hadoop/hadoop-mapreduce.install
+++ b/bigtop-packages/src/deb/hadoop/hadoop-mapreduce.install
@@ -7,4 +7,4 @@
 /usr/bin/mapred
 /var/lib/hadoop-mapreduce
 /var/log/hadoop-mapreduce
-/var/run/hadoop-mapreduce
+/run/hadoop-mapreduce

--- a/bigtop-packages/src/deb/hadoop/hadoop-yarn.install
+++ b/bigtop-packages/src/deb/hadoop/hadoop-yarn.install
@@ -8,4 +8,4 @@
 /usr/bin/yarn
 /var/lib/hadoop-yarn
 /var/log/hadoop-yarn
-/var/run/hadoop-yarn
+/run/hadoop-yarn

--- a/bigtop-packages/src/deb/hadoop/hadoop-yarn.postinst
+++ b/bigtop-packages/src/deb/hadoop/hadoop-yarn.postinst
@@ -23,9 +23,9 @@ case "$1" in
     configure)
 	chown root:yarn /usr/lib/hadoop-yarn/bin/container-executor
 	chmod 4754 /usr/lib/hadoop-yarn/bin/container-executor
-	mkdir -p /var/log/hadoop-yarn /var/run/hadoop-yarn /var/lib/hadoop-yarn/cache || :
-	chown yarn:hadoop /var/log/hadoop-yarn /var/run/hadoop-yarn
-	chmod g+w /var/log/hadoop-yarn /var/run/hadoop-yarn
+	mkdir -p /var/log/hadoop-yarn /run/hadoop-yarn /var/lib/hadoop-yarn/cache || :
+	chown yarn:hadoop /var/log/hadoop-yarn /run/hadoop-yarn
+	chmod g+w /var/log/hadoop-yarn /run/hadoop-yarn
 	chown yarn:hadoop /var/lib/hadoop-yarn/ /var/lib/hadoop-yarn/cache
 	chmod 0755 /var/lib/hadoop-yarn
 	chmod 1777 /var/lib/hadoop-yarn/cache

--- a/bigtop-packages/src/deb/hadoop/rules
+++ b/bigtop-packages/src/deb/hadoop/rules
@@ -71,6 +71,13 @@ override_dh_auto_install:
 	cp debian/hadoop-fuse.default debian/tmp/etc/default/hadoop-fuse
 	mkdir -p debian/tmp/etc/security/limits.d
 	cp debian/hdfs.conf debian/yarn.conf debian/mapreduce.conf debian/tmp/etc/security/limits.d
+	cp debian/hadoop-mapreduce-historyserver.service .
+	cp debian/hadoop-yarn-router.service .
+	cp debian/hadoop-yarn-proxyserver.service .
+	cp debian/hadoop-yarn-timelineserver.service .
+	cp debian/hadoop-yarn-nodemanager.service .
+	cp debian/hadoop-yarn-resourcemanager.service .
+	cp debian/hadoop-yarn.tmpfile .
 
 override_dh_install: $(hadoop_svcs)
 	dh_install


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4279

This is a draft PR because we need to merge #1313 

### How was this patch tested?

Tested on both RPM(rocky linux8) and DEB (Ubuntu 22.04 w/ https://github.com/apache/bigtop/pull/1304, https://github.com/apache/bigtop/pull/1305)

* Check if building package is SUCCESSFUL
* Check if `yarn` smoke test is SUCCESSFUL
* Check if hadoop-yarn-{resourcemanager, nodemanager, proxyserver, router, timelineserver} is running with the packages
* Check if the services can start after restating
  * Since `/run/hadoop-yarn` is shared by multiple services, I used `systemd-tmpfile` to create it (Unlike hadoop-mapreduce's approach)

<details>
<summary>Tested logs</summary>

* build & smoketests

```
$ ./gradlew allclean hadoop-pkg-ind repo-ind -POS=rockylinux-8
$ cd provisioner/docker
$ ./docker-hadoop.sh --enable-local-repo --disable-gpg-check     --docker-compose-plugin     -C config_rockylinux-8.yaml     -F docker-compose-cgroupv2.yml     --stack hdfs,yarn --smoke-tests yarn -c 1
(snip)
BUILD SUCCESSFUL in 15s
28 actionable tasks: 7 executed, 21 up-to-date
Stopped 1 worker daemon(s).
+ rm -rf buildSrc/build/test-results/binary
+ rm -rf /bigtop-home/.gradle
```

* install additional packages (timelineserver, router), `systemctl start`, then `systemctl status`

```
$ ./docker-hadoop.sh -dcp --exec 1 /bin/bash
[root@a60f5b5943d3 /]# dnf install hadoop-yarn-timelineserver hadoop-yarn-router
(snip)
Complete!


[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl start hadoop-yarn-$service_name; done


[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
● hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-resourcemanager.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:01:49 UTC; 4min 55s ago
     Docs: https://hadoop.apache.org/
 Main PID: 6692 (java)
    Tasks: 227 (limit: 5099)
   Memory: 437.7M
   CGroup: /system.slice/hadoop-yarn-resourcemanager.service
           └─6692 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_resourcemanager -Djava.net.preferIPv4Stack=true -Dservice.libdir=/usr/lib/hadoop-yarn/./,/usr/lib/hadoop-yarn/lib,/usr/lib/hadoop-hdfs/./,/usr/lib/hadoop-hdfs/lib,/usr/lib/hadoop/./,/usr/lib/hadoop/lib -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-res…

Dec 01 03:01:47 a60f5b5943d3 systemd[1]: Starting Hadoop ResourceManager...
Dec 01 03:01:49 a60f5b5943d3 systemd[1]: Started Hadoop ResourceManager.
● hadoop-yarn-nodemanager.service - Hadoop NodeManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-nodemanager.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:02:21 UTC; 4min 24s ago
     Docs: https://hadoop.apache.org/
 Main PID: 8309 (java)
    Tasks: 102 (limit: 5099)
   Memory: 293.2M
   CGroup: /system.slice/hadoop-yarn-nodemanager.service
           └─8309 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_nodemanager -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-nodemanager-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.di…

Dec 01 03:02:19 a60f5b5943d3 systemd[1]: Starting Hadoop NodeManager...
Dec 01 03:02:21 a60f5b5943d3 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-proxyserver.service - Hadoop ProxyServer
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-proxyserver.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:01:56 UTC; 4min 48s ago
     Docs: https://hadoop.apache.org/
 Main PID: 7184 (java)
    Tasks: 33 (limit: 5099)
   Memory: 129.3M
   CGroup: /system.slice/hadoop-yarn-proxyserver.service
           └─7184 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_proxyserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-proxyserver-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.di…

Dec 01 03:01:54 a60f5b5943d3 systemd[1]: Starting Hadoop ProxyServer...
Dec 01 03:01:56 a60f5b5943d3 systemd[1]: Started Hadoop ProxyServer.
● hadoop-yarn-timelineserver.service - Hadoop NodeManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-timelineserver.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:06:27 UTC; 18s ago
     Docs: https://hadoop.apache.org/
  Process: 9484 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver (code=exited, status=0/SUCCESS)
 Main PID: 9535 (java)
    Tasks: 53 (limit: 5099)
   Memory: 424.5M
   CGroup: /system.slice/hadoop-yarn-timelineserver.service
           └─9535 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_timelineserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-timelineserver-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.…

Dec 01 03:06:25 a60f5b5943d3 systemd[1]: Starting Hadoop NodeManager...
Dec 01 03:06:27 a60f5b5943d3 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-router.service - Hadoop Router
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-router.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:06:29 UTC; 16s ago
     Docs: https://hadoop.apache.org/
  Process: 9598 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router (code=exited, status=0/SUCCESS)
 Main PID: 9649 (java)
    Tasks: 97 (limit: 5099)
   Memory: 274.4M
   CGroup: /system.slice/hadoop-yarn-router.service
           └─9649 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_router -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-router-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.dir=/var/log…

Dec 01 03:06:27 a60f5b5943d3 systemd[1]: Starting Hadoop Router...
Dec 01 03:06:29 a60f5b5943d3 systemd[1]: Started Hadoop Router.
```

* Check if prepared unit files are used w/ `systemctl cat`
```
[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl cat hadoop-yarn-$service_name; done
# /usr/lib/systemd/system/hadoop-yarn-resourcemanager.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop ResourceManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-resourcemanager.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop resourcemanager
# /usr/lib/systemd/system/hadoop-yarn-nodemanager.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop NodeManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-nodemanager.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop nodemanager
# /usr/lib/systemd/system/hadoop-yarn-proxyserver.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop ProxyServer
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-proxyserver.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop proxyserver
# /usr/lib/systemd/system/hadoop-yarn-timelineserver.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop NodeManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-timelineserver.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop timelineserver
# /usr/lib/systemd/system/hadoop-yarn-router.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop Router
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-router.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop router
```

* restart container

```
[root@a60f5b5943d3 /]# exit
$ docker restart a60f5b5943d3
$ ./docker-hadoop.sh -dcp --exec 1 /bin/bash
[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl start hadoop-yarn-$service_name; done
[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
● hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-resourcemanager.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:27 UTC; 14s ago
     Docs: https://hadoop.apache.org/
  Process: 401 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager (code=exited, status=0/SUCCESS)
 Main PID: 455 (java)
    Tasks: 231 (limit: 5099)
   Memory: 456.5M
   CGroup: /system.slice/hadoop-yarn-resourcemanager.service
           └─455 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_resourcemanager -Djava.net.preferIPv4Stack=true -Dservice.libdir=/usr/lib/hadoop-yarn/./,/usr/lib/hadoop-yarn/lib,/usr/lib/hadoop-hdfs/./,/usr/lib/hadoop-hdfs/lib,/usr/lib/hadoop/./,/usr/lib/hadoop/lib -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-reso…

Dec 01 03:12:25 a60f5b5943d3 systemd[1]: Starting Hadoop ResourceManager...
Dec 01 03:12:27 a60f5b5943d3 systemd[1]: Started Hadoop ResourceManager.
● hadoop-yarn-nodemanager.service - Hadoop NodeManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-nodemanager.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:29 UTC; 12s ago
     Docs: https://hadoop.apache.org/
  Process: 695 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager (code=exited, status=0/SUCCESS)
 Main PID: 749 (java)
    Tasks: 107 (limit: 5099)
   Memory: 287.7M
   CGroup: /system.slice/hadoop-yarn-nodemanager.service
           └─749 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_nodemanager -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-nodemanager-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.dir…

Dec 01 03:12:27 a60f5b5943d3 systemd[1]: Starting Hadoop NodeManager...
Dec 01 03:12:29 a60f5b5943d3 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-proxyserver.service - Hadoop ProxyServer
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-proxyserver.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:31 UTC; 10s ago
     Docs: https://hadoop.apache.org/
  Process: 918 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver (code=exited, status=0/SUCCESS)
 Main PID: 970 (java)
    Tasks: 34 (limit: 5099)
   Memory: 123.6M
   CGroup: /system.slice/hadoop-yarn-proxyserver.service
           └─970 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_proxyserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-proxyserver-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.dir…

Dec 01 03:12:29 a60f5b5943d3 systemd[1]: Starting Hadoop ProxyServer...
Dec 01 03:12:31 a60f5b5943d3 systemd[1]: Started Hadoop ProxyServer.
● hadoop-yarn-timelineserver.service - Hadoop NodeManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-timelineserver.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:33 UTC; 8s ago
     Docs: https://hadoop.apache.org/
  Process: 1012 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver (code=exited, status=0/SUCCESS)
 Main PID: 1064 (java)
    Tasks: 53 (limit: 5099)
   Memory: 246.1M
   CGroup: /system.slice/hadoop-yarn-timelineserver.service
           └─1064 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_timelineserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-timelineserver-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.…

Dec 01 03:12:31 a60f5b5943d3 systemd[1]: Starting Hadoop NodeManager...
Dec 01 03:12:33 a60f5b5943d3 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-router.service - Hadoop Router
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-router.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:36 UTC; 6s ago
     Docs: https://hadoop.apache.org/
  Process: 1127 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router (code=exited, status=0/SUCCESS)
 Main PID: 1179 (java)
    Tasks: 97 (limit: 5099)
   Memory: 277.0M
   CGroup: /system.slice/hadoop-yarn-router.service
           └─1179 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_router -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-router-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.dir=/var/log…

Dec 01 03:12:33 a60f5b5943d3 systemd[1]: Starting Hadoop Router...
Dec 01 03:12:36 a60f5b5943d3 systemd[1]: Started Hadoop Router.
```


#### DEB (Ubuntu-22.04)

* build & smoketests

```
$ ./gradlew hadoop-clean bigtop-utils-pkg bigtop-jsvc-pkg bigtop-groovy-pkg hadoop-pkg repo
(snip)
$ cd provisioner/docker/
$ ./docker-hadoop.sh --enable-local-repo --disable-gpg-check     --docker-compose-plugin     -C config_ubuntu-22.04.yaml     -F docker-compose-cgroupv2.yml     --stack hdfs,yarn --smoke-tests yarn -c 1
(snip)
Gradle Test Executor 2 finished executing tests.

> Task :bigtop-tests:smoke-tests:yarn:test
Finished generating test XML results (0.003 secs) into: /bigtop-home/bigtop-tests/smoke-tests/yarn/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.006 secs) into: /bigtop-home/bigtop-tests/smoke-tests/yarn/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:yarn:test (Thread[Execution worker for ':' Thread 6,5,main]) completed. Took 2.93 secs.

BUILD SUCCESSFUL in 20s
28 actionable tasks: 6 executed, 22 up-to-date
Stopped 1 worker daemon(s).
+ rm -rf buildSrc/build/test-results/binary
+ rm -rf /bigtop-home/.gradle
```


* install additional packages (timelineserver, router), `systemctl start`, then `systemctl status`

```
$ ./docker-hadoop.sh -dcp --exec 1 /bin/bash
root@cd7a61f76c23:/# apt install hadoop-yarn-timelineserver hadoop-yarn-router
(snip)
root@cd7a61f76c23:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl start hadoop-yarn-$service_name; done
root@cd7a61f76c23:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
● hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-resourcemanager.service; static)
     Active: active (running) since Sun 2024-12-01 09:20:23 UTC; 5min ago
       Docs: https://hadoop.apache.org/
   Main PID: 5842 (java)
      Tasks: 227 (limit: 956)
     Memory: 422.4M
        CPU: 7.317s
     CGroup: /system.slice/hadoop-yarn-resourcemanager.service
             └─5842 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_resourcemanager -Djava.net.preferIPv4Stack=true -Dservice.libdir=/usr/lib/hadoop-yarn/./,/usr/lib/hado…

Dec 01 09:20:21 cd7a61f76c23 systemd[1]: Starting Hadoop ResourceManager...
Dec 01 09:20:23 cd7a61f76c23 systemd[1]: Started Hadoop ResourceManager.
● hadoop-yarn-nodemanager.service - Hadoop NodeManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-nodemanager.service; static)
     Active: active (running) since Sun 2024-12-01 09:20:44 UTC; 5min ago
       Docs: https://hadoop.apache.org/
   Main PID: 6949 (java)
      Tasks: 102 (limit: 956)
     Memory: 282.3M
        CPU: 5.484s
     CGroup: /system.slice/hadoop-yarn-nodemanager.service
             └─6949 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_nodemanager -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop…

Dec 01 09:20:42 cd7a61f76c23 systemd[1]: Starting Hadoop NodeManager...
Dec 01 09:20:44 cd7a61f76c23 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-proxyserver.service - Hadoop ProxyServer
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-proxyserver.service; static)
     Active: active (running) since Sun 2024-12-01 09:20:29 UTC; 5min ago
       Docs: https://hadoop.apache.org/
   Main PID: 6429 (java)
      Tasks: 33 (limit: 956)
     Memory: 118.4M
        CPU: 1.318s
     CGroup: /system.slice/hadoop-yarn-proxyserver.service
             └─6429 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_proxyserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop…

Dec 01 09:20:27 cd7a61f76c23 systemd[1]: Starting Hadoop ProxyServer...
Dec 01 09:20:29 cd7a61f76c23 systemd[1]: Started Hadoop ProxyServer.
● hadoop-yarn-timelineserver.service - Hadoop NodeManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-timelineserver.service; static)
     Active: active (running) since Sun 2024-12-01 09:26:15 UTC; 7s ago
       Docs: https://hadoop.apache.org/
    Process: 8047 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver (code=exited, status=0/SUCCESS)
   Main PID: 8086 (java)
      Tasks: 53 (limit: 956)
     Memory: 351.3M
        CPU: 2.539s
     CGroup: /system.slice/hadoop-yarn-timelineserver.service
             └─8086 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_timelineserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=had…

Dec 01 09:26:13 cd7a61f76c23 systemd[1]: Starting Hadoop NodeManager...
Dec 01 09:26:15 cd7a61f76c23 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-router.service - Hadoop Router
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-router.service; static)
     Active: active (running) since Sun 2024-12-01 09:26:17 UTC; 5s ago
       Docs: https://hadoop.apache.org/
    Process: 8149 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router (code=exited, status=0/SUCCESS)
   Main PID: 8188 (java)
      Tasks: 97 (limit: 956)
     Memory: 259.5M
        CPU: 2.636s
     CGroup: /system.slice/hadoop-yarn-router.service
             └─8188 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_router -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn…

Dec 01 09:26:15 cd7a61f76c23 systemd[1]: Starting Hadoop Router...
Dec 01 09:26:17 cd7a61f76c23 systemd[1]: Started Hadoop Router.
```

* * Check if prepared unit files are used w/ `systemctl cat` `systemctl cat`

```
root@cd7a61f76c23:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl cat hadoop-yarn-$service_name; done
# /lib/systemd/system/hadoop-yarn-resourcemanager.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop ResourceManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-resourcemanager.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop resourcemanager
# /lib/systemd/system/hadoop-yarn-nodemanager.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop NodeManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-nodemanager.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop nodemanager
# /lib/systemd/system/hadoop-yarn-proxyserver.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop ProxyServer
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-proxyserver.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop proxyserver
# /lib/systemd/system/hadoop-yarn-timelineserver.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop NodeManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-timelineserver.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop timelineserver
# /lib/systemd/system/hadoop-yarn-router.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop Router
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-router.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop router
```


* restart container

```
root@cd7a61f76c23:/# exit
exit
masatana@ubuntu-2204-dev:~/bigtop/provisioner/docker$ docker restart cd7a61f76c23
cd7a61f76c23
masatana@ubuntu-2204-dev:~/bigtop/provisioner/docker$ ./docker-hadoop.sh -dcp --exec 1 /bin/bash
root@cd7a61f76c23:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
○ hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-resourcemanager.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 01 09:20:21 cd7a61f76c23 systemd[1]: Starting Hadoop ResourceManager...
Dec 01 09:20:23 cd7a61f76c23 systemd[1]: Started Hadoop ResourceManager.
○ hadoop-yarn-nodemanager.service - Hadoop NodeManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-nodemanager.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 01 09:20:42 cd7a61f76c23 systemd[1]: Starting Hadoop NodeManager...
Dec 01 09:20:44 cd7a61f76c23 systemd[1]: Started Hadoop NodeManager.
○ hadoop-yarn-proxyserver.service - Hadoop ProxyServer
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-proxyserver.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 01 09:20:27 cd7a61f76c23 systemd[1]: Starting Hadoop ProxyServer...
Dec 01 09:20:29 cd7a61f76c23 systemd[1]: Started Hadoop ProxyServer.
○ hadoop-yarn-timelineserver.service - Hadoop NodeManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-timelineserver.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 01 09:26:13 cd7a61f76c23 systemd[1]: Starting Hadoop NodeManager...
Dec 01 09:26:15 cd7a61f76c23 systemd[1]: Started Hadoop NodeManager.
○ hadoop-yarn-router.service - Hadoop Router
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-router.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 01 09:26:15 cd7a61f76c23 systemd[1]: Starting Hadoop Router...
Dec 01 09:26:17 cd7a61f76c23 systemd[1]: Started Hadoop Router.
root@cd7a61f76c23:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl start hadoop-yarn-$service_name; done
root@cd7a61f76c23:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
● hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-resourcemanager.service; static)
     Active: active (running) since Sun 2024-12-01 09:29:11 UTC; 13s ago
       Docs: https://hadoop.apache.org/
    Process: 412 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager (code=exited, status=0/SUCCESS)
   Main PID: 454 (java)
      Tasks: 229 (limit: 956)
     Memory: 402.6M
        CPU: 3.940s
     CGroup: /system.slice/hadoop-yarn-resourcemanager.service
             └─454 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_resourcemanager -Djava.net.preferIPv4Stack=true -Dservice.libdir=/usr/lib/hadoop-yarn/./,/usr/lib/hadoo…

Dec 01 09:29:09 cd7a61f76c23 systemd[1]: Starting Hadoop ResourceManager...
Dec 01 09:29:11 cd7a61f76c23 systemd[1]: Started Hadoop ResourceManager.
● hadoop-yarn-nodemanager.service - Hadoop NodeManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-nodemanager.service; static)
     Active: active (running) since Sun 2024-12-01 09:29:13 UTC; 11s ago
       Docs: https://hadoop.apache.org/
    Process: 691 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager (code=exited, status=0/SUCCESS)
   Main PID: 733 (java)
      Tasks: 107 (limit: 956)
     Memory: 287.1M
        CPU: 2.745s
     CGroup: /system.slice/hadoop-yarn-nodemanager.service
             └─733 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_nodemanager -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-…

Dec 01 09:29:11 cd7a61f76c23 systemd[1]: Starting Hadoop NodeManager...
Dec 01 09:29:13 cd7a61f76c23 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-proxyserver.service - Hadoop ProxyServer
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-proxyserver.service; static)
     Active: active (running) since Sun 2024-12-01 09:29:15 UTC; 9s ago
       Docs: https://hadoop.apache.org/
    Process: 902 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver (code=exited, status=0/SUCCESS)
   Main PID: 942 (java)
      Tasks: 34 (limit: 956)
     Memory: 123.5M
        CPU: 1.060s
     CGroup: /system.slice/hadoop-yarn-proxyserver.service
             └─942 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_proxyserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-…

Dec 01 09:29:13 cd7a61f76c23 systemd[1]: Starting Hadoop ProxyServer...
Dec 01 09:29:15 cd7a61f76c23 systemd[1]: Started Hadoop ProxyServer.
● hadoop-yarn-timelineserver.service - Hadoop NodeManager
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-timelineserver.service; static)
     Active: active (running) since Sun 2024-12-01 09:29:17 UTC; 7s ago
       Docs: https://hadoop.apache.org/
    Process: 984 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver (code=exited, status=0/SUCCESS)
   Main PID: 1024 (java)
      Tasks: 53 (limit: 956)
     Memory: 256.2M
        CPU: 2.300s
     CGroup: /system.slice/hadoop-yarn-timelineserver.service
             └─1024 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_timelineserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=had…

Dec 01 09:29:15 cd7a61f76c23 systemd[1]: Starting Hadoop NodeManager...
Dec 01 09:29:17 cd7a61f76c23 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-router.service - Hadoop Router
     Loaded: loaded (/lib/systemd/system/hadoop-yarn-router.service; static)
     Active: active (running) since Sun 2024-12-01 09:29:19 UTC; 5s ago
       Docs: https://hadoop.apache.org/
    Process: 1087 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router (code=exited, status=0/SUCCESS)
   Main PID: 1127 (java)
      Tasks: 97 (limit: 956)
     Memory: 299.0M
        CPU: 2.505s
     CGroup: /system.slice/hadoop-yarn-router.service
             └─1127 /usr/lib/jvm/java-1.8.0-openjdk-arm64/bin/java -Dproc_router -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn…

Dec 01 09:29:17 cd7a61f76c23 systemd[1]: Starting Hadoop Router...
Dec 01 09:29:19 cd7a61f76c23 systemd[1]: Started Hadoop Router.
```

</details>

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/