### PR TITLE
BIGTOP-4386. Fix build failure of ZooKeeper on openeuler-22.03.

### DIFF
--- a/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
+++ b/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
@@ -92,7 +92,12 @@ Source9: zookeeper-rest.svc
 Source10: %{svc_zookeeper}.service
 Source11: %{svc_zookeeper}.tmpfile
 #BIGTOP_PATCH_FILES
-BuildRequires: autoconf, automake, cppunit-devel, systemd, systemd-rpm-macros
+BuildRequires: autoconf, automake, cppunit-devel, systemd
+
+%if 0%{?openEuler} == 0
+BuildRequires: systemd-rpm-macros
+%endif
+
 Requires(pre): coreutils, /usr/sbin/groupadd, /usr/sbin/useradd
 Requires(post): %{alternatives_dep}
 Requires(preun): %{alternatives_dep}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4386

```
error: Failed build dependencies:
	systemd-rpm-macros is needed by zookeeper-3.8.4-1.x86_64
```

Required files seems to be provided by systemd package on openEuler 22.03.

```
[root@c87aa0124f11 /]# rpm -q -f /usr/lib/rpm/macros.d/macros.systemd
systemd-249-100.oe2203sp3.x86_64
```
