### PR TITLE
BIGTOP-4420. Fix packaging failure of bigtop-select using container due to undefined Gradle tasks.

### DIFF
--- a/packages.gradle
+++ b/packages.gradle
@@ -221,7 +221,7 @@ task "all-components" (description: "List the components of the stack") doLast {
   }
 }
 
-def genTasks = { target ->
+def genTasks = { target, packaging ->
   Task t = task "${target}-download" (dependsOn: "${target}_vardefines",
       description: "Download $target artifacts",
       group: PACKAGES_GROUP) doLast {
@@ -734,13 +734,15 @@ def genTasks = { target ->
   }
   if (nativePackaging) {
     def ptype = nativePackaging.pkg
-    task "$target-pkg" (dependsOn: "$target-$ptype",
-        description: "Invoking a native binary packaging target $ptype",
-        group: PACKAGES_GROUP) doLast {
-    }
-    task "$target-spkg" (dependsOn: "$target-s$ptype",
-        description: "Invoking a native binary packaging target s$ptype",
-        group: PACKAGES_GROUP) doLast {
+    if (ptype.equals(packaging)) {
+      task "$target-pkg" (dependsOn: "$target-$ptype",
+          description: "Invoking a native binary packaging target $ptype",
+          group: PACKAGES_GROUP) doLast {
+      }
+      task "$target-spkg" (dependsOn: "$target-s$ptype",
+          description: "Invoking a native binary packaging target s$ptype",
+          group: PACKAGES_GROUP) doLast {
+      }
     }
   }
   task "$target-pkg-ind" (
@@ -889,9 +891,7 @@ project.afterEvaluate {
   doValidateBOM(config)
   config.bigtop.components.each { component_label, comp ->
     assert component_label == comp.name
-    if (!comp.packaging || comp.packaging.equalsIgnoreCase(nativePackaging.pkg)) {
-      genTasks(comp.name)
-    }
+    genTasks(comp.name, comp.packaging)
   }
   // Versions need to be preserved for more than just component:
   //  - there are JDK version requirement


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4420

```
[bigtop-select] $ /bin/bash -ex /tmp/jenkins1810671388621150548.sh
+ JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-arm64
+ ./gradlew -POS=rockylinux-9 -Pprefix=3.4.0 -Pdocker-run-option=--privileged -Pmvn-cache-volume=true bigtop-select-clean bigtop-select-pkg-ind
Starting a Gradle Daemon, 3 busy Daemons could not be reused, use --status for details

FAILURE: Build failed with an exception.

* What went wrong:
Task 'bigtop-select-clean' not found in root project 'bigtop'.
```

`bigtop-select-*` tasks are not defined if the host OS is Debian family after [BIGTOP-4420](https://issues.apache.org/jira/browse/BIGTOP-4420). The intent was to avoid failure `./gradlew pkgs`. bigtop-select-pkg-ind and bigtop-select-clean should be defined for RPM packaging on Debian family host using container. I updated to exclude only bigtop-select-[s]pkg on Debian family host here.