### PR TITLE
BIGTOP-4460. Upgrade Airflow to 2.10.5.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -349,7 +349,7 @@ bigtop {
     'airflow' {
       name    = "airflow"
       relNotes = "Apache Airflow"
-      version { base = '2.10.4'; pkg = base; release = 1 }
+      version { base = '2.10.5'; pkg = base; release = 1 }
       tarball { source      = "apache_airflow-${version.base}.tar.gz"
                 destination = source }
       url     { download_path = "/${name}/${version.base}/"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

This PR upgrades Airflow to 2.10.5.

### How was this patch tested?

Tested against Debian 12, Fedora 40, Rocky 9 and Ubuntu 24.04 on x86_64 as follows:

```
$ ./gradlew airflow-clean airflow-pkg repo -Dbuildwithdeps=true

(snip)

Processing files: airflow-2.10.5-1.fc40.x86_64
Provides: airflow = 2.10.5-1.fc40 airflow(x86-64) = 2.10.5-1.fc40 config(airflow) = 2.10.5-1.fc40

(snip)

BUILD SUCCESSFUL in 1m 37s
9 actionable tasks: 9 executed
$ cd provisioner/docker
$ ./docker-hadoop.sh -d -dcp -C config_fedora-40.yaml -F docker-compose-cgroupv2.yml -G -L -r file:///bigtop-home/output -k bigtop-utils,airflow -s airflow -c 1

(snip)

> Task :bigtop-tests:smoke-tests:airflow:test

(snip)

Now testing...
:bigtop-tests:smoke-tests:airflow:test (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.562 secs.

BUILD SUCCESSFUL in 15s
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/