### PR TITLE
BIGTOP-4289. Fix Hadoop build on Fedora 40.

### DIFF
--- a/bigtop-packages/src/common/hadoop/patch4-HADOOP-19551.diff
+++ b/bigtop-packages/src/common/hadoop/patch4-HADOOP-19551.diff
@@ -1,0 +1,14 @@
+diff --git a/hadoop-common-project/hadoop-common/HadoopCommon.cmake b/hadoop-common-project/hadoop-common/HadoopCommon.cmake
+index 7628ecf628de..8ed478dc8df7 100644
+--- a/hadoop-common-project/hadoop-common/HadoopCommon.cmake
++++ b/hadoop-common-project/hadoop-common/HadoopCommon.cmake
+@@ -145,6 +145,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+     # Make GNU extensions available.
+     hadoop_add_compiler_flags("-D_GNU_SOURCE")
+ 
++    # using old default behavior on GCC >= 14.0
++    hadoop_add_compiler_flags("-Wno-error=implicit-function-declaration")
++
+     # If JVM_ARCH_DATA_MODEL is 32, compile all binaries as 32-bit.
+     if(JVM_ARCH_DATA_MODEL EQUAL 32)
+         # Force 32-bit code generation on amd64/x86_64, ppc64, sparc64


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4289

We need backport of [HADOOP-19551](https://issues.apache.org/jira/browse/HADOOP-19551) (https://github.com/apache/hadoop/pull/7644) to fix compilation error due to GCC compatibility.

This PR depends on [BIGTOP-3974](https://issues.apache.org/jira/browse/BIGTOP-3974) (#1341) for OpenSSL 3 support.