### PR TITLE
BIGTOP-4373. jenkins user/group creation fails due to conflict of uid/gid on Ubuntu 24.04.

### DIFF
--- a/bigtop_toolchain/manifests/user.pp
+++ b/bigtop_toolchain/manifests/user.pp
@@ -19,14 +19,14 @@ class bigtop_toolchain::user {
     ensure => present,
     home => '/var/lib/jenkins',
     managehome => true,
-    uid        => 1000,
+    uid        => 2000,
     gid        => 'jenkins',
     require    => Group['jenkins'],
   }
 
   group { 'jenkins':
     ensure => present,
-    gid    => 1000,
+    gid    => 2000,
   }
 
   file {"/var/lib/jenkins/.m2":


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4373

Since the 1000 is already used as uid/gid of ubunut user/group in the ubuntu base image, groupadd fails on applying toolchain manifest.

* 1000 is the lowest uid for end users on linux distributions. We should use higher number which is expected to be available.
* While some CI jobs assume that jenkins is 1000, those can be easily fixed.
*  `*-pkg-ind` should work regardless of junkins uid in the container since [it extracts results by `docker cp`](https://github.com/apache/bigtop/blob/340665e910309666cbe8c980514940e7611b05df/bigtop-ci/build.sh#L94-L127).