### PR TITLE
Update do-component-build

### DIFF
--- a/bigtop-packages/src/common/alluxio/do-component-build
+++ b/bigtop-packages/src/common/alluxio/do-component-build
@@ -50,6 +50,11 @@ else
   if [ "${OS}" = "openEuler" ] || [ "${OS}" = "fedora" ]; then
     sed -i "s|<activeByDefault>false</activeByDefault>|<activeByDefault>true</activeByDefault>|g" integration/jnifuse/native/pom.xml
   fi
+  #openEuler use python3 default, node-gyp support python3 from 6.0.0.
+  if [ "${OS}" = "openEuler" ];then
+    sed -i 's#"node-gyp": "^3.8.0",#"node-gyp": "^6.0.0",#g'  `grep -rn '"node-gyp": "^3.8.0"' -rl`
+	  sed -i 's#https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz#https://registry.npmjs.org/node-gyp/-/node-gyp-6.0.0.tgz#g' `grep https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz -rl`
+  fi
 
   mvn clean install -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Dmaven.buildNumber.revisionOnScmFailure=v${ALLUXIO_VERSION} -Phadoop-3 -Pyarn "$@"
 


### PR DESCRIPTION
Fix the alluxio compile failed bug.

openEuler use python3 default, node-gyp support python3 from 6.0.0.

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/