### PR TITLE
BIGTOP-4432. Fix flaky smoke-test of Hive executing command before HiveServer2 is ready.

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -177,6 +177,7 @@ hadoop_hive::common_config::kerberos_realm: "%{hiera('kerberos::site::realm')}"
 hadoop_hive::common_config::metastore_uris: "thrift://%{hiera('bigtop::hadoop_head_node')}:9083"
 # set this to true in production to avoid potential metastore corruption
 hadoop_hive::common_config::metastore_schema_verification: false
+hadoop_hive::common_config::server2_sleep_interval_between_start_attempts: "1s"
 
 # tez
 hadoop::common::tez_conf_dir: "/etc/tez/conf"

--- a/bigtop-deploy/puppet/modules/hadoop_hive/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/hadoop_hive/manifests/init.pp
@@ -56,6 +56,7 @@ class hadoop_hive {
                        $metastore_schema_verification = true,
                        $server2_thrift_port = "10000",
                        $server2_thrift_http_port = "10001",
+                       $server2_sleep_interval_between_start_attempts = "60s",
                        $hive_execution_engine = "mr") {
     include hadoop_hive::client_package
     if ($kerberos_realm and $kerberos_realm != "") {

--- a/bigtop-deploy/puppet/modules/hadoop_hive/templates/hive-site.xml
+++ b/bigtop-deploy/puppet/modules/hadoop_hive/templates/hive-site.xml
@@ -108,6 +108,11 @@
    <value><%= @server2_thrift_http_port %></value>
 </property>
 
+<property>
+   <name>hive.server2.sleep.interval.between.start.attempts</name>
+   <value><%= @server2_sleep_interval_between_start_attempts %></value>
+</property>
+
 <% if @metastore_uris != "" %>
 <property>
    <name>hive.metastore.uris</name>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4432

smoke-tests of Hive intermittently fails due to "connection refused". Retrying the test succeeded after waiting for HiveServer2 startup.

```
org.apache.bigtop.itest.hive.TestHiveSmoke > test FAILED
    java.lang.AssertionError: Example hive count failed. [] [SLF4J: Class path contains multiple SLF4J bindings., SLF4J: Found binding in [jar:file:/usr/lib/hive/lib/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class], SLF4J: Found binding in [jar:file:/usr/lib/hadoop/lib/slf4j-re\
load4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class], SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation., SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory], SLF4J: Class path contains multiple SLF4J bindings., SLF4J: Found binding in\
 [jar:file:/usr/lib/hive/lib/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class], SLF4J: Found binding in [jar:file:/usr/lib/hadoop/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class], SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanat\
ion., SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory], Connecting to jdbc:hive2://localhost:10000/default, 25/05/22 13:33:41 [main]: WARN jdbc.HiveConnection: Failed to connect to localhost:10000, Could not open connection to the HS2 server. Please check the server UR\
I and if the URI is correct, then ask the administrator to check the server status. Enable verbose error messages (--verbose=true) for more information., Error: Could not open client transport with JDBC Uri: jdbc:hive2://localhost:10000/default: java.net.ConnectException: Connection refused (Connec\
tion refused) (state=08S01,code=0)]
```

[HiveServer2 sleeps 60s if it fails to connect to HDFS on startup](https://github.com/apache/hive/blob/rel/release-4.0.1/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java#L3903-L3905). Starting HiveServer2 after HDFS is ready should mitigate the issue.

```
2025-05-25T11:42:21,331  WARN [main] server.HiveServer2: Error starting HiveServer2 on attempt 1, will retry in 60000ms
java.lang.RuntimeException: Error applying authorization policy on hive configuration: java.net.ConnectException: Call From df7e4a3bc0d2.bigtop.apache.org/172.19.0.2 to df7e4a3bc0d2.bigtop.apache.org:8020 failed on connection exception: java.net.ConnectException: Connection refused; For more detail\
s
 see:  http://wiki.apache.org/hadoop/ConnectionRefused
```

This PR change the sleep interval from 60s to 1s for quick start on smoke-tests.