### PR TITLE
BIGTOP-4469. Add dependency on initscripts to Flink RPM.

### DIFF
--- a/bigtop-packages/src/rpm/flink/SPECS/flink.spec
+++ b/bigtop-packages/src/rpm/flink/SPECS/flink.spec
@@ -106,6 +106,7 @@ Summary: Provides the Apache Flink Job Manager service.
 Group: System/Daemons
 Requires: %{name} = %{version}-%{release}
 Requires(pre): %{name} = %{version}-%{release}
+Requires: initscripts
 
 %description jobmanager
 Apache Flink Job Manager service.
@@ -115,6 +116,7 @@ Summary: Provides the Apache Flink Task Manager service.
 Group: System/Daemons
 Requires: %{name} = %{version}-%{release}
 Requires(pre): %{name} = %{version}-%{release}
+Requires: initscripts
 
 %description taskmanager
 Apache Flink Task Manager service.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4469

Starting services of Flink failed on Rocky Linux 9 due to absence of /etc/init.d/funcsions provided by initscripts package. Since the dependency on /etc/init.d/funcitons (via /lib/lsb/init-functions) [is specific to Flink](https://github.com/apache/bigtop/blob/734e142de1d64a4432faba5e244b09f64fcc4b5b/bigtop-packages/src/common/flink/flink-jobmanager.svc#L27C1-L82), other packages using generic init scripts are not affected. Current smoke-tests of Flink [seems to pass regardless of the service statuses](https://ci.bigtop.apache.org/job/Bigtop-3.4.0-smoke-tests/COMPONENTS=hdfs.flink@flink,OS=rockylinux-9-aarch64-deploy/6/console).

```
Error: Systemd start for flink-taskmanager failed!
journalctl log for flink-taskmanager:
Jul 19 07:17:32 e113dd687caf systemd[1]: /run/systemd/generator.late/flink-taskmanager.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/flink/flink-flink-taskexecutor.pid ??? /run/flink/flink-flink-taskexecutor.pid; please update the unit file accordingly.
Jul 19 07:17:32 e113dd687caf systemd[1]: Starting LSB: Flink taskmanager...
Jul 19 07:17:32 e113dd687caf flink-taskmanager[8507]: /etc/redhat-lsb/lsb_log_message: line 3: /etc/init.d/functions: No such file or directory
Jul 19 07:17:32 e113dd687caf flink-taskmanager[8507]: Starting Flink taskmanager (flink-taskmanager):
Jul 19 07:17:32 e113dd687caf flink-taskmanager[8508]: /etc/redhat-lsb/lsb_log_message: line 11: success: command not found
Jul 19 07:17:32 e113dd687caf flink-taskmanager[8530]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
Jul 19 07:17:32 e113dd687caf flink-taskmanager[8531]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
Jul 19 07:17:32 e113dd687caf runuser[8532]: pam_unix(runuser:session): session opened for user flink(uid=994) by (uid=0)
Jul 19 07:17:32 e113dd687caf runuser[8532]: pam_unix(runuser:session): session closed for user flink
Jul 19 07:17:35 e113dd687caf flink-taskmanager[9040]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
Jul 19 07:17:35 e113dd687caf flink-taskmanager[9041]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
Jul 19 07:17:35 e113dd687caf flink-taskmanager[9042]: /etc/redhat-lsb/lsb_log_message: line 3: /etc/init.d/functions: No such file or directory
Jul 19 07:17:35 e113dd687caf flink-taskmanager[9042]: Failed to start Flink taskmanager. Return value: 127
Jul 19 07:17:35 e113dd687caf flink-taskmanager[9043]: /etc/redhat-lsb/lsb_log_message: line 16: failure: command not found
Jul 19 07:17:35 e113dd687caf systemd[1]: flink-taskmanager.service: Control process exited, code=exited, status=127/n/a
Jul 19 07:17:35 e113dd687caf systemd[1]: flink-taskmanager.service: Failed with result 'exit-code'.
Jul 19 07:17:35 e113dd687caf systemd[1]: flink-taskmanager.service: Unit process 9013 (java) remains running after unit stopped.
Jul 19 07:17:35 e113dd687caf systemd[1]: Failed to start LSB: Flink taskmanager.
Jul 19 07:17:35 e113dd687caf systemd[1]: flink-taskmanager.service: Consumed 6.398s CPU time.
```

Current smoke-tests of Flink [seems to pass regardless of the service statuses](https://ci.bigtop.apache.org/job/Bigtop-3.4.0-smoke-tests/COMPONENTS=hdfs.flink@flink,OS=rockylinux-9-aarch64-deploy/6/console).
