### PR TITLE
BIGTOP-4461. Upgrade Flink to 1.20.1.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -234,7 +234,7 @@ bigtop {
       name    = 'flink'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Flink'
-      version { base = '1.20.0'; pkg = base; release = 1 }
+      version { base = '1.20.1'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}-src.tgz" }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Flink to 1.20.1.

### How was this patch tested?

Tested with Debian 12 on x86_64, as follows:

```
$ ./gradlew allclean hadoop-pkg flink-pkg repo -Dbuildwithdeps=true
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_debian-12.yaml -F docker-compose-cgroupv2.yml -G -L -k hdfs,yarn,flink -s flink -c 1

...

> Task :bigtop-tests:smoke-tests:flink:test
Finished generating test XML results (0.005 secs) into: /bigtop-home/bigtop-tests/smoke-tests/flink/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.01 secs) into: /bigtop-home/bigtop-tests/smoke-tests/flink/build/reports/tests/test
Now testing...
:bigtop-tests:smoke-tests:flink:test (Thread[Execution worker for ':',5,main]) completed. Took 10.541 secs.

BUILD SUCCESSFUL in 26s
28 actionable tasks: 7 executed, 21 up-to-date
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/