### PR TITLE
BIGTOP-4417. Fix failure of importing package signining keys on Rocky 

### DIFF
--- a/bigtop-deploy/puppet/manifests/bigtop_repo.pp
+++ b/bigtop-deploy/puppet/manifests/bigtop_repo.pp
@@ -47,6 +47,16 @@ class bigtop_repo {
         }
       }
       Yumrepo<||> -> Package<||>
+
+      if versioncmp($operatingsystemmajrelease, '9') == 0 {
+        # SHA-1 for package signing was deprecated in RHEL 9.
+        # https://www.redhat.com/en/blog/rhel-security-sha-1-package-signatures-distrusted-rhel-9
+        exec { 'update_crypto_policies_legacy':
+          command => '/usr/bin/update-crypto-policies --set LEGACY'
+        }
+
+        Exec['update_crypto_policies_legacy'] -> Yumrepo<||>
+      }
     }
 
     /(Ubuntu|Debian)/: {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4417

Importing package signing keys fails since [RHEL 9 deprecated DHA-1 for signing](https://www.redhat.com/en/blog/rhel-security-sha-1-package-signatures-distrusted-rhel-9).

This PR updates the manifest for calling `update-crypto-policies --set LEGACY` before importing the KEYS as a temporal fix. Since the update-crypto-policies is not available on Fedora 40 and openEuler 22.03, it is in the conditional.

KEYS should be updated before majority of OS distros deprecate the SHA-1 as package signing key.
