### PR TITLE
BIGTOP-4421. Fix build failure of Hadoop and Alluxio due to node-gyp error.

### DIFF
--- a/bigtop_toolchain/manifests/python.pp
+++ b/bigtop_toolchain/manifests/python.pp
@@ -40,7 +40,7 @@ class bigtop_toolchain::python {
     ensure => present
   }
 
-  if ($architecture in ['aarch64']) {
+  if ($architecture in ['aarch64', 'ppc64le']) {
     exec { "download_python2.7":
       cwd => "/usr/src",
       command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.18 && /bin/tar -xvzf Python-2.7.18.tgz -C Python-2.7.18 --strip-components=1 && cd Python-2.7.18",

--- a/bigtop_toolchain/manifests/python.pp
+++ b/bigtop_toolchain/manifests/python.pp
@@ -43,13 +43,13 @@ class bigtop_toolchain::python {
   if ($architecture in ['aarch64', 'ppc64le']) {
     exec { "download_python2.7":
       cwd => "/usr/src",
-      command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.18 && /bin/tar -xvzf Python-2.7.18.tgz -C Python-2.7.18 --strip-components=1 && cd Python-2.7.18",
+      command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz && /usr/bin/mkdir Python-2.7.18 && /bin/tar -xvzf Python-2.7.18.tgz -C Python-2.7.18 --strip-components=1 && cd Python-2.7.18",
       creates => "/usr/src/Python-2.7.18",
     }
 
     exec { "install_python2.7":
       cwd => "/usr/src/Python-2.7.18",
-      command => "/usr/src/Python-2.7.18/configure --prefix=/usr/local/python2.7.18 && /usr/bin/make -j8 && /usr/bin/make install -j8",
+      command => "/usr/src/Python-2.7.18/configure --prefix=/usr/local/python2.7.18 && /usr/bin/make -j${processors['cores']} && /usr/bin/make install -j${processors['cores']}",
       require => [Exec["download_python2.7"]],
       timeout => 3000
     }

--- a/bigtop_toolchain/manifests/python.pp
+++ b/bigtop_toolchain/manifests/python.pp
@@ -56,7 +56,7 @@ class bigtop_toolchain::python {
 
     exec { "ln python2.7":
       cwd => "/usr/bin",
-      command => "/usr/bin/ln -s /usr/local/python2.7.18/bin/python2.7 python2.7 && /usr/bin/ln -snf python2.7 python2",
+      command => "/usr/bin/ln -snf /usr/local/python2.7.18/bin/python2.7 python2.7 && /usr/bin/ln -snf python2.7 python2",
       require => Exec["install_python2.7"],
     }
   }

--- a/bigtop_toolchain/manifests/python.pp
+++ b/bigtop_toolchain/manifests/python.pp
@@ -41,19 +41,23 @@ class bigtop_toolchain::python {
   }
 
   if ($architecture in ['aarch64']) {
-    case $operatingsystem{
-      /(?i:(fedora|ubuntu|debian))/: {
-        package { 'python2' :
-          ensure => present
-        }
-      }
-      /(?i:(centos|redhat|rocky))/: {
-        if (versioncmp($operatingsystemmajrelease, '8') == 0) {
-          package { 'python2' :
-            ensure => present
-          }
-        }
-      }
+    exec { "download_python2.7":
+      cwd => "/usr/src",
+      command => "/usr/bin/wget https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz --no-check-certificate && /usr/bin/mkdir Python-2.7.18 && /bin/tar -xvzf Python-2.7.18.tgz -C Python-2.7.18 --strip-components=1 && cd Python-2.7.18",
+      creates => "/usr/src/Python-2.7.18",
+    }
+
+    exec { "install_python2.7":
+      cwd => "/usr/src/Python-2.7.18",
+      command => "/usr/src/Python-2.7.18/configure --prefix=/usr/local/python2.7.18 && /usr/bin/make -j8 && /usr/bin/make install -j8",
+      require => [Exec["download_python2.7"]],
+      timeout => 3000
+    }
+
+    exec { "ln python2.7":
+      cwd => "/usr/bin",
+      command => "/usr/bin/ln -s /usr/local/python2.7.18/bin/python2.7 python2.7 && /usr/bin/ln -snf python2.7 python2",
+      require => Exec["install_python2.7"],
     }
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4421

We need python2 for rebuilding native libraries required for old node-spss by node-gyp on the architecture for which pre-built native libraries are not provided. Since recent OS distributions do not provide python2, we need another solution here.

```
[INFO] gyp ERR! configure error
[INFO] gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
[INFO] gyp ERR! stack     at PythonFinder.failNoPython (/bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/node-sass/node_modules/node-gyp/lib/configure.js:484:19)
[INFO] gyp ERR! stack     at PythonFinder.<anonymous> (/bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/node-sass/node_modules/node-gyp/lib/configure.js:406:16)
[INFO] gyp ERR! stack     at F (/bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/which/which.js:68:16)
[INFO] gyp ERR! stack     at E (/bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/which/which.js:80:29)
[INFO] gyp ERR! stack     at /bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/which/which.js:89:16
[INFO] gyp ERR! stack     at /bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/isexe/index.js:42:5
[INFO] gyp ERR! stack     at /bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/isexe/mode.js:8:5
[INFO] gyp ERR! stack     at FSReqCallback.oncomplete (fs.js:168:21)
[INFO] gyp ERR! System Linux 6.10.14-linuxkit
[INFO] gyp ERR! command "/bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node/node" "/bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/node-sass/node_module\
s/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
[INFO] gyp ERR! cwd /bigtop-home/build/hadoop/rpm/BUILD/hadoop-3.3.6-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/target/webapp/node_modules/node-sass
[INFO] gyp ERR! node -v v12.22.1
[INFO] gyp ERR! node-gyp -v v3.8.0
[INFO] gyp ERR! not ok
```

I'm bringing back the manifest to install Python 2 from source code removed by BIGTOP-4098(#1262). Previously it was for specific combination of OS and architecture. Now we need this for all OS distributions (supported on Bigtop 3.4.0) on aarch64.

