### PR TITLE
BIGTOP-4382. Fix error on updating java alternatives on fedora-40.

### DIFF
--- a/bigtop_toolchain/manifests/installer.pp
+++ b/bigtop_toolchain/manifests/installer.pp
@@ -29,31 +29,6 @@ class bigtop_toolchain::installer {
   include bigtop_toolchain::isal
   Class['bigtop_toolchain::jdk11']->Class['bigtop_toolchain::jdk']
 
-  case $::operatingsystem {
-    /Debian/: {
-      exec { 'ensure java 8 is set as default':
-        command => "update-java-alternatives --set temurin-8*",
-        path    => ['/usr/sbin', '/usr/bin', '/bin'],
-        require => Class['bigtop_toolchain::jdk'],
-      }
-    }
-    /Ubuntu/: {
-      exec { 'ensure java 8 is set as default':
-        command => "update-java-alternatives --set java-1.8.0-openjdk-$(dpkg --print-architecture)",
-        path    => ['/usr/sbin', '/usr/bin', '/bin'],
-        require => Class['bigtop_toolchain::jdk'],
-      }
-    }
-    /(CentOS|Fedora|RedHat|Rocky)/: {
-      exec { 'ensure java 8 is set as default':
-        command => "update-alternatives --set java java-1.8.0-openjdk.$(uname -m) \
-                    && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)",
-        path    => ['/usr/sbin', '/usr/bin', '/bin'],
-        require => Class['bigtop_toolchain::jdk'],
-      }
-    }
-  }
-
   stage { 'last':
     require => Stage['main'],
   }

--- a/bigtop_toolchain/manifests/jdk.pp
+++ b/bigtop_toolchain/manifests/jdk.pp
@@ -18,21 +18,25 @@ class bigtop_toolchain::jdk {
     /Debian/: {
       include apt
 
-      package { 'temurin-8-jdk' :
+      package { 'jdk8' :
+        name => 'temurin-8-jdk',
         ensure => present,
       }
     }
     /Ubuntu/: {
       include apt
 
-      package { 'openjdk-8-jdk' :
+      package { 'jdk8' :
+        name => 'openjdk-8-jdk',
         ensure  => present,
       }
     }
     /(CentOS|Amazon|Fedora|RedHat|Rocky|openEuler)/: {
-      package { 'java-1.8.0-openjdk-devel' :
+      package { 'jdk8' :
+        name => 'java-1.8.0-openjdk-devel',
         ensure => present
       }
+
       if ($::operatingsystem == "Fedora") {
         file { '/usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/cacerts':
           ensure => 'link',
@@ -41,8 +45,42 @@ class bigtop_toolchain::jdk {
       }
     }
     /OpenSuSE/: {
-      package { 'java-1_8_0-openjdk-devel' :
+      package { 'jdk8' :
+        name => 'java-1_8_0-openjdk-devel',
         ensure => present
+      }
+    }
+  }
+
+  case $::operatingsystem {
+    /Debian/: {
+      exec { 'ensure java 8 is set as default':
+        command => "update-java-alternatives --set temurin-8*",
+        path    => ['/usr/sbin', '/usr/bin', '/bin'],
+        require => Package['jdk8'],
+      }
+    }
+    /Ubuntu/: {
+      exec { 'ensure java 8 is set as default':
+        command => "update-java-alternatives --set java-1.8.0-openjdk-$(dpkg --print-architecture)",
+        path    => ['/usr/sbin', '/usr/bin', '/bin'],
+        require => Package['jdk8'],
+      }
+    }
+    /(CentOS|RedHat|Rocky)/: {
+      exec { 'ensure java 8 is set as default':
+        command => "update-alternatives --set java java-1.8.0-openjdk.$(uname -m) \
+                    && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)",
+        path    => ['/usr/sbin', '/usr/bin', '/bin'],
+        require => Package['jdk8'],
+      }
+    }
+    /Fedora/: {
+      exec { 'ensure java 8 is set as default':
+        command => "update-alternatives --set java /usr/lib/jvm/java-1.8.0-openjdk/jre/bin/java \
+                    && update-alternatives --set javac /usr/lib/jvm/java-1.8.0-openjdk/jre/bin/javac",
+        path    => ['/usr/sbin', '/usr/bin', '/bin'],
+        require => Package['jdk8'],
       }
     }
   }

--- a/bigtop_toolchain/manifests/jdk.pp
+++ b/bigtop_toolchain/manifests/jdk.pp
@@ -78,7 +78,7 @@ class bigtop_toolchain::jdk {
     /Fedora/: {
       exec { 'ensure java 8 is set as default':
         command => "update-alternatives --set java /usr/lib/jvm/java-1.8.0-openjdk/jre/bin/java \
-                    && update-alternatives --set javac /usr/lib/jvm/java-1.8.0-openjdk/jre/bin/javac",
+                    && update-alternatives --set javac /usr/lib/jvm/java-1.8.0-openjdk/bin/javac",
         path    => ['/usr/sbin', '/usr/bin', '/bin'],
         require => Package['jdk8'],
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4382

Updating java alternatives fails on applying toolchain manifest.

```
#7 2103.5 ESC[mNotice: /Stage[main]/Bigtop_toolchain::Installer/Exec[ensure java 8 is set as default]/returns: java-1.8.0-openjdk.x86_64 has not been configured as an alternative for javaESC[0m
#7 2103.5 ESC[1;31mError: 'update-alternatives --set java java-1.8.0-openjdk.$(uname -m)                     && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)' returned 2 instead of one of [0]ESC[0m
#7 2103.5 ESC[1;31mError: /Stage[main]/Bigtop_toolchain::Installer/Exec[ensure java 8 is set as default]/returns: change from 'notrun' to ['0'] failed: 'update-alternatives --set java java-1.8.0-openjdk.$(uname -m)                     && update-alternatives --set javac java-1.8.0-openjdk.$(uname -m)' returned 2 instead of one of [0]ESC[0m
```

The cause is unavailable family name in the latest java-1.8.0-openjdk-devel package. The fix is to add fedora specific conditional. The patch includes refactoring that moves resources for jdk8 to jdk.pp.
