### PR TITLE
BIGTOP-4462. Upgrade HBase to 2.6.2.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -168,7 +168,7 @@ bigtop {
       name    = 'hbase'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache HBase'
-      version { base = '2.6.1'; pkg = base; release = 1 }
+      version { base = '2.6.2'; pkg = base; release = 1 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades HBase to 2.6.2.

### How was this patch tested?

Tested with Ubuntu 24.04 on x86_64, as follows:

```
$ ./gradlew allclean hbase-pkg repo -Dbuildwithdeps=true
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_ubuntu-24.04.yaml -F docker-compose-cgroupv2.yml -G -L -k zookeeper,hdfs,hbase -s hbase -c 1

...

> Task :bigtop-tests:smoke-tests:hbase:test
Finished generating test XML results (0.02 secs) into: /bigtop-home/bigtop-tests/smoke-tests/hbase/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.019 secs) into: /bigtop-home/bigtop-tests/smoke-tests/hbase/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:hbase:test (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 2 mins 7.33 secs.

BUILD SUCCESSFUL in 2m 32s
30 actionable tasks: 9 executed, 21 up-to-date
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/