### PR TITLE
BIGTOP-4385. Fix build failure of Hadoop on openeuler-22.03.

### DIFF
--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -194,7 +194,7 @@ Source45: hadoop-hdfs.tmpfile
 
 #BIGTOP_PATCH_FILES
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id} -u -n)
-BuildRequires: fuse-devel, fuse, systemd, systemd-rpm-macros
+BuildRequires: fuse-devel, fuse, systemd
 Requires: coreutils, /usr/sbin/useradd, /usr/sbin/usermod, /sbin/chkconfig, /sbin/service, bigtop-utils >= 0.7, %{zookeeper_pkg_name} >= 3.4.0
 Requires: psmisc, %{netcat_package}
 Requires: openssl-devel
@@ -215,7 +215,7 @@ Requires: sh-utils, insserv
 %if 0%{?openEuler}
 BuildRequires: pkgconfig, fuse-libs, openEuler-rpm-config, lzo-devel, openssl-devel
 %else
-BuildRequires: pkgconfig, fuse-libs, redhat-rpm-config, lzo-devel, openssl-devel
+BuildRequires: pkgconfig, fuse-libs, redhat-rpm-config, lzo-devel, openssl-devel, systemd-rpm-macros
 %endif
 # Required for init scripts
 Requires: coreutils, /lib/lsb/init-functions


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4385

```
error: Failed build dependencies:
	systemd-rpm-macros is needed by hadoop-3.3.6-1.x86_64
```

Required files seems to be provided by systemd package on openEuler 22.03.

```
[root@c87aa0124f11 /]# rpm -q -f /usr/lib/rpm/macros.d/macros.systemd
systemd-249-100.oe2203sp3.x86_64
```