### PR TITLE
BIGTOP-4433. Enabling ZK and Hadoop services doesn't work.

### DIFF
--- a/bigtop-packages/src/common/hadoop/hadoop-hdfs-datanode.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-hdfs-datanode.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/hdfs --config /etc/hadoop/conf --daemon start datanode
 ExecStop=/usr/bin/hdfs --config /etc/hadoop/conf --daemon stop datanode
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-hdfs-dfsrouter.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-hdfs-dfsrouter.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/hdfs --config /etc/hadoop/conf --daemon start dfsrouter
 ExecStop=/usr/bin/hdfs --config /etc/hadoop/conf --daemon stop dfsrouter
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-hdfs-journalnode.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-hdfs-journalnode.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/hdfs --config /etc/hadoop/conf --daemon start journalnode
 ExecStop=/usr/bin/hdfs --config /etc/hadoop/conf --daemon stop journalnode
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-hdfs-namenode.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-hdfs-namenode.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/hdfs --config /etc/hadoop/conf --daemon start namenode
 ExecStop=/usr/bin/hdfs --config /etc/hadoop/conf --daemon stop namenode
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-hdfs-secondarynamenode.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-hdfs-secondarynamenode.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/hdfs --config /etc/hadoop/conf --daemon start secondarynamenode
 ExecStop=/usr/bin/hdfs --config /etc/hadoop/conf --daemon stop secondarynamenode
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-hdfs-zkfc.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-hdfs-zkfc.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/hdfs --config /etc/hadoop/conf --daemon start zkfc
 ExecStop=/usr/bin/hdfs --config /etc/hadoop/conf --daemon stop zkfc
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-mapreduce-historyserver.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-mapreduce-historyserver.service
@@ -33,3 +33,7 @@ RuntimeDirectory=hadoop-mapreduce
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/mapred --config /etc/hadoop/conf --daemon start historyserver
 ExecStop=/usr/bin/mapred --config /etc/hadoop/conf --daemon stop historyserver
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-nodemanager.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-nodemanager.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start nodemanager
 ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop nodemanager
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-proxyserver.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-proxyserver.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start proxyserver
 ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop proxyserver
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-resourcemanager.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-resourcemanager.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start resourcemanager
 ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop resourcemanager
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-router.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-router.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start router
 ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop router
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/hadoop/hadoop-yarn-timelineserver.service
+++ b/bigtop-packages/src/common/hadoop/hadoop-yarn-timelineserver.service
@@ -32,3 +32,7 @@ RemainAfterExit=no
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/yarn --config /etc/hadoop/conf --daemon start timelineserver
 ExecStop=/usr/bin/yarn --config /etc/hadoop/conf --daemon stop timelineserver
+
+[Install]
+WantedBy=multi-user.target
+

--- a/bigtop-packages/src/common/zookeeper/zookeeper-server.service
+++ b/bigtop-packages/src/common/zookeeper/zookeeper-server.service
@@ -36,3 +36,7 @@ PIDFile=/run/zookeeper/zookeeper_server.pid
 SuccessExitStatus=5 6
 ExecStart=/usr/bin/zookeeper-server start
 ExecStop=/usr/bin/zookeeper-server stop
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR adds the `[Install]` section to ZK and Hadoop's unit files and make `systemctl enable` work.

### How was this patch tested?

Build and install ZK and Hadoop with this PR:

```
$ ./gradlew allclean hadoop-pkg repo -Dbuildwithdeps=true
$ cat <<EOF > bigtop-deploy/puppet/hieradata/site.yaml
bigtop::bigtop_repo_gpg_check: false
bigtop::bigtop_repo_uri: [file:///$(pwd)/output]
bigtop::hadoop_head_node: "$(facter fqdn)"
hadoop::hadoop_storage_dirs: [/data]
hadoop_cluster_node::cluster_components: [bigtop-utils, zookeeper, hdfs, yarn]
EOF
$ sudo cp -r bigtop-deploy/puppet/hiera* /etc/puppet
$ sudo puppet apply --hiera_config=/etc/puppet/hiera.yaml --modulepath=$PWD/bigtop-deploy/puppet/modules:/etc/puppet/code/modules $PWD/bigtop-deploy/puppet/manifests
```

Enable services and ensure it's activated after rebooting OS:

```
$ sudo systemctl enable hadoop-hdfs-namenode.service 
Created symlink /etc/systemd/system/multi-user.target.wants/hadoop-hdfs-namenode.service → /usr/lib/systemd/system/hadoop-hdfs-namenode.service.
$ sudo systemctl status hadoop-hdfs-namenode.service 
● hadoop-hdfs-namenode.service - Hadoop NameNode
     Loaded: loaded (/usr/lib/systemd/system/hadoop-hdfs-namenode.service; enabled; preset: disabled)
     Active: active (running) since Mon 2025-05-26 12:20:58 UTC; 1min 6s ago
       Docs: https://hadoop.apache.org/
   Main PID: 3631 (java)
      Tasks: 63 (limit: 100444)
     Memory: 335.5M
        CPU: 2.450s
     CGroup: /system.slice/hadoop-hdfs-namenode.service
             └─3631 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.452.b09-2.el9.x86_64/bin/java -Dproc_namenode -Djava.net.preferIPv4Stack=true -Dhdfs.audit.logger=INFO,NullAppender -Dcom.sun.manag>

May 26 12:20:56 rocky9.localdomain systemd[1]: Starting Hadoop NameNode...
May 26 12:20:58 rocky9.localdomain systemd[1]: Started Hadoop NameNode.
$ sudo reboot
```

```
$ sudo systemctl status hadoop-hdfs-namenode.service
● hadoop-hdfs-namenode.service - Hadoop NameNode
     Loaded: loaded (/usr/lib/systemd/system/hadoop-hdfs-namenode.service; enabled; preset: disabled)
     Active: active (running) since Mon 2025-05-26 12:22:42 UTC; 1min 8s ago
       Docs: https://hadoop.apache.org/
    Process: 742 ExecStart=/usr/bin/hdfs --config /etc/hadoop/conf --daemon start namenode (code=exited, status=0/SUCCESS)
   Main PID: 832 (java)
      Tasks: 63 (limit: 100444)
     Memory: 392.8M
        CPU: 2.431s
     CGroup: /system.slice/hadoop-hdfs-namenode.service
             └─832 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.452.b09-2.el9.x86_64/bin/java -Dproc_namenode -Djava.net.preferIPv4Stack=true -Dhdfs.audit.logger=INFO,NullAppender -Dcom.sun.manage>

May 26 12:22:40 rocky9.localdomain systemd[1]: Starting Hadoop NameNode...
May 26 12:22:42 rocky9.localdomain systemd[1]: Started Hadoop NameNode.
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/