### PR TITLE
BIGTOP-4419. Fix deployment failure due to Puppet incompatibility with Ruby 3.3.

### DIFF
--- a/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp
@@ -29,7 +29,7 @@ class hadoop ($hadoop_security_authentication = "simple",
   $hadoop_http_authentication_type = undef,
   $hadoop_http_authentication_signature_secret = undef,
   $hadoop_http_authentication_signature_secret_file = "/etc/hadoop/conf/hadoop-http-authentication-signature-secret",
-  $hadoop_http_authentication_cookie_domain = regsubst($fqdn, "^[^\\.]+\\.", ""),
+  $hadoop_http_authentication_cookie_domain = $fqdn.split("\\.")[1, -1].join("."),
 ) {
 
   include stdlib


### PR DESCRIPTION
Deployment on Fedora 40 failed since the [Puppet's regsubst function is not compatible with Ruby 3.3](https://bugzilla.redhat.com/show_bug.cgi?id=2280109).

```
Notice: Scope(Class[Node_with_components]): Roles to deploy: [resourcemanager, nodemanager, mapred-app, hadoop-client, mapred-app, namenode, datanode]
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, wrong number of arguments (given 3, expected 1..2) (file: /bigtop-home/bigtop-deploy/puppet/modules/hadoop/manifests/init.pp, line: 32, column: 47) (file: /bigtop-home/bigtop-deploy/puppet/manifests/cluster.pp, line: 182) on node 1d7ea83c4a05.bigtop.apache.org
```

The `regsubst` is only used in one place. I replaced it with `split` and `join` for removing the part before the first `.`.

```
$ docker run --rm -i -t bigtop/puppet:trunk-fedora-40 /bin/bash
[root@0a62e9eeb842 /]# puppet apply -e 'notice("foo.bar.baz".split("\\.")[1, -1].join("."))'
Notice: Scope(Class[main]): bar.baz
```