### PR TITLE
BIGTOP-4431. Upgrade Fedora's version in the docker provisioner config to 40.

### DIFF
--- a/provisioner/docker/config_fedora-40.yaml
+++ b/provisioner/docker/config_fedora-40.yaml
@@ -15,9 +15,9 @@
 
 docker:
         memory_limit: "4g"
-        image: "bigtop/puppet:trunk-fedora-38"
+        image: "bigtop/puppet:trunk-fedora-40"
 
-repo: "http://repos.bigtop.apache.org/releases/3.3.0/fedora/38/$basearch"
+repo: "http://repos.bigtop.apache.org/releases/3.3.0/fedora/40/$basearch"
 distro: centos
 components: [hdfs, yarn, mapreduce]
 enable_local_repo: false


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Fedora's version in the provisioner config to 40.

### How was this patch tested?

I ensured the following command worked after applying this PR to master.

```
$ ./docker-hadoop.sh -d -dcp -C config_fedora-40.yaml -F docker-compose-cgroupv2.yml -G -L -k zookeeper -s zookeeper -c 1

...

BUILD SUCCESSFUL in 18s
27 actionable tasks: 6 executed, 21 up-to-date
Stopped 1 worker daemon(s).
+ rm -rf buildSrc/build/test-results/binary
+ rm -rf /bigtop-home/.gradle
$ ./docker-hadoop.sh -dcp -e 1 cat /etc/redhat-release
Fedora release 40 (Forty)
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/