### PR TITLE
BIGTOP-4418. Fix installation failure of packages on Fedora 40 due to lack of /lib/lsb/init-functions.

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -29,7 +29,7 @@ class hadoop ($hadoop_security_authentication = "simple",
   $hadoop_http_authentication_type = undef,
   $hadoop_http_authentication_signature_secret = undef,
   $hadoop_http_authentication_signature_secret_file = "/etc/hadoop/conf/hadoop-http-authentication-signature-secret",
-  $hadoop_http_authentication_cookie_domain = $fqdn.split("\\.")[1, -1].join("."),
+  $hadoop_http_authentication_cookie_domain = regsubst($fqdn, "^[^\\.]+\\.", ""),
 ) {
 
   include stdlib

--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -29,7 +29,7 @@ class hadoop ($hadoop_security_authentication = "simple",
   $hadoop_http_authentication_type = undef,
   $hadoop_http_authentication_signature_secret = undef,
   $hadoop_http_authentication_signature_secret_file = "/etc/hadoop/conf/hadoop-http-authentication-signature-secret",
-  $hadoop_http_authentication_cookie_domain = regsubst($fqdn, "^[^\\.]+\\.", ""),
+  $hadoop_http_authentication_cookie_domain = $fqdn.split("\\.")[1, -1].join("."),
 ) {
 
   include stdlib

--- a/bigtop-packages/src/rpm/alluxio/SPECS/alluxio.spec
+++ b/bigtop-packages/src/rpm/alluxio/SPECS/alluxio.spec
@@ -68,14 +68,15 @@ Source7:       alluxio-job-worker.svc
 # Required for init scripts
 Requires: insserv
 %global        initd_dir %{_sysconfdir}/rc.d
-
 %else
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 Requires: initscripts
-
 %global        initd_dir %{_sysconfdir}/rc.d/init.d
-
 %endif
 
 Requires: bigtop-utils

--- a/bigtop-packages/src/rpm/flink/SPECS/flink.spec
+++ b/bigtop-packages/src/rpm/flink/SPECS/flink.spec
@@ -75,7 +75,11 @@ Requires(preun): /sbin/service
 Requires: insserv
 %else
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 %description

--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -218,7 +218,11 @@ BuildRequires: pkgconfig, fuse-libs, openEuler-rpm-config, lzo-devel, openssl-de
 BuildRequires: pkgconfig, fuse-libs, redhat-rpm-config, lzo-devel, openssl-devel, systemd-rpm-macros
 %endif
 # Required for init scripts
-Requires: coreutils, /lib/lsb/init-functions
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
+Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 %if  0%{?mgaversion}

--- a/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
+++ b/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
@@ -154,7 +154,11 @@ Requires: initscripts
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 %description master
@@ -180,7 +184,11 @@ Requires: initscripts
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 
@@ -207,7 +215,11 @@ Requires: initscripts
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 
@@ -235,7 +247,11 @@ Requires: initscripts
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 
@@ -272,7 +288,11 @@ Requires: initscripts
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 

--- a/bigtop-packages/src/rpm/hive/SPECS/hive.spec
+++ b/bigtop-packages/src/rpm/hive/SPECS/hive.spec
@@ -112,7 +112,11 @@ Hive is a data warehouse infrastructure built on top of Hadoop that provides too
 Requires: insserv
 %else
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 %package server2
@@ -126,7 +130,11 @@ Requires(pre): %{name} = %{version}-%{release}
 Requires: insserv
 %else
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 %description server2

--- a/bigtop-packages/src/rpm/livy/SPECS/livy.spec
+++ b/bigtop-packages/src/rpm/livy/SPECS/livy.spec
@@ -57,13 +57,16 @@ It supports executing snippets of code or programs in a Spark context that runs 
 # Required for init scripts
 Requires: insserv
 %global        initd_dir %{_sysconfdir}/rc.d
-
 %else
 # Required for init scripts
+%if %{!?suse_version:1}0 && %{!?mgaversion:1}0
+# Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
-
+%endif
 %global        initd_dir %{_sysconfdir}/init.d
-
 %endif
 
 # disable repacking jars

--- a/bigtop-packages/src/rpm/livy/SPECS/livy.spec
+++ b/bigtop-packages/src/rpm/livy/SPECS/livy.spec
@@ -59,8 +59,6 @@ Requires: insserv
 %global        initd_dir %{_sysconfdir}/rc.d
 %else
 # Required for init scripts
-%if %{!?suse_version:1}0 && %{!?mgaversion:1}0
-# Required for init scripts
 %if 0%{?fedora} >= 40
 Requires: redhat-lsb-core
 %else

--- a/bigtop-packages/src/rpm/solr/SPECS/solr.spec
+++ b/bigtop-packages/src/rpm/solr/SPECS/solr.spec
@@ -74,7 +74,11 @@ Requires: bigtop-utils >= 0.7
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 %description 

--- a/bigtop-packages/src/rpm/spark/SPECS/spark.spec
+++ b/bigtop-packages/src/rpm/spark/SPECS/spark.spec
@@ -73,13 +73,14 @@ Requires(preun): /sbin/service
 # Required for init scripts
 Requires: insserv
 %global initd_dir %{_sysconfdir}/rc.d
-
 %else
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
-
+%endif
 %global initd_dir %{_sysconfdir}/rc.d/init.d
-
 %endif
 
 %description 

--- a/bigtop-packages/src/rpm/zeppelin/SPECS/zeppelin.spec
+++ b/bigtop-packages/src/rpm/zeppelin/SPECS/zeppelin.spec
@@ -72,13 +72,14 @@ AutoReq: no
 # Required for init scripts
 Requires: insserv
 %global initd_dir %{_sysconfdir}/rc.d
-
 %else
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
-
+%endif
 %global initd_dir %{_sysconfdir}/rc.d/init.d
-
 %endif
 
 %description 

--- a/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
+++ b/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec
@@ -135,7 +135,11 @@ Requires: initscripts
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4418

While redhat-lsb provides the [/lib/lsb/init-functions](https://github.com/apache/bigtop/blob/master/bigtop-packages/src/rpm/zookeeper/SPECS/zookeeper.spec#L138), it can not be pulled by package dependency nor Puppet manifest.

```
Error: /Stage[main]/Hadoop_zookeeper::Server/Package[zookeeper-server]/ensure: change from 'purged' to 'latest' failed: Could not update: Execution of '/usr/bin/dnf -d 0 -e 1 -y install zookeeper-server' returned 1: Error:
 Problem: conflicting requests
  - nothing provides /lib/lsb/init-functions needed by zookeeper-server-3.8.4-1.fc40.x86_64 from Bigtop_0
```

This PR adds Fedora specific conditionals to the .spec files. While I think conditionals for SUSE and Megaia are obsolete and useless, I left them as-is. It should be removed by follow-up JIRAs.