### PR TITLE
BIGTOP-3974. Fix failure of loading OpenSSL by libhadoop.so due to version mismatch.

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch2-HADOOP-18583.diff
+++ b/bigtop-packages/src/common/hadoop/patch2-HADOOP-18583.diff
@@ -1,0 +1,115 @@
+commit acbb688da6831ebefff34cc9ab1e5c86012da875
+Author: Sebastian Klemke <3669903+packet23@users.noreply.github.com>
+Date:   Thu Nov 7 19:14:13 2024 +0100
+
+    HADOOP-18583. Fix loading of OpenSSL 3.x symbols  (#5256) (#7149)
+    
+    Contributed by Sebastian Klemke
+    
+    (cherry picked from commit f5cdb2658dd9ea3d3749db0ca40b0628f723ac20)
+
+diff --git a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/crypto/OpensslCipher.c b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/crypto/OpensslCipher.c
+index abff7ea5f17f..f17169dec247 100644
+--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/crypto/OpensslCipher.c
++++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/crypto/OpensslCipher.c
+@@ -24,6 +24,57 @@
+  
+ #include "org_apache_hadoop_crypto_OpensslCipher.h"
+ 
++/*
++   # OpenSSL ABI Symbols
++
++   Available on all OpenSSL versions:
++
++   | Function                       | 1.0 | 1.1 | 3.0 |
++   |--------------------------------|-----|-----|-----|
++   | EVP_CIPHER_CTX_new             | YES | YES | YES |
++   | EVP_CIPHER_CTX_free            | YES | YES | YES |
++   | EVP_CIPHER_CTX_set_padding     | YES | YES | YES |
++   | EVP_CIPHER_CTX_test_flags      | YES | YES | YES |
++   | EVP_CipherInit_ex              | YES | YES | YES |
++   | EVP_CipherUpdate               | YES | YES | YES |
++   | EVP_CipherFinal_ex             | YES | YES | YES |
++   | ENGINE_by_id                   | YES | YES | YES |
++   | ENGINE_free                    | YES | YES | YES |
++   | EVP_aes_256_ctr                | YES | YES | YES |
++   | EVP_aes_128_ctr                | YES | YES | YES |
++
++   Available on old versions:
++
++   | Function                       | 1.0 | 1.1 | 3.0 |
++   |--------------------------------|-----|-----|-----|
++   | EVP_CIPHER_CTX_cleanup         | YES | --- | --- |
++   | EVP_CIPHER_CTX_init            | YES | --- | --- |
++   | EVP_CIPHER_CTX_block_size      | YES | YES | --- |
++   | EVP_CIPHER_CTX_encrypting      | --- | YES | --- |
++
++   Available on new versions:
++
++   | Function                       | 1.0 | 1.1 | 3.0 |
++   |--------------------------------|-----|-----|-----|
++   | OPENSSL_init_crypto            | --- | YES | YES |
++   | EVP_CIPHER_CTX_reset           | --- | YES | YES |
++   | EVP_CIPHER_CTX_get_block_size  | --- | --- | YES |
++   | EVP_CIPHER_CTX_is_encrypting   | --- | --- | YES |
++
++   Optionally available on new versions:
++
++   | Function                       | 1.0 | 1.1 | 3.0 |
++   |--------------------------------|-----|-----|-----|
++   | EVP_sm4_ctr                    | --- | opt | opt |
++
++   Name changes:
++
++   | < 3.0 name                 | >= 3.0 name                    |
++   |----------------------------|--------------------------------|
++   | EVP_CIPHER_CTX_block_size  | EVP_CIPHER_CTX_get_block_size  |
++   | EVP_CIPHER_CTX_encrypting  | EVP_CIPHER_CTX_is_encrypting   |
++ */
++
+ #ifdef UNIX
+ static EVP_CIPHER_CTX * (*dlsym_EVP_CIPHER_CTX_new)(void);
+ static void (*dlsym_EVP_CIPHER_CTX_free)(EVP_CIPHER_CTX *);
+@@ -87,6 +138,15 @@ static __dlsym_EVP_aes_128_ctr dlsym_EVP_aes_128_ctr;
+ static HMODULE openssl;
+ #endif
+ 
++// names changed in OpenSSL 3 ABI - see History section in EVP_EncryptInit(3)
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++#define CIPHER_CTX_BLOCK_SIZE "EVP_CIPHER_CTX_get_block_size"
++#define CIPHER_CTX_ENCRYPTING "EVP_CIPHER_CTX_is_encrypting"
++#else
++#define CIPHER_CTX_BLOCK_SIZE "EVP_CIPHER_CTX_block_size"
++#define CIPHER_CTX_ENCRYPTING "EVP_CIPHER_CTX_encrypting"
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
++
+ static void loadAesCtr(JNIEnv *env)
+ {
+ #ifdef UNIX
+@@ -142,10 +202,10 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_crypto_OpensslCipher_initIDs
+   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_test_flags, env, openssl,  \
+                       "EVP_CIPHER_CTX_test_flags");
+   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_block_size, env, openssl,  \
+-                      "EVP_CIPHER_CTX_block_size");
++                      CIPHER_CTX_BLOCK_SIZE);
+ #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_encrypting, env, openssl,  \
+-                      "EVP_CIPHER_CTX_encrypting");
++                      CIPHER_CTX_ENCRYPTING);
+ #endif
+   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CipherInit_ex, env, openssl,  \
+                       "EVP_CipherInit_ex");
+@@ -173,11 +233,11 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_crypto_OpensslCipher_initIDs
+                       openssl, "EVP_CIPHER_CTX_test_flags");
+   LOAD_DYNAMIC_SYMBOL(__dlsym_EVP_CIPHER_CTX_block_size,  \
+                       dlsym_EVP_CIPHER_CTX_block_size, env,  \
+-                      openssl, "EVP_CIPHER_CTX_block_size");
++                      openssl, CIPHER_CTX_BLOCK_SIZE);
+ #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+   LOAD_DYNAMIC_SYMBOL(__dlsym_EVP_CIPHER_CTX_encrypting,  \
+                       dlsym_EVP_CIPHER_CTX_encrypting, env,  \
+-                      openssl, "EVP_CIPHER_CTX_encrypting");
++                      openssl, CIPHER_CTX_ENCRYPTING);
+ #endif
+   LOAD_DYNAMIC_SYMBOL(__dlsym_EVP_CipherInit_ex, dlsym_EVP_CipherInit_ex,  \
+                       env, openssl, "EVP_CipherInit_ex");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-3974

openssl can not be loaded on platforms providing OpenSSL 3 instead of 1.

```
root@7c80996cf943:/# hadoop checknative
2023-08-03 03:22:24,027 INFO bzip2.Bzip2Factory: Successfully loaded & initialized native-bzip2 library system-native
2023-08-03 03:22:24,030 INFO zlib.ZlibFactory: Successfully loaded & initialized native-zlib library
2023-08-03 03:22:24,063 INFO nativeio.NativeIO: The native code was built without PMDK support.
Native library checking:
hadoop:  true /usr/lib/hadoop/lib/native/libhadoop.so.1.0.0
zlib:    true /lib/x86_64-linux-gnu/libz.so.1
zstd  :  true /lib/x86_64-linux-gnu/libzstd.so.1
bzip2:   true /lib/x86_64-linux-gnu/libbz2.so.1
openssl: false EVP_CIPHER_CTX_block_size
ISA-L:   true /usr/lib/hadoop/lib/native/libisal.so.2
PMDK:    false The native code was built without PMDK support.
```

backporting HADOOP-18583 should fix this.