### PR TITLE
BIGTOP-4382. Fix error on updating java alternatives due to timing issue.

### DIFF
--- a/bigtop_toolchain/manifests/installer.pp
+++ b/bigtop_toolchain/manifests/installer.pp
@@ -34,14 +34,14 @@ class bigtop_toolchain::installer {
       exec { 'ensure java 8 is set as default':
         command => "update-java-alternatives --set temurin-8*",
         path    => ['/usr/sbin', '/usr/bin', '/bin'],
-        require => Class['bigtop_toolchain::jdk'],
+        require => [Class['bigtop_toolchain::jdk'], Class['bigtop_toolchain::jdk11']],
       }
     }
     /Ubuntu/: {
       exec { 'ensure java 8 is set as default':
         command => "update-java-alternatives --set java-1.8.0-openjdk-$(dpkg --print-architecture)",
         path    => ['/usr/sbin', '/usr/bin', '/bin'],
-        require => Class['bigtop_toolchain::jdk'],
+        require => [Class['bigtop_toolchain::jdk'], Class['bigtop_toolchain::jdk11']],
       }
     }
     /(CentOS|Fedora|RedHat|Rocky)/: {
@@ -49,7 +49,7 @@ class bigtop_toolchain::installer {
         command => "update-alternatives --set java java-1.8.0-openjdk.$(uname -m) \
                     && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)",
         path    => ['/usr/sbin', '/usr/bin', '/bin'],
-        require => Class['bigtop_toolchain::jdk'],
+        require => [Class['bigtop_toolchain::jdk'], Class['bigtop_toolchain::jdk11']],
       }
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4382

```
#7 2103.5 ESC[mNotice: /Stage[main]/Bigtop_toolchain::Installer/Exec[ensure java 8 is set as default]/returns: java-1.8.0-openjdk.x86_64 has not been configured as an alternative for javaESC[0m
#7 2103.5 ESC[1;31mError: 'update-alternatives --set java java-1.8.0-openjdk.$(uname -m)                     && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)' returned 2 instead of one of [0]ESC[0m
#7 2103.5 ESC[1;31mError: /Stage[main]/Bigtop_toolchain::Installer/Exec[ensure java 8 is set as default]/returns: change from 'notrun' to ['0'] failed: 'update-alternatives --set java java-1.8.0-openjdk.$(uname -m)                     && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)' returned 2 instead of one of [0]ESC[0m
```