### PR TITLE
BIGTOP-4473. Add dependency on initscripts to Spark RPM.

### DIFF
--- a/bigtop-packages/src/rpm/spark/SPECS/spark.spec
+++ b/bigtop-packages/src/rpm/spark/SPECS/spark.spec
@@ -102,6 +102,7 @@ Spark core
 Summary: Server for Spark master
 Group: Development/Libraries
 Requires: %{spark_pkg_name}-core = %{version}-%{release}
+Requires: initscripts
 
 %description -n %{spark_pkg_name}-master
 Server for Spark master
@@ -110,6 +111,7 @@ Server for Spark master
 Summary: Server for Spark worker
 Group: Development/Libraries
 Requires: %{spark_pkg_name}-core = %{version}-%{release}
+Requires: initscripts
 
 %description -n %{spark_pkg_name}-worker
 Server for Spark worker
@@ -128,6 +130,7 @@ Includes PySpark, an interactive Python shell for Spark, and related libraries
 Summary: History server for Apache Spark
 Group: Development/Libraries
 Requires: %{spark_pkg_name}-core = %{version}-%{release}
+Requires: initscripts
 
 %description -n %{spark_pkg_name}-history-server
 History server for Apache Spark
@@ -136,6 +139,7 @@ History server for Apache Spark
 Summary: Thrift server for Spark SQL
 Group: Development/Libraries
 Requires: %{spark_pkg_name}-core = %{version}-%{release}
+Requires: initscripts
 
 %description -n %{spark_pkg_name}-thriftserver
 Thrift server for Spark SQL


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4473

Similar to [BIGTOP-4469](https://issues.apache.org/jira/browse/BIGTOP-4469), services of Spark depends on /etc/init.d/functions provided by initscripts package. Dependency on the initscripts should be added to the RPMs.

```
Error: Systemd start for spark-thriftserver failed!
journalctl log for spark-thriftserver:
Jul 22 14:58:45 ea5db6fa9c10 systemd[1]: /run/systemd/generator.late/spark-thriftserver.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/spark/spark-thriftserver.pid ??? /run/spark/spark-thriftserver.pid; please update the unit file accordingly.
Jul 22 14:58:51 ea5db6fa9c10 systemd[1]: /run/systemd/generator.late/spark-thriftserver.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/spark/spark-thriftserver.pid ??? /run/spark/spark-thriftserver.pid; please update the unit file accordingly.
Jul 22 14:58:51 ea5db6fa9c10 systemd[1]: /run/systemd/generator.late/spark-thriftserver.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/spark/spark-thriftserver.pid ??? /run/spark/spark-thriftserver.pid; please update the unit file accordingly.
Jul 22 15:00:00 ea5db6fa9c10 systemd[1]: /run/systemd/generator.late/spark-thriftserver.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/spark/spark-thriftserver.pid ??? /run/spark/spark-thriftserver.pid; please update the unit file accordingly.
Jul 22 15:00:08 ea5db6fa9c10 systemd[1]: /run/systemd/generator.late/spark-thriftserver.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/spark/spark-thriftserver.pid ??? /run/spark/spark-thriftserver.pid; please update the unit file accordingly.
Jul 22 15:00:09 ea5db6fa9c10 systemd[1]: /run/systemd/generator.late/spark-thriftserver.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/spark/spark-thriftserver.pid ??? /run/spark/spark-thriftserver.pid; please update the unit file accordingly.
Jul 22 15:00:15 ea5db6fa9c10 systemd[1]: /run/systemd/generator.late/spark-thriftserver.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/spark/spark-thriftserver.pid ??? /run/spark/spark-thriftserver.pid; please update the unit file accordingly.
Jul 22 15:00:15 ea5db6fa9c10 systemd[1]: Starting LSB: Spark thriftserver...
Jul 22 15:00:15 ea5db6fa9c10 spark-thriftserver[32943]: /etc/redhat-lsb/lsb_log_message: line 3: /etc/init.d/functions: No such file or directory
Jul 22 15:00:15 ea5db6fa9c10 spark-thriftserver[32943]: Starting Spark thriftserver (spark-thriftserver):
Jul 22 15:00:15 ea5db6fa9c10 spark-thriftserver[32944]: /etc/redhat-lsb/lsb_log_message: line 11: success: command not found
Jul 22 15:00:15 ea5db6fa9c10 spark-thriftserver[32945]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
Jul 22 15:00:15 ea5db6fa9c10 spark-thriftserver[32946]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
Jul 22 15:00:15 ea5db6fa9c10 runuser[32947]: pam_unix(runuser:session): session opened for user spark(uid=990) by (uid=0)
Jul 22 15:00:15 ea5db6fa9c10 runuser[32947]: pam_unix(runuser:session): session closed for user spark
Jul 22 15:00:22 ea5db6fa9c10 spark-thriftserver[33059]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
Jul 22 15:00:22 ea5db6fa9c10 spark-thriftserver[33060]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
Jul 22 15:00:22 ea5db6fa9c10 systemd[1]: spark-thriftserver.service: Control process exited, code=exited, status=127/n/a
Jul 22 15:00:22 ea5db6fa9c10 systemd[1]: spark-thriftserver.service: Failed with result 'exit-code'.
Jul 22 15:00:22 ea5db6fa9c10 systemd[1]: spark-thriftserver.service: Unit process 32949 (java) remains running after unit stopped.
Jul 22 15:00:22 ea5db6fa9c10 systemd[1]: Failed to start LSB: Spark thriftserver.
Jul 22 15:00:22 ea5db6fa9c10 systemd[1]: spark-thriftserver.service: Consumed 8.802s CPU time.
```

following services need to be addressed.

* [spark-history-server](https://github.com/apache/bigtop/blob/cdd7bd88050bc340399853e1e7183357b7f6a08a/bigtop-packages/src/common/spark/spark-history-server.svc)
* [spark-master](https://github.com/apache/bigtop/blob/cdd7bd88050bc340399853e1e7183357b7f6a08a/bigtop-packages/src/common/spark/spark-master.svc)
* [spark-thriftserver](https://github.com/apache/bigtop/blob/cdd7bd88050bc340399853e1e7183357b7f6a08a/bigtop-packages/src/common/spark/spark-thriftserver.svc)
* [spark-worker](https://github.com/apache/bigtop/blob/cdd7bd88050bc340399853e1e7183357b7f6a08a/bigtop-packages/src/common/spark/spark-worker.svc)
