### PR TITLE
BIGTOP-4429. Fix deployment failure of Ranger on rockylinux-9 due to mismatch of python package.

### DIFF
--- a/bigtop-deploy/puppet/modules/ranger/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ranger/manifests/init.pp
@@ -25,7 +25,7 @@ class ranger {
   class admin($admin_password) {
     # Before Facter 3.14.17, Rocky Linux 8 is detected as 'RedHat'.
     # https://puppet.com/docs/pe/2019.8/osp/release_notes_facter.html#enhancements-3-14-17
-    if ( $operatingsystem =~ /^(?i:(redhat|rocky))$/ and 0 <= versioncmp($operatingsystemmajrelease, '8')) {
+    if ( $operatingsystem =~ /^(?i:(redhat|rocky))$/ and 0 == versioncmp($operatingsystemmajrelease, '8')) {
       $python = 'python36'
     } else {
       $python = 'python3'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4429

Applying Puppet manifest failed since python36 is not available on rockylinux-9.

```
Error: Could not update: Execution of '/usr/bin/dnf -d 0 -e 1 -y list python36' returned 1: Error: No matching Packages to list
Error: /Stage[main]/Ranger::Admin/Package[python36]/ensure: change from 'purged' to 'latest' failed: Could not update: Execution of '/usr/bin/dnf -d 0 -e 1 -y list python36' returned 1: Error: No matching Packages to list
```

`python36` was workaround for rockylinux-8 on which `python3` did not work. We can use `python3` on rockylinux-9.
