### PR TITLE
BIGTOP-4279: Provide systemd service unit files: Hadoop(YARN)

### DIFF
--- a/bigtop-packages/src/common/hadoop/hadoop-layout.sh
+++ b/bigtop-packages/src/common/hadoop/hadoop-layout.sh
@@ -23,9 +23,9 @@ YARN_LIB_JARS_DIR="lib"
 MAPRED_DIR="./"
 MAPRED_LIB_JARS_DIR="lib"
 
-HADOOP_LIBEXEC_DIR=${HADOOP_LIBEXEC_DIR:-"/usr/lib/hadoop/libexec"}
-HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-"/etc/hadoop/conf"}
-HADOOP_COMMON_HOME=${HADOOP_COMMON_HOME:-"/usr/lib/hadoop"}
-HADOOP_HDFS_HOME=${HADOOP_HDFS_HOME:-"/usr/lib/hadoop-hdfs"}
-HADOOP_MAPRED_HOME=${HADOOP_MAPRED_HOME:-"/usr/lib/hadoop-mapreduce"}
-HADOOP_YARN_HOME=${HADOOP_YARN_HOME:-"/usr/lib/hadoop-yarn"}
+export HADOOP_LIBEXEC_DIR=${HADOOP_LIBEXEC_DIR:-"/usr/lib/hadoop/libexec"}
+export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-"/etc/hadoop/conf"}
+export HADOOP_COMMON_HOME=${HADOOP_COMMON_HOME:-"/usr/lib/hadoop"}
+export HADOOP_HDFS_HOME=${HADOOP_HDFS_HOME:-"/usr/lib/hadoop-hdfs"}
+export HADOOP_MAPRED_HOME=${HADOOP_MAPRED_HOME:-"/usr/lib/hadoop-mapreduce"}
+export HADOOP_YARN_HOME=${HADOOP_YARN_HOME:-"/usr/lib/hadoop-yarn"}

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-nodemanager.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-nodemanager.service
@@ -12,7 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export HADOOP_IDENT_STRING=yarn
-export HADOOP_PID_DIR=/run/hadoop-yarn
-export HADOOP_LOG_DIR=/var/log/hadoop-yarn
-export HADOOP_CONF_DIR=/etc/hadoop/conf
+
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop NodeManager
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
+
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-nodemanager.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop nodemanager

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-proxyserver.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-proxyserver.service
@@ -12,7 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export HADOOP_IDENT_STRING=yarn
-export HADOOP_PID_DIR=/run/hadoop-yarn
-export HADOOP_LOG_DIR=/var/log/hadoop-yarn
-export HADOOP_CONF_DIR=/etc/hadoop/conf
+
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop ProxyServer
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
+
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-proxyserver.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop proxyserver

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-resourcemanager.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-resourcemanager.service
@@ -12,7 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export HADOOP_IDENT_STRING=yarn
-export HADOOP_PID_DIR=/run/hadoop-yarn
-export HADOOP_LOG_DIR=/var/log/hadoop-yarn
-export HADOOP_CONF_DIR=/etc/hadoop/conf
+
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop ResourceManager
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
+
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-resourcemanager.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop resourcemanager

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-router.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-router.service
@@ -12,7 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export HADOOP_IDENT_STRING=yarn
-export HADOOP_PID_DIR=/run/hadoop-yarn
-export HADOOP_LOG_DIR=/var/log/hadoop-yarn
-export HADOOP_CONF_DIR=/etc/hadoop/conf
+
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop Router
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
+
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-router.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop router

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-timelineserver.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-timelineserver.service
@@ -12,7 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export HADOOP_IDENT_STRING=yarn
-export HADOOP_PID_DIR=/run/hadoop-yarn
-export HADOOP_LOG_DIR=/var/log/hadoop-yarn
-export HADOOP_CONF_DIR=/etc/hadoop/conf
+
+[Unit]
+Documentation=https://hadoop.apache.org/
+Description=Hadoop NodeManager
+Before=multi-user.target
+Before=graphical.target
+After=remote-fs.target
+
+[Service]
+User=yarn
+Group=yarn
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+PIDFile=/run/hadoop-yarn/hadoop-yarn-timelineserver.pid
+SuccessExitStatus=5 6
+ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver
+ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop timelineserver

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn.tmpfile
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn.tmpfile
@@ -12,7 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export HADOOP_IDENT_STRING=yarn
-export HADOOP_PID_DIR=/run/hadoop-yarn
-export HADOOP_LOG_DIR=/var/log/hadoop-yarn
-export HADOOP_CONF_DIR=/etc/hadoop/conf
+
+d /run/hadoop-yarn 0755 yarn hadoop -

--- a/bigtop-packages/src/common/hadoop/install_hadoop.sh
+++ b/bigtop-packages/src/common/hadoop/install_hadoop.sh
@@ -181,7 +181,7 @@ export PATH="/sbin/:$PATH"
 # Make bin wrappers
 mkdir -p $PREFIX/$BIN_DIR
 
-for component in $PREFIX/$HADOOP_DIR/bin/hadoop $PREFIX/$HDFS_DIR/bin/hdfs $PREFIX/$YARN_DIR/bin/yarn ; do
+for component in $PREFIX/$HADOOP_DIR/bin/hadoop $PREFIX/$HDFS_DIR/bin/hdfs ; do
   wrapper=$PREFIX/$BIN_DIR/${component#*/bin/}
   cat > $wrapper <<EOF
 #!/bin/bash
@@ -208,6 +208,26 @@ cat > $wrapper <<EOF
 export HADOOP_IDENT_STRING=\${HADOOP_IDENT_STRING:-mapred}
 export HADOOP_PID_DIR=\${HADOOP_PID_DIR:-/run/hadoop-mapreduce}
 export HADOOP_LOG_DIR=\${HADOOP_LOG_DIR:-/var/log/hadoop-mapreduce}
+
+export HADOOP_LIBEXEC_DIR=/$HADOOP_DIR/libexec
+
+exec ${component#${PREFIX}} "\$@"
+EOF
+chmod 755 $wrapper
+
+#yarn
+component=$PREFIX/$YARN_DIR/bin/yarn
+wrapper=$PREFIX/$BIN_DIR/${component#*/bin/}
+cat > $wrapper <<EOF
+#!/bin/bash
+
+# Autodetect JAVA_HOME if not defined
+. /usr/lib/bigtop-utils/bigtop-detect-javahome
+
+export HADOOP_IDENT_STRING=\${HADOOP_IDENT_STRING:-yarn}
+export HADOOP_PID_DIR=\${HADOOP_PID_DIR:-/run/hadoop-yarn}
+export HADOOP_LOG_DIR=\${HADOOP_LOG_DIR:-/var/log/hadoop-yarn}
+export HADOOP_CONF_DIR=\${HADOOP_CONF_DIR:-/etc/hadoop/conf}
 
 export HADOOP_LIBEXEC_DIR=/$HADOOP_DIR/libexec
 
@@ -433,7 +453,8 @@ install -d -m 0755 ${PREFIX}/${VAR_HDFS}
 install -d -m 0755 ${PREFIX}/${VAR_YARN}
 install -d -m 0755 ${PREFIX}/${VAR_MAPREDUCE}
 install -d -m 0755 $PREFIX/var/{log,run}/hadoop-hdfs
-install -d -m 0755 $PREFIX/var/{log,run}/hadoop-yarn
+install -d -m 0755 $PREFIX/var/log/hadoop-yarn
+install -d -m 0755 $PREFIX/run/hadoop-yarn
 install -d -m 0755 $PREFIX/var/log/hadoop-mapreduce
 install -d -m 0755 $PREFIX/run/hadoop-mapreduce
 

--- a/bigtop-packages/src/deb/hadoop/hadoop-yarn.install
+++ b/bigtop-packages/src/deb/hadoop/hadoop-yarn.install
@@ -8,4 +8,4 @@
 /usr/bin/yarn
 /var/lib/hadoop-yarn
 /var/log/hadoop-yarn
-/var/run/hadoop-yarn
+/run/hadoop-yarn

--- a/bigtop-packages/src/deb/hadoop/hadoop-yarn.postinst
+++ b/bigtop-packages/src/deb/hadoop/hadoop-yarn.postinst
@@ -23,9 +23,9 @@ case "$1" in
     configure)
 	chown root:yarn /usr/lib/hadoop-yarn/bin/container-executor
 	chmod 4754 /usr/lib/hadoop-yarn/bin/container-executor
-	mkdir -p /var/log/hadoop-yarn /var/run/hadoop-yarn /var/lib/hadoop-yarn/cache || :
-	chown yarn:hadoop /var/log/hadoop-yarn /var/run/hadoop-yarn
-	chmod g+w /var/log/hadoop-yarn /var/run/hadoop-yarn
+	mkdir -p /var/log/hadoop-yarn /run/hadoop-yarn /var/lib/hadoop-yarn/cache || :
+	chown yarn:hadoop /var/log/hadoop-yarn /run/hadoop-yarn
+	chmod g+w /var/log/hadoop-yarn /run/hadoop-yarn
 	chown yarn:hadoop /var/lib/hadoop-yarn/ /var/lib/hadoop-yarn/cache
 	chmod 0755 /var/lib/hadoop-yarn
 	chmod 1777 /var/lib/hadoop-yarn/cache

--- a/bigtop-packages/src/deb/hadoop/rules
+++ b/bigtop-packages/src/deb/hadoop/rules
@@ -71,6 +71,7 @@ override_dh_auto_install:
 	cp debian/hadoop-fuse.default debian/tmp/etc/default/hadoop-fuse
 	mkdir -p debian/tmp/etc/security/limits.d
 	cp debian/hdfs.conf debian/yarn.conf debian/mapreduce.conf debian/tmp/etc/security/limits.d
+	cp debian/hadoop-mapreduce-historyserver.service .
 
 override_dh_install: $(hadoop_svcs)
 	dh_install

--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -54,7 +54,7 @@
 %define np_var_log_httpfs /var/log/%{hadoop_name}-httpfs
 %define np_var_log_kms /var/log/%{hadoop_name}-kms
 %define np_var_log_mapreduce /var/log/%{hadoop_name}-mapreduce
-%define np_var_run_yarn /var/run/%{hadoop_name}-yarn
+%define np_run_yarn /run/%{hadoop_name}-yarn
 %define np_var_run_hdfs /var/run/%{hadoop_name}-hdfs
 %define np_var_run_httpfs /var/run/%{hadoop_name}-httpfs
 %define np_var_run_kms /var/run/%{hadoop_name}-kms
@@ -178,6 +178,13 @@ Source29: hadoop-yarn-timelineserver.svc
 Source30: hadoop-kms.svc
 Source31: kms.default
 Source32: hadoop-mapreduce-historyserver.service
+Source33: hadoop-yarn-resourcemanager.service
+Source34: hadoop-yarn-nodemanager.service
+Source35: hadoop-yarn-router.service
+Source36: hadoop-yarn-proxyserver.service
+Source37: hadoop-yarn-timelineserver.service
+Source38: hadoop-yarn.tmpfile
+
 #BIGTOP_PATCH_FILES
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id} -u -n)
 BuildRequires: fuse-devel, fuse, systemd, systemd-rpm-macros
@@ -595,6 +602,12 @@ do
 done
 
 %__install -D -m 0644 %{SOURCE32} $RPM_BUILD_ROOT/%{_unitdir}/hadoop-mapreduce-historyserver.service
+%__install -D -m 0644 %{SOURCE38} $RPM_BUILD_ROOT/%{_tmpfilesdir}/hadoop-yarn.conf
+%__install -D -m 0644 %{SOURCE33} $RPM_BUILD_ROOT/%{_unitdir}/hadoop-yarn-resourcemanager.service
+%__install -D -m 0644 %{SOURCE34} $RPM_BUILD_ROOT/%{_unitdir}/hadoop-yarn-nodemanager.service
+%__install -D -m 0644 %{SOURCE35} $RPM_BUILD_ROOT/%{_unitdir}/hadoop-yarn-router.service
+%__install -D -m 0644 %{SOURCE36} $RPM_BUILD_ROOT/%{_unitdir}/hadoop-yarn-proxyserver.service
+%__install -D -m 0644 %{SOURCE37} $RPM_BUILD_ROOT/%{_unitdir}/hadoop-yarn-timelineserver.service
 
 # Install security limits
 %__install -d -m 0755 $RPM_BUILD_ROOT/etc/security/limits.d
@@ -617,11 +630,12 @@ done
 %__install -d -m 0755 $RPM_BUILD_ROOT/%{np_var_log_httpfs}
 %__install -d -m 0755 $RPM_BUILD_ROOT/%{np_var_log_kms}
 # /var/run/*
-%__install -d -m 0755 $RPM_BUILD_ROOT/%{np_var_run_yarn}
 %__install -d -m 0755 $RPM_BUILD_ROOT/%{np_var_run_hdfs}
 %__install -d -m 0755 $RPM_BUILD_ROOT/%{np_var_run_mapreduce}
 %__install -d -m 0755 $RPM_BUILD_ROOT/%{np_var_run_httpfs}
 %__install -d -m 0755 $RPM_BUILD_ROOT/%{np_var_run_kms}
+# /run/*
+%__install -d -m 0755 $RPM_BUILD_ROOT/%{np_run_yarn}
 
 %__install -d -m 1777 $RPM_BUILD_ROOT/%{usr_lib_hadoop}/logs
 
@@ -691,14 +705,15 @@ fi
 %config(noreplace) %{etc_hadoop}/conf.empty/capacity-scheduler.xml
 %config(noreplace) %{etc_hadoop}/conf.empty/container-executor.cfg
 %config(noreplace) /etc/security/limits.d/yarn.conf
+%config(noreplace) %{_tmpfilesdir}/hadoop-yarn.conf
 %{usr_lib_hadoop}/libexec/yarn-config.sh
 %{usr_lib_yarn}
 %attr(4754,root,yarn) %{usr_lib_yarn}/bin/container-executor
 %{bin_dir}/yarn
-%attr(0775,yarn,hadoop) %{np_var_run_yarn}
 %attr(0775,yarn,hadoop) %{np_var_log_yarn}
 %attr(0755,yarn,hadoop) %{var_lib_yarn}
 %attr(1777,yarn,hadoop) %{var_lib_yarn}/cache
+%attr(0775,yarn,hadoop) %{np_run_yarn}
 
 %files hdfs
 %defattr(-,root,root)
@@ -819,11 +834,6 @@ fi
 %service_macro hdfs-journalnode
 %service_macro hdfs-datanode
 %service_macro hdfs-dfsrouter
-%service_macro yarn-resourcemanager
-%service_macro yarn-nodemanager
-%service_macro yarn-proxyserver
-%service_macro yarn-timelineserver
-%service_macro yarn-router
 
 # Systemd unit file management RPMs
 %define systemd_macro() \
@@ -844,6 +854,11 @@ if [ $1 -ge 1 ]; then \
 fi
 
 %systemd_macro mapreduce-historyserver
+%systemd_macro yarn-resourcemanager
+%systemd_macro yarn-nodemanager
+%systemd_macro yarn-proxyserver
+%systemd_macro yarn-timelineserver
+%systemd_macro yarn-router
 
 # Pseudo-distributed Hadoop installation
 %post conf-pseudo


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4279

Add system unit file for Hadoop(YARN)

### How was this patch tested?
Tested on RPM(Rocky Linux 8 and DEB(Ubuntu-24.04).
* Did YARN smoke tests
* Checked if  `systemctl start` , `systemctl status` works
* Checked if `/run` exists after the OS(Container) restarts (Unlike MapReduce Service, I used `systemd-tmpfile` because there are many processes that use `/var/run/hadoop-yarn` and don't want to change the behavior)

<details>

<summary>Manual Testing logs...</summary>

#### RPM (Rocky-8)

* build & smoketests

```
$ ./gradlew allclean hadoop-pkg-ind repo-ind -POS=rockylinux-8
$ cd provisioner/docker
$ ./docker-hadoop.sh --enable-local-repo --disable-gpg-check     --docker-compose-plugin     -C config_rockylinux-8.yaml     -F docker-compose-cgroupv2.yml     --stack hdfs,yarn --smoke-tests yarn -c 1
(snip)
BUILD SUCCESSFUL in 15s
28 actionable tasks: 7 executed, 21 up-to-date
Stopped 1 worker daemon(s).
+ rm -rf buildSrc/build/test-results/binary
+ rm -rf /bigtop-home/.gradle
```

* install additional packages (timelineserver, router), `systemctl start`, then `systemctl status`

```
$ ./docker-hadoop.sh -dcp --exec 1 /bin/bash
[root@a60f5b5943d3 /]# dnf install hadoop-yarn-timelineserver hadoop-yarn-router
(snip)
Complete!


[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl start hadoop-yarn-$service_name; done


[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
● hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-resourcemanager.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:01:49 UTC; 4min 55s ago
     Docs: https://hadoop.apache.org/
 Main PID: 6692 (java)
    Tasks: 227 (limit: 5099)
   Memory: 437.7M
   CGroup: /system.slice/hadoop-yarn-resourcemanager.service
           └─6692 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_resourcemanager -Djava.net.preferIPv4Stack=true -Dservice.libdir=/usr/lib/hadoop-yarn/./,/usr/lib/hadoop-yarn/lib,/usr/lib/hadoop-hdfs/./,/usr/lib/hadoop-hdfs/lib,/usr/lib/hadoop/./,/usr/lib/hadoop/lib -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-res…

Dec 01 03:01:47 a60f5b5943d3 systemd[1]: Starting Hadoop ResourceManager...
Dec 01 03:01:49 a60f5b5943d3 systemd[1]: Started Hadoop ResourceManager.
● hadoop-yarn-nodemanager.service - Hadoop NodeManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-nodemanager.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:02:21 UTC; 4min 24s ago
     Docs: https://hadoop.apache.org/
 Main PID: 8309 (java)
    Tasks: 102 (limit: 5099)
   Memory: 293.2M
   CGroup: /system.slice/hadoop-yarn-nodemanager.service
           └─8309 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_nodemanager -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-nodemanager-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.di…

Dec 01 03:02:19 a60f5b5943d3 systemd[1]: Starting Hadoop NodeManager...
Dec 01 03:02:21 a60f5b5943d3 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-proxyserver.service - Hadoop ProxyServer
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-proxyserver.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:01:56 UTC; 4min 48s ago
     Docs: https://hadoop.apache.org/
 Main PID: 7184 (java)
    Tasks: 33 (limit: 5099)
   Memory: 129.3M
   CGroup: /system.slice/hadoop-yarn-proxyserver.service
           └─7184 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_proxyserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-proxyserver-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.di…

Dec 01 03:01:54 a60f5b5943d3 systemd[1]: Starting Hadoop ProxyServer...
Dec 01 03:01:56 a60f5b5943d3 systemd[1]: Started Hadoop ProxyServer.
● hadoop-yarn-timelineserver.service - Hadoop NodeManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-timelineserver.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:06:27 UTC; 18s ago
     Docs: https://hadoop.apache.org/
  Process: 9484 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver (code=exited, status=0/SUCCESS)
 Main PID: 9535 (java)
    Tasks: 53 (limit: 5099)
   Memory: 424.5M
   CGroup: /system.slice/hadoop-yarn-timelineserver.service
           └─9535 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_timelineserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-timelineserver-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.…

Dec 01 03:06:25 a60f5b5943d3 systemd[1]: Starting Hadoop NodeManager...
Dec 01 03:06:27 a60f5b5943d3 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-router.service - Hadoop Router
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-router.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:06:29 UTC; 16s ago
     Docs: https://hadoop.apache.org/
  Process: 9598 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router (code=exited, status=0/SUCCESS)
 Main PID: 9649 (java)
    Tasks: 97 (limit: 5099)
   Memory: 274.4M
   CGroup: /system.slice/hadoop-yarn-router.service
           └─9649 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_router -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-router-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.dir=/var/log…

Dec 01 03:06:27 a60f5b5943d3 systemd[1]: Starting Hadoop Router...
Dec 01 03:06:29 a60f5b5943d3 systemd[1]: Started Hadoop Router.
```

* Check if prepared unit files are used w/ `systemctl cat`
```
[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl cat hadoop-yarn-$service_name; done
# /usr/lib/systemd/system/hadoop-yarn-resourcemanager.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop ResourceManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-resourcemanager.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop resourcemanager
# /usr/lib/systemd/system/hadoop-yarn-nodemanager.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop NodeManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-nodemanager.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop nodemanager
# /usr/lib/systemd/system/hadoop-yarn-proxyserver.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop ProxyServer
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-proxyserver.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop proxyserver
# /usr/lib/systemd/system/hadoop-yarn-timelineserver.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop NodeManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-timelineserver.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop timelineserver
# /usr/lib/systemd/system/hadoop-yarn-router.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop Router
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-router.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop router
```

* restart container

```
[root@a60f5b5943d3 /]# exit
$ docker restart a60f5b5943d3
$ ./docker-hadoop.sh -dcp --exec 1 /bin/bash
[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl start hadoop-yarn-$service_name; done
[root@a60f5b5943d3 /]# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
● hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-resourcemanager.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:27 UTC; 14s ago
     Docs: https://hadoop.apache.org/
  Process: 401 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager (code=exited, status=0/SUCCESS)
 Main PID: 455 (java)
    Tasks: 231 (limit: 5099)
   Memory: 456.5M
   CGroup: /system.slice/hadoop-yarn-resourcemanager.service
           └─455 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_resourcemanager -Djava.net.preferIPv4Stack=true -Dservice.libdir=/usr/lib/hadoop-yarn/./,/usr/lib/hadoop-yarn/lib,/usr/lib/hadoop-hdfs/./,/usr/lib/hadoop-hdfs/lib,/usr/lib/hadoop/./,/usr/lib/hadoop/lib -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-reso…

Dec 01 03:12:25 a60f5b5943d3 systemd[1]: Starting Hadoop ResourceManager...
Dec 01 03:12:27 a60f5b5943d3 systemd[1]: Started Hadoop ResourceManager.
● hadoop-yarn-nodemanager.service - Hadoop NodeManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-nodemanager.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:29 UTC; 12s ago
     Docs: https://hadoop.apache.org/
  Process: 695 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager (code=exited, status=0/SUCCESS)
 Main PID: 749 (java)
    Tasks: 107 (limit: 5099)
   Memory: 287.7M
   CGroup: /system.slice/hadoop-yarn-nodemanager.service
           └─749 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_nodemanager -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-nodemanager-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.dir…

Dec 01 03:12:27 a60f5b5943d3 systemd[1]: Starting Hadoop NodeManager...
Dec 01 03:12:29 a60f5b5943d3 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-proxyserver.service - Hadoop ProxyServer
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-proxyserver.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:31 UTC; 10s ago
     Docs: https://hadoop.apache.org/
  Process: 918 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver (code=exited, status=0/SUCCESS)
 Main PID: 970 (java)
    Tasks: 34 (limit: 5099)
   Memory: 123.6M
   CGroup: /system.slice/hadoop-yarn-proxyserver.service
           └─970 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_proxyserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-proxyserver-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.dir…

Dec 01 03:12:29 a60f5b5943d3 systemd[1]: Starting Hadoop ProxyServer...
Dec 01 03:12:31 a60f5b5943d3 systemd[1]: Started Hadoop ProxyServer.
● hadoop-yarn-timelineserver.service - Hadoop NodeManager
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-timelineserver.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:33 UTC; 8s ago
     Docs: https://hadoop.apache.org/
  Process: 1012 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver (code=exited, status=0/SUCCESS)
 Main PID: 1064 (java)
    Tasks: 53 (limit: 5099)
   Memory: 246.1M
   CGroup: /system.slice/hadoop-yarn-timelineserver.service
           └─1064 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_timelineserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-timelineserver-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.…

Dec 01 03:12:31 a60f5b5943d3 systemd[1]: Starting Hadoop NodeManager...
Dec 01 03:12:33 a60f5b5943d3 systemd[1]: Started Hadoop NodeManager.
● hadoop-yarn-router.service - Hadoop Router
   Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-router.service; static; vendor preset: disabled)
   Active: active (running) since Sun 2024-12-01 03:12:36 UTC; 6s ago
     Docs: https://hadoop.apache.org/
  Process: 1127 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router (code=exited, status=0/SUCCESS)
 Main PID: 1179 (java)
    Tasks: 97 (limit: 5099)
   Memory: 277.0M
   CGroup: /system.slice/hadoop-yarn-router.service
           └─1179 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.432.b06-2.el8.aarch64/bin/java -Dproc_router -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-router-a60f5b5943d3.log -Dyarn.home.dir=/usr/lib/hadoop-yarn -Dyarn.root.logger=INFO,console -Djava.library.path=//usr/lib/hadoop/lib/native -Dhadoop.log.dir=/var/log…

Dec 01 03:12:33 a60f5b5943d3 systemd[1]: Starting Hadoop Router...
Dec 01 03:12:36 a60f5b5943d3 systemd[1]: Started Hadoop Router.
```


#### DEB (Ubuntu-24.04)

* build & smoketests

```
$ ./gradlew hadoop-clean bigtop-utils-pkg bigtop-jsvc-pkg bigtop-groovy-pkg hadoop-pkg repo
(snip)


$ cd provisioner/docker/
$ ./docker-hadoop.sh --enable-local-repo --disable-gpg-check     --docker-compose-plugin     -C config_ubuntu-24.04.yaml     -F docker-compose-cgroupv2.yml     --stack hdfs,yarn --smoke-tests yarn -c 1
Environment check...
Check docker:
Docker version 27.3.1, build ce12230
Check docker-compose:
Check ruby:
ruby 3.2.3 (2024-01-18 revision 52bb2ac0a6) [x86_64-linux-gnu]
[+] Running 2/2
 ✔ Network 20241217_034747_r14921_default     Created                                                                                                                                                       0.1s
 ✔ Container 20241217_034747_r14921-bigtop-1  Started

(snip)


Successfully started process 'Gradle Test Executor 2'

org.apache.bigtop.itest.hadoop.yarn.TestRmAdmin > testRmAdminBasic STANDARD_OUT
    -help
    -getGroups

org.apache.bigtop.itest.hadoop.yarn.TestRmAdmin > testRmAdminRefreshcommands STANDARD_OUT
    -refreshQueues
    -refreshNodes
    -refreshUserToGroupsMappings
    -refreshSuperUserGroupsConfiguration
    -refreshAdminAcls

org.apache.bigtop.itest.hadoop.yarn.TestNode > testNodeBasic STANDARD_OUT
    -list
    -status

Gradle Test Executor 2 finished executing tests.

> Task :bigtop-tests:smoke-tests:yarn:test
Finished generating test XML results (0.008 secs) into: /bigtop-home/bigtop-tests/smoke-tests/yarn/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.016 secs) into: /bigtop-home/bigtop-tests/smoke-tests/yarn/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:yarn:test (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 8.19 secs.

BUILD SUCCESSFUL in 32s
28 actionable tasks: 6 executed, 22 up-to-date
Stopped 1 worker daemon(s).
+ rm -rf buildSrc/build/test-results/binary
+ rm -rf /bigtop-home/.gradle
```


* install additional packages (timelineserver, router), `systemctl start`, then `systemctl status`

```
$ ./docker-hadoop.sh -dcp --exec 1 /bin/bash
root@763e2d03d895:/# apt install hadoop-yarn-timelineserver hadoop-yarn-router
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  hadoop-yarn-router hadoop-yarn-timelineserver
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/8658 B of archives.
After this operation, 57.3 kB of additional disk space will be used.
WARNING: The following packages cannot be authenticated!
  hadoop-yarn-router hadoop-yarn-timelineserver
Authentication warning overridden.
Get:1 file:/bigtop-home/output/apt bigtop/contrib amd64 hadoop-yarn-router amd64 3.3.6-1 [4294 B]
Get:2 file:/bigtop-home/output/apt bigtop/contrib amd64 hadoop-yarn-timelineserver amd64 3.3.6-1 [4364 B]
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package hadoop-yarn-router.
(Reading database ... 52684 files and directories currently installed.)
Preparing to unpack .../hadoop-yarn-router_3.3.6-1_amd64.deb ...
Unpacking hadoop-yarn-router (3.3.6-1) ...
Selecting previously unselected package hadoop-yarn-timelineserver.
Preparing to unpack .../hadoop-yarn-timelineserver_3.3.6-1_amd64.deb ...
Unpacking hadoop-yarn-timelineserver (3.3.6-1) ...
Setting up hadoop-yarn-timelineserver (3.3.6-1) ...
invoke-rc.d: policy-rc.d denied execution of start.
Setting up hadoop-yarn-router (3.3.6-1) ...
invoke-rc.d: policy-rc.d denied execution of start.
root@763e2d03d895:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl start hadoop-yarn-$service_name; done
root@763e2d03d895:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
● hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-resourcemanager.service; static)
     Active: active (running) since Mon 2024-12-16 18:49:48 UTC; 4h 40min ago
       Docs: https://hadoop.apache.org/
   Main PID: 5627 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-resourcemanager.service
             └─5627 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_resourcemanager -Djava.net.preferIPv4Stack=true -Dservice.libdir=/usr/lib/hadoop-yarn/./,/usr/lib/hadoop-yarn/lib,/usr/lib/hadoop-hdfs…

Dec 16 18:49:46 763e2d03d895 systemd[1]: Starting hadoop-yarn-resourcemanager.service - Hadoop ResourceManager...
Dec 16 18:49:48 763e2d03d895 systemd[1]: Started hadoop-yarn-resourcemanager.service - Hadoop ResourceManager.
● hadoop-yarn-nodemanager.service - Hadoop NodeManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-nodemanager.service; static)
     Active: active (running) since Mon 2024-12-16 18:50:30 UTC; 4h 39min ago
       Docs: https://hadoop.apache.org/
   Main PID: 6835 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-nodemanager.service
             └─6835 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_nodemanager -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-nodemanager-763e2d03d895.l…

Dec 16 18:50:28 763e2d03d895 systemd[1]: Starting hadoop-yarn-nodemanager.service - Hadoop NodeManager...
Dec 16 18:50:30 763e2d03d895 systemd[1]: Started hadoop-yarn-nodemanager.service - Hadoop NodeManager.
● hadoop-yarn-proxyserver.service - Hadoop ProxyServer
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-proxyserver.service; static)
     Active: active (running) since Mon 2024-12-16 18:50:04 UTC; 4h 40min ago
       Docs: https://hadoop.apache.org/
   Main PID: 6266 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-proxyserver.service
             └─6266 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_proxyserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-proxyserver-763e2d03d895.l…

Dec 16 18:50:02 763e2d03d895 systemd[1]: Starting hadoop-yarn-proxyserver.service - Hadoop ProxyServer...
Dec 16 18:50:04 763e2d03d895 systemd[1]: Started hadoop-yarn-proxyserver.service - Hadoop ProxyServer.
● hadoop-yarn-timelineserver.service - Hadoop NodeManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-timelineserver.service; static)
     Active: active (running) since Mon 2024-12-16 23:29:51 UTC; 16s ago
       Docs: https://hadoop.apache.org/
    Process: 7983 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver (code=exited, status=0/SUCCESS)
   Main PID: 8022 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-timelineserver.service
             └─8022 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_timelineserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-timelineserver-763e2d03…

Dec 16 23:29:49 763e2d03d895 systemd[1]: Starting hadoop-yarn-timelineserver.service - Hadoop NodeManager...
Dec 16 23:29:51 763e2d03d895 systemd[1]: Started hadoop-yarn-timelineserver.service - Hadoop NodeManager.
● hadoop-yarn-router.service - Hadoop Router
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-router.service; static)
     Active: active (running) since Mon 2024-12-16 23:29:53 UTC; 14s ago
       Docs: https://hadoop.apache.org/
    Process: 8087 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router (code=exited, status=0/SUCCESS)
   Main PID: 8126 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-router.service
             └─8126 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_router -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-router-763e2d03d895.log -Dyarn.…

Dec 16 23:29:51 763e2d03d895 systemd[1]: Starting hadoop-yarn-router.service - Hadoop Router...
Dec 16 23:29:53 763e2d03d895 systemd[1]: Started hadoop-yarn-router.service - Hadoop Router.
```

* * Check if prepared unit files are used w/ `systemctl cat` `systemctl cat`

```
root@763e2d03d895:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl cat hadoop-yarn-$service_name; done
# /usr/lib/systemd/system/hadoop-yarn-resourcemanager.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop ResourceManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-resourcemanager.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop resourcemanager
# /usr/lib/systemd/system/hadoop-yarn-nodemanager.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop NodeManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-nodemanager.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop nodemanager
# /usr/lib/systemd/system/hadoop-yarn-proxyserver.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop ProxyServer
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-proxyserver.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop proxyserver
# /usr/lib/systemd/system/hadoop-yarn-timelineserver.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop NodeManager
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-timelineserver.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop timelineserver
# /usr/lib/systemd/system/hadoop-yarn-router.service
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

[Unit]
Documentation=https://hadoop.apache.org/
Description=Hadoop Router
Before=multi-user.target
Before=graphical.target
After=remote-fs.target

[Service]
User=yarn
Group=yarn
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=no
PIDFile=/run/hadoop-yarn/hadoop-yarn-router.pid
SuccessExitStatus=5 6
ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router
ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop router
root@763e2d03d895:/#
root@763e2d03d895:/# exit
exit
```


* restart container

```
$ docker ps
CONTAINER ID   IMAGE                              COMMAND        CREATED       STATUS       PORTS     NAMES
763e2d03d895   bigtop/puppet:trunk-ubuntu-24.04   "/sbin/init"   5 hours ago   Up 5 hours             20241217_034747_r14921-bigtop-1
$ docker restart 763e2d03d895
763e2d03d895



$ ./docker-hadoop.sh -dcp --exec 1 /bin/bash
root@763e2d03d895:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
○ hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-resourcemanager.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 16 18:49:46 763e2d03d895 systemd[1]: Starting hadoop-yarn-resourcemanager.service - Hadoop ResourceManager...
Dec 16 18:49:48 763e2d03d895 systemd[1]: Started hadoop-yarn-resourcemanager.service - Hadoop ResourceManager.
○ hadoop-yarn-nodemanager.service - Hadoop NodeManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-nodemanager.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 16 18:50:28 763e2d03d895 systemd[1]: Starting hadoop-yarn-nodemanager.service - Hadoop NodeManager...
Dec 16 18:50:30 763e2d03d895 systemd[1]: Started hadoop-yarn-nodemanager.service - Hadoop NodeManager.
○ hadoop-yarn-proxyserver.service - Hadoop ProxyServer
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-proxyserver.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 16 18:50:02 763e2d03d895 systemd[1]: Starting hadoop-yarn-proxyserver.service - Hadoop ProxyServer...
Dec 16 18:50:04 763e2d03d895 systemd[1]: Started hadoop-yarn-proxyserver.service - Hadoop ProxyServer.
○ hadoop-yarn-timelineserver.service - Hadoop NodeManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-timelineserver.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 16 23:29:49 763e2d03d895 systemd[1]: Starting hadoop-yarn-timelineserver.service - Hadoop NodeManager...
Dec 16 23:29:51 763e2d03d895 systemd[1]: Started hadoop-yarn-timelineserver.service - Hadoop NodeManager.
○ hadoop-yarn-router.service - Hadoop Router
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-router.service; static)
     Active: inactive (dead)
       Docs: https://hadoop.apache.org/

Dec 16 23:29:51 763e2d03d895 systemd[1]: Starting hadoop-yarn-router.service - Hadoop Router...
Dec 16 23:29:53 763e2d03d895 systemd[1]: Started hadoop-yarn-router.service - Hadoop Router.




root@763e2d03d895:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl start hadoop-yarn-$service_name; done
root@763e2d03d895:/# for service_name in resourcemanager nodemanager proxyserver timelineserver router; do  systemctl status --no-pager hadoop-yarn-$service_name; done
● hadoop-yarn-resourcemanager.service - Hadoop ResourceManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-resourcemanager.service; static)
     Active: active (running) since Mon 2024-12-16 23:32:01 UTC; 38s ago
       Docs: https://hadoop.apache.org/
    Process: 460 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager (code=exited, status=0/SUCCESS)
   Main PID: 502 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-resourcemanager.service
             └─502 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_resourcemanager -Djava.net.preferIPv4Stack=true -Dservice.libdir=/usr/lib/hadoop-yarn/./,/usr/lib/hadoop-yarn/lib,/usr/lib/hadoop-hdfs/…

Dec 16 23:32:00 763e2d03d895 systemd[1]: Starting hadoop-yarn-resourcemanager.service - Hadoop ResourceManager...
Dec 16 23:32:01 763e2d03d895 systemd[1]: Started hadoop-yarn-resourcemanager.service - Hadoop ResourceManager.
● hadoop-yarn-nodemanager.service - Hadoop NodeManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-nodemanager.service; static)
     Active: active (running) since Mon 2024-12-16 23:32:03 UTC; 36s ago
       Docs: https://hadoop.apache.org/
    Process: 554 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager (code=exited, status=0/SUCCESS)
   Main PID: 596 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-nodemanager.service
             └─596 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_nodemanager -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-nodemanager-763e2d03d895.lo…

Dec 16 23:32:01 763e2d03d895 systemd[1]: Starting hadoop-yarn-nodemanager.service - Hadoop NodeManager...
Dec 16 23:32:03 763e2d03d895 systemd[1]: Started hadoop-yarn-nodemanager.service - Hadoop NodeManager.
● hadoop-yarn-proxyserver.service - Hadoop ProxyServer
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-proxyserver.service; static)
     Active: active (running) since Mon 2024-12-16 23:32:05 UTC; 33s ago
       Docs: https://hadoop.apache.org/
    Process: 944 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver (code=exited, status=0/SUCCESS)
   Main PID: 994 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-proxyserver.service
             └─994 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_proxyserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-proxyserver-763e2d03d895.lo…

Dec 16 23:32:03 763e2d03d895 systemd[1]: Starting hadoop-yarn-proxyserver.service - Hadoop ProxyServer...
Dec 16 23:32:05 763e2d03d895 systemd[1]: Started hadoop-yarn-proxyserver.service - Hadoop ProxyServer.
● hadoop-yarn-timelineserver.service - Hadoop NodeManager
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-timelineserver.service; static)
     Active: active (running) since Mon 2024-12-16 23:32:07 UTC; 31s ago
       Docs: https://hadoop.apache.org/
    Process: 1043 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver (code=exited, status=0/SUCCESS)
   Main PID: 1083 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-timelineserver.service
             └─1083 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_timelineserver -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-timelineserver-763e2d03…

Dec 16 23:32:05 763e2d03d895 systemd[1]: Starting hadoop-yarn-timelineserver.service - Hadoop NodeManager...
Dec 16 23:32:07 763e2d03d895 systemd[1]: Started hadoop-yarn-timelineserver.service - Hadoop NodeManager.
● hadoop-yarn-router.service - Hadoop Router
     Loaded: loaded (/usr/lib/systemd/system/hadoop-yarn-router.service; static)
     Active: active (running) since Mon 2024-12-16 23:32:09 UTC; 29s ago
       Docs: https://hadoop.apache.org/
    Process: 1148 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router (code=exited, status=0/SUCCESS)
   Main PID: 1188 (java)
     CGroup: /docker/763e2d03d895d436374e7bd32f7cfbe0793edcd372cbc633d6bbb1f1a414ec17/system.slice/hadoop-yarn-router.service
             └─1188 /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dproc_router -Djava.net.preferIPv4Stack=true -Dyarn.log.dir=/var/log/hadoop-yarn -Dyarn.log.file=hadoop-yarn-router-763e2d03d895.log -Dyarn.…

Dec 16 23:32:07 763e2d03d895 systemd[1]: Starting hadoop-yarn-router.service - Hadoop Router...
Dec 16 23:32:09 763e2d03d895 systemd[1]: Started hadoop-yarn-router.service - Hadoop Router.
```

</details>

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/