### PR TITLE
BIGTOP-4446. Remove obsolete fuse from toolchain in Debian and Ubuntu.

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -245,7 +245,6 @@ class bigtop_toolchain::packages {
         "libtool",
         "gcc",
         "g++",
-        "fuse",
         "reprepro",
         "rsync",
         "liblzo2-dev",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4446

Old fuse package can not be installed on recent Ubuntu with GUI enabled since it conflicts with fuse3.

```
$ ./gradlew toolchain
...
The following packages have unmet dependencies:
 xdg-desktop-portal : Depends: fuse3 but it is not going to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
Error: /Stage[main]/Bigtop_toolchain::Packages/Package[fuse]/ensure: change from 'absent' to 'present' failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install fuse' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 xdg-desktop-portal : Depends: fuse3 but it is not going to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```

I left libfuse-dev as is since I'm not confident that it is not necessary now. Just removing fuse solved the issue and it did not break packaging at least.
