### PR TITLE
BIGTOP-4364. Fix Zeppelin's default settings.

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -195,7 +195,7 @@ hadoop::common::tez_jars: "/usr/lib/tez"
 kafka::server::port: "9092"
 kafka::server::zookeeper_connection_string: "%{hiera('bigtop::hadoop_head_node')}:2181"
 
-zeppelin::server::spark_master_url: "yarn-client"
+zeppelin::server::spark_master_url: "yarn"
 zeppelin::server::hiveserver2_url: "jdbc:hive2://%{hiera('hadoop-hive::common::hiveserver2_host')}:%{hiera('hadoop-hive::common::hiveserver2_port')}"
 zeppelin::server::hiveserver2_user: "%{hiera('bigtop::hiveserver2_user')}"
 zeppelin::server::hiveserver2_password: "%{hiera('bigtop::hiveserver2_password')}"

--- a/bigtop-deploy/puppet/modules/zeppelin/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/zeppelin/manifests/init.pp
@@ -34,8 +34,13 @@ class zeppelin {
     }
 
     file { '/etc/zeppelin/conf/zeppelin-env.sh':
-      content   => template('zeppelin/zeppelin-env.sh'),
-      require   => Package['zeppelin'],
+      content => template('zeppelin/zeppelin-env.sh'),
+      require => Package['zeppelin'],
+    }
+
+    file { '/etc/zeppelin/conf/zeppelin-site.xml':
+      content => template('zeppelin/zeppelin-site.xml'),
+      require => Package['zeppelin'],
     }
 
     file { '/etc/zeppelin/conf/interpreter.json':
@@ -50,6 +55,7 @@ class zeppelin {
       subscribe  => [
           Package['zeppelin'],
           File['/etc/zeppelin/conf/zeppelin-env.sh'],
+          File['/etc/zeppelin/conf/zeppelin-site.xml'],
           File['/etc/zeppelin/conf/interpreter.json'],
       ],
       hasrestart => true,

--- a/bigtop-deploy/puppet/modules/zeppelin/templates/interpreter.json
+++ b/bigtop-deploy/puppet/modules/zeppelin/templates/interpreter.json
@@ -72,6 +72,7 @@
         "spark.cores.max": "",
         "spark.yarn.jar": "",
         "master": "<%= @spark_master_url %>",
+        "spark.submit.deployMode": "client",
         "zeppelin.spark.maxResult": "1000",
         "zeppelin.dep.localrepo": "local-repo",
         "spark.app.name": "Zeppelin",

--- a/bigtop-deploy/puppet/modules/zeppelin/templates/zeppelin-site.xml
+++ b/bigtop-deploy/puppet/modules/zeppelin/templates/zeppelin-site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+
+<property>
+  <name>zeppelin.interpreter.localRepo</name>
+  <value>/var/lib/zeppelin/local-repo</value>
+  <description>Local repository for interpreter's additional dependency loading</description>
+</property>
+
+</configuration>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR fixes the Puppet manifest of Zeppelin and its related files so that Zeppelin works just after deployed using them.

### How was this patch tested?

Created a cluster with the revised files and ensured Spark example notebooks worked by default.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/