### PR TITLE
BIGTOP-4310: Executing `{hadoop_mapreduce_home}/bin/mapred` would occur ERROR that the mapred-config.sh doesn't exist

### DIFF
--- a/bigtop-packages/src/common/hadoop/install_hadoop.sh
+++ b/bigtop-packages/src/common/hadoop/install_hadoop.sh
@@ -265,6 +265,8 @@ cp -a ${BUILD_DIR}/bin/hdfs $PREFIX/$HDFS_DIR/bin
 install -d -m 0755 $PREFIX/$YARN_DIR/bin
 cp -a ${BUILD_DIR}/bin/{yarn,container-executor} $PREFIX/$YARN_DIR/bin
 install -d -m 0755 $PREFIX/$MAPREDUCE_DIR/bin
+# Fix: BIGTOP-4310
+sed -i "s#\${bin}/../libexec#\${bin}/../../hadoop/libexec#g" ${BUILD_DIR}/bin/mapred
 cp -a ${BUILD_DIR}/bin/mapred $PREFIX/$MAPREDUCE_DIR/bin
 # FIXME: MAPREDUCE-3980
 cp -a ${BUILD_DIR}/bin/mapred $PREFIX/$YARN_DIR/bin

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -156,7 +156,7 @@ bigtop {
       name    = 'hadoop'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Hadoop'
-      version { base = '3.3.6'; pkg = base; release = 1 }
+      version { base = '3.3.6'; pkg = base; release = 2 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/common/$name-${version.base}"


### PR DESCRIPTION


<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Details see: [BIGTOP-4310](https://issues.apache.org/jira/browse/BIGTOP-4310)

Fix the issue that executing `{hadoop_mapreduce_home}/bin/mapred` would occur ERROR.

### How was this patch tested?
Applying this changes，
And executing the command: `{hadoop_mapreduce_home}/bin/mapred --help`, would print messages, as fallow.
```
Usage: mapred [OPTIONS] SUBCOMMAND [SUBCOMMAND OPTIONS]
 or    mapred [OPTIONS] CLASSNAME [CLASSNAME OPTIONS]
  where CLASSNAME is a user-provided Java class

  OPTIONS is none or any of:
......
```


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/