### PR TITLE
BIGTOP-4472. Fix invalid permission of hadoop-layout.sh.

### DIFF
--- a/bigtop-packages/src/common/hadoop/install_hadoop.sh
+++ b/bigtop-packages/src/common/hadoop/install_hadoop.sh
@@ -259,7 +259,7 @@ chmod 755 $wrapper
 #libexec
 install -d -m 0755 $PREFIX/$HADOOP_DIR/libexec
 cp -r ${BUILD_DIR}/libexec/* $PREFIX/$HADOOP_DIR/libexec/
-cp ${DISTRO_DIR}/hadoop-layout.sh $PREFIX/$HADOOP_DIR/libexec/
+install -m 0755 ${DISTRO_DIR}/hadoop-layout.sh $PREFIX/$HADOOP_DIR/libexec/
 install -m 0755 ${DISTRO_DIR}/init-hdfs.sh $PREFIX/$HADOOP_DIR/libexec/
 install -m 0755 ${DISTRO_DIR}/init-hcfs.json $PREFIX/$HADOOP_DIR/libexec/
 install -m 0755 ${DISTRO_DIR}/init-hcfs.groovy $PREFIX/$HADOOP_DIR/libexec/


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4472

Starting hadoop services failed due to invalid permission (0200) of hadoop-config.sh.

```
Error: Systemd start for hadoop-hdfs-namenode failed!
journalctl log for hadoop-hdfs-namenode:
Jul 19 06:06:33 d2cdaffc4669 systemd[1]: Starting Hadoop NameNode...
Jul 19 06:06:33 d2cdaffc4669 hdfs[9365]: //usr/lib/hadoop/libexec/hadoop-config.sh: line 79: //usr/lib/hadoop/libexec/hadoop-layout.sh: Permission denied
Jul 19 06:06:33 d2cdaffc4669 hdfs[9365]: ERROR: HADOOP_COMMON_HOME or related vars are not configured.
Jul 19 06:06:33 d2cdaffc4669 systemd[1]: hadoop-hdfs-namenode.service: Control process exited, code=exited, status=1/FAILURE
Jul 19 06:06:33 d2cdaffc4669 systemd[1]: hadoop-hdfs-namenode.service: Failed with result 'exit-code'.
Jul 19 06:06:33 d2cdaffc4669 systemd[1]: Failed to start Hadoop NameNode.
```

While the issue is only reproducible on specific envireonment (building aarch64 RPM using Docker Desktop on Mac mini M4 for me), it should be nice to fix for stable build.