### PR TITLE
BIGTOP-4309. Add Fedora 40 support to toolchain.

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -21,7 +21,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case ${ID}-${VERSION_ID} in
-    fedora-38)
+    fedora-38|fedora-40)
         dnf -y install yum-utils
         dnf -y check-update
         dnf -y install hostname diffutils findutils curl sudo unzip wget puppet procps-ng libxcrypt-compat systemd


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4309

as a candidate for Bigtop 3.4.0 release.

Issues related to packaging will be addressed in follow-up JIRAs.