### PR TITLE
BIGTOP-4428. Starting Hive services depends on initscripts on rockylinux-9 and fedora-40.

### DIFF
--- a/bigtop-packages/src/rpm/hive/SPECS/hive.spec
+++ b/bigtop-packages/src/rpm/hive/SPECS/hive.spec
@@ -130,6 +130,7 @@ Requires(pre): %{name} = %{version}-%{release}
 Requires: insserv
 %else
 # Required for init scripts
+Requires: initscripts
 %if 0%{?fedora} >= 40
 Requires: redhat-lsb-core
 %else
@@ -139,6 +140,7 @@ Requires: /lib/lsb/init-functions
 
 %description server2
 This optional package hosts a Thrift server for Hive clients across a network to use with improved concurrency support.
+
 %package metastore
 Summary: Shared metadata repository for Hive.
 Group: System/Daemons
@@ -150,7 +152,12 @@ Requires(pre): %{name} = %{version}-%{release}
 Requires: insserv
 %else
 # Required for init scripts
+Requires: initscripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 
@@ -205,16 +212,16 @@ Requires: %{name}-hcatalog = %{version}-%{release}
 Requires: insserv
 %endif
 
-%if  0%{?mgaversion}
-# Required for init scripts
-Requires: initscripts
-%endif
-
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
 # Required for init scripts
+Requires: initscripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 %description hcatalog-server
@@ -231,11 +238,6 @@ Requires: %{name}-webhcat = %{version}-%{release}
 Requires: insserv
 %endif
 
-%if  0%{?mgaversion}
-# Required for init scripts
-Requires: initscripts
-%endif
-
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora
 %if %{!?suse_version:1}0 && %{!?mgaversion:1}0
@@ -246,7 +248,12 @@ Requires: initscripts
     /usr/lib/rpm/brp-python-bytecompile ; \
     %{nil}
 # Required for init scripts
+Requires: initscripts
+%if 0%{?fedora} >= 40
+Requires: redhat-lsb-core
+%else
 Requires: /lib/lsb/init-functions
+%endif
 %endif
 
 %description webhcat-server


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4428

Hive services fails due to insufficent dependency on /etc/init.d/functions.

```
May 21 03:55:17 88e0b2a91ea7 systemd[1]: Starting hive-server2.service - LSB: Hive Server2...
░░ Subject: A start job for unit hive-server2.service has begun execution
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░
░░ A start job for unit hive-server2.service has begun execution.
░░
░░ The job identifier is 1523.
May 21 03:55:17 88e0b2a91ea7 hive-server2[3973]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
May 21 03:55:17 88e0b2a91ea7 hive-server2[3974]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
May 21 03:55:17 88e0b2a91ea7 runuser[3976]: pam_unix(runuser:session): session opened for user hive(uid=989) by (uid=0)
May 21 03:55:17 88e0b2a91ea7 runuser[3976]: pam_unix(runuser:session): session closed for user hive
May 21 03:55:20 88e0b2a91ea7 hive-server2[4139]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
May 21 03:55:20 88e0b2a91ea7 hive-server2[4140]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
May 21 03:55:20 88e0b2a91ea7 hive-server2[4141]: /etc/redhat-lsb/lsb_log_message: line 3: /etc/init.d/functions: No such file or directory
May 21 03:55:20 88e0b2a91ea7 hive-server2[4141]: Failed to start Hive Server2. Return value: 127
May 21 03:55:20 88e0b2a91ea7 hive-server2[4142]: /etc/redhat-lsb/lsb_log_message: line 16: failure: command not found
May 21 03:55:20 88e0b2a91ea7 systemd[1]: hive-server2.service: Control process exited, code=exited, status=127/n/a
```

Since all Red Hat family OS distributions supported in Bigtop 3.4 (fedora-40, rockylinux-9 and openeuler-22.03) are providing initscripts package as a source of /etc/init.d/functions and other related resources, I added the dependency in the hive.spec.
