### PR TITLE
BIGTOP-4354: Update packaging scripts for Tez 0.10.4

### DIFF
--- a/bigtop-packages/src/deb/tez/rules
+++ b/bigtop-packages/src/deb/tez/rules
@@ -42,9 +42,9 @@ override_dh_auto_install:
 		--build-dir=. \
 		--doc-dir=usr/share/doc/${tez_pkg_name}-doc \
 		--prefix=debian/tmp
-	rm -f debian/tmp/usr/lib/${tez_pkg_name}/lib/slf4j-log4j12-*.jar
-	ln -sf /usr/lib/hadoop/hadoop-annotations.jar debian/tmp/${lib_tez}/hadoop-annotations.jar
-	ln -sf /usr/lib/hadoop/hadoop-auth.jar debian/tmp/${lib_tez}/hadoop-auth.jar
+	rm -f debian/tmp/usr/lib/${tez_pkg_name}/lib/slf4j-reload4j-*.jar
+	rm -f debian/tmp/usr/lib/${tez_pkg_name}/lib/hadoop-*.jar
+	ln -sf /usr/lib/hadoop-hdfs/hadoop-hdfs-client.jar debian/tmp/${lib_tez}/hadoop-hdfs-client.jar
 	ln -sf /usr/lib/hadoop-mapreduce/hadoop-mapreduce-client-common.jar debian/tmp/${lib_tez}/hadoop-mapreduce-client-common.jar
 	ln -sf /usr/lib/hadoop-mapreduce/hadoop-mapreduce-client-core.jar debian/tmp/${lib_tez}/hhadoop-mapreduce-client-core.jar
-	ln -sf /usr/lib/hadoop-yarn/hadoop-yarn-server-web-proxy.jar debian/tmp/${lib_tez}/hadoop-yarn-server-web-proxy.jar
+	ln -sf /usr/lib/hadoop-yarn/hadoop-yarn-server-timeline-pluginstorage.jar debian/tmp/${lib_tez}/hadoop-yarn-server-timeline-pluginstorage.jar

--- a/bigtop-packages/src/rpm/tez/SPECS/tez.spec
+++ b/bigtop-packages/src/rpm/tez/SPECS/tez.spec
@@ -117,12 +117,12 @@ sh %{SOURCE2} \
     --lib-dir=%{usr_lib_tez} \
     --etc-tez=%{etc_tez}
 
-%__rm -f $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/slf4j-log4j12-*.jar
-%__ln_s -f %{usr_lib_hadoop}/hadoop-annotations.jar $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/hadoop-annotations.jar
-%__ln_s -f %{usr_lib_hadoop}/hadoop-auth.jar $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/hadoop-auth.jar
+%__rm -f $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/slf4j-reload4j-*.jar
+%__rm -f $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/hadoop-*.jar
+%__ln_s -f %{usr_lib_hadoop}-hdfs/hadoop-hdfs-client.jar $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/hadoop-hdfs-client.jar
 %__ln_s -f %{usr_lib_hadoop}-mapreduce/hadoop-mapreduce-client-common.jar $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/hadoop-mapreduce-client-common.jar
 %__ln_s -f %{usr_lib_hadoop}-mapreduce/hadoop-mapreduce-client-core.jar $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/hadoop-mapreduce-client-core.jar
-%__ln_s -f %{usr_lib_hadoop}-yarn/hadoop-yarn-server-web-proxy.jar $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/hadoop-yarn-server-web-proxy.jar
+%__ln_s -f %{usr_lib_hadoop}-yarn/hadoop-yarn-server-timeline-pluginstorage.jar $RPM_BUILD_ROOT/%{usr_lib_tez}/lib/hadoop-yarn-server-timeline-pluginstorage.jar
 
 %pre
 


### PR DESCRIPTION
### Description of PR

tez-0.10.4-minimal.tar.gz has made some changes compared to previous versions:
- slf4j-log4j12-\*.jar -> slf4j-reload4j-\*.jar
- hadoop related jars within lib/ directory are: hadoop-hdfs-client, hadoop-mapreduce-client-core, hadoop-mapreduce-client-common, and hadoop-yarn-server-timeline-pluginstorage

We should update the rpm and deb scripts accordingly.

### How was this patch tested?
By a local build.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/