### PR TITLE
BIGTOP-4356: Ensure zookeeper-jute.jar is on the classpath along with zookeeper.jar

### DIFF
--- a/bigtop-packages/src/deb/hadoop/rules
+++ b/bigtop-packages/src/deb/hadoop/rules
@@ -63,6 +63,7 @@ override_dh_auto_install:
 	  --man-dir=/usr/share/man
 	# Forcing Zookeeper dependency to be on the packaged jar
 	ln -sf /usr/lib/zookeeper/zookeeper.jar debian/tmp/usr/lib/hadoop/lib/zookeeper-[[:digit:]]*.jar
+	ln -sf /usr/lib/zookeeper/zookeeper-jute.jar debian/tmp/usr/lib/hadoop/lib/zookeeper-jute-[[:digit:]]*.jar
 	# Workaround for BIGTOP-583
 	rm -f debian/tmp/usr/lib/hadoop-*/lib/slf4j-log4j12-*.jar
 	# FIXME: BIGTOP-463

--- a/bigtop-packages/src/deb/hbase/rules
+++ b/bigtop-packages/src/deb/hbase/rules
@@ -50,6 +50,7 @@ override_dh_auto_install:
 	# provide an unversioned symlink foo.jar -> foo-0.1.2.jar.
 	rm -f debian/tmp/usr/lib/${hbase_pkg_name}/lib/{hadoop,zookeeper,slf4j-log4j12-}*.jar
 	ln -f -s ${zookeeper_home}/zookeeper.jar debian/tmp/usr/lib/${hbase_pkg_name}/lib/
+	ln -f -s ${zookeeper_home}/zookeeper-jute.jar debian/tmp/usr/lib/${hbase_pkg_name}/lib/
 	ln -f -s ${hadoop_home}/client/hadoop-annotations.jar debian/tmp/usr/lib/${hbase_pkg_name}/lib/
 	ln -f -s ${hadoop_home}/client/hadoop-auth.jar debian/tmp/usr/lib/${hbase_pkg_name}/lib/
 	ln -f -s ${hadoop_home}/client/hadoop-common.jar debian/tmp/usr/lib/${hbase_pkg_name}/lib/

--- a/bigtop-packages/src/deb/hive/rules
+++ b/bigtop-packages/src/deb/hive/rules
@@ -60,6 +60,7 @@ override_dh_auto_install: server2 metastore hcatalog-server webhcat-server
 	ln -s /usr/lib/hbase/hbase-common.jar /usr/lib/hbase/hbase-client.jar /usr/lib/hbase/hbase-hadoop-compat.jar /usr/lib/hbase/hbase-hadoop2-compat.jar debian/tmp/usr/lib/hive/lib
 	ln -s /usr/lib/hbase/hbase-procedure.jar /usr/lib/hbase/hbase-protocol.jar /usr/lib/hbase/hbase-server.jar debian/tmp/usr/lib/hive/lib/
 	ln -s /usr/lib/zookeeper/zookeeper.jar debian/tmp/usr/lib/hive/lib
+	ln -s /usr/lib/zookeeper/zookeeper-jute.jar debian/tmp/usr/lib/hive/lib
 	# Workaround for BIGTOP-583
 	rm -f debian/tmp/usr/lib/hive/lib/slf4j-log4j12-*.jar
 	bash debian/build-hive-install-file.sh >> debian/hive.install

--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -590,6 +590,7 @@ env HADOOP_VERSION=%{hadoop_base_version} bash %{SOURCE2} \
 
 # Forcing Zookeeper dependency to be on the packaged jar
 %__ln_s -f %{usr_lib_zookeeper}/zookeeper.jar $RPM_BUILD_ROOT/%{usr_lib_hadoop}/lib/zookeeper-[[:digit:]]*.jar
+%__ln_s -f %{usr_lib_zookeeper}/zookeeper-jute.jar $RPM_BUILD_ROOT/%{usr_lib_hadoop}/lib/zookeeper-jute-[[:digit:]]*.jar
 # Workaround for BIGTOP-583
 %__rm -f $RPM_BUILD_ROOT/%{usr_lib_hadoop}-*/lib/slf4j-log4j12-*.jar
 

--- a/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
+++ b/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
@@ -339,6 +339,7 @@ done
 # Pull zookeeper and hadoop from their packages
 rm -f $RPM_BUILD_ROOT/%{usr_lib_hbase}/lib/{hadoop,zookeeper,slf4j-log4j12-}*.jar
 ln -f -s %{usr_lib_zookeeper}/zookeeper.jar $RPM_BUILD_ROOT/%{usr_lib_hbase}/lib
+ln -f -s %{usr_lib_zookeeper}/zookeeper-jute.jar $RPM_BUILD_ROOT/%{usr_lib_hbase}/lib
 
 ln -f -s %{usr_lib_hadoop}/client/hadoop-annotations.jar $RPM_BUILD_ROOT/%{usr_lib_hbase}/lib
 ln -f -s %{usr_lib_hadoop}/client/hadoop-auth.jar $RPM_BUILD_ROOT/%{usr_lib_hbase}/lib

--- a/bigtop-packages/src/rpm/hive/SPECS/hive.spec
+++ b/bigtop-packages/src/rpm/hive/SPECS/hive.spec
@@ -293,6 +293,7 @@ cp $RPM_SOURCE_DIR/hive-site.xml .
 # We need to get rid of jars that happen to be shipped in other Bigtop packages
 %__rm -f $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/hbase-*.jar $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/zookeeper-*.jar
 %__ln_s  %{usr_lib_zookeeper}/zookeeper.jar  $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/
+%__ln_s  %{usr_lib_zookeeper}/zookeeper-jute.jar  $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/
 %__ln_s  %{usr_lib_hbase}/hbase-common.jar %{usr_lib_hbase}/hbase-client.jar %{usr_lib_hbase}/hbase-hadoop-compat.jar %{usr_lib_hbase}/hbase-hadoop2-compat.jar $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/
 %__ln_s  %{usr_lib_hbase}/hbase-procedure.jar %{usr_lib_hbase}/hbase-protocol.jar %{usr_lib_hbase}/hbase-server.jar $RPM_BUILD_ROOT/%{usr_lib_hive}/lib/
 


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/BIGTOP-4356

From ZooKeeper 3.5.5, zookeeper.jar has been splitted into two jars: zookeeper.jar and zookeeper-jute.jar. Both should be symlinked in Hadoop/Hive/HBase lib directories.

### How was this patch tested?
By a local build.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/