### PR TITLE
BIGTOP-4345: Remove spark and scala from Hive Maven opts

### DIFF
--- a/bigtop-packages/src/common/hive/do-component-build
+++ b/bigtop-packages/src/common/hive/do-component-build
@@ -23,9 +23,6 @@ HIVE_MAVEN_OPTS=" -Dhbase.version=$HBASE_VERSION \
 -Dhadoop.version=$HADOOP_VERSION \
 -DskipTests \
 -Dtez.version=${TEZ_VERSION} \
--Dspark.version=${SPARK_VERSION} \
--Dscala.binary.version=${SCALA_VERSION%.*} \
--Dscala.version=${SCALA_VERSION} \
 -Dguava.version=27.0-jre \
 -Dcurator.version=4.2.0
 "


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4345

Hive on Spark feature has been removed since Hive 4.0.0 ([HIVE-26134](https://issues.apache.org/jira/browse/HIVE-26134)), so there's no need to have
```
-Dspark.version=${SPARK_VERSION} \
-Dscala.binary.version=${SCALA_VERSION%.*} \
-Dscala.version=${SCALA_VERSION} \
```

in Maven opts.

### How was this patch tested?
By a local build.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/