### PR TITLE
BIGTOP-4474. Add dependency on initscripts to Kafka RPM.

### DIFF
--- a/bigtop-packages/src/rpm/kafka/SPECS/kafka.spec
+++ b/bigtop-packages/src/rpm/kafka/SPECS/kafka.spec
@@ -92,6 +92,7 @@ larger than the capability of any single machine and to allow clusters of co-ord
 Summary: Server for kafka
 Group: System/Daemons
 Requires: %{name} = %{version}-%{release}
+Requires: initscripts
 
 # CentOS 5 does not have any dist macro
 # So I will suppose anything that is not Mageia or a SUSE will be a RHEL/CentOS/Fedora


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4474

Services of Kafka depends on /etc/init.d/functions provided by initscripts package. Dependency on the initscripts should be added to the RPMs.

```
Error: /Stage[main]/Kafka::Server/Service[kafka-server]/ensure: change from 'stopped' to 'running' failed: Systemd start for kafka-server failed!
journalctl log for kafka-server:
Jul 23 10:43:58 1aa6041f1bf0 systemd[1]: /run/systemd/generator.late/kafka-server.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/kafka/kafka-server.pid ??? /run/kafka/kafka-server.pid; please update the unit file accordingly.
Jul 23 10:43:59 1aa6041f1bf0 systemd[1]: /run/systemd/generator.late/kafka-server.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/kafka/kafka-server.pid ??? /run/kafka/kafka-server.pid; please update the unit file accordingly.
Jul 23 10:43:59 1aa6041f1bf0 systemd[1]: Starting LSB: Kafka Server...
Jul 23 10:43:59 1aa6041f1bf0 kafka-server[3942]: /etc/redhat-lsb/lsb_log_message: line 3: /etc/init.d/functions: No such file or directory
Jul 23 10:43:59 1aa6041f1bf0 kafka-server[3942]: Starting Kafka Server (kafka-server):
Jul 23 10:43:59 1aa6041f1bf0 kafka-server[3946]: /etc/redhat-lsb/lsb_log_message: line 11: success: command not found
Jul 23 10:43:59 1aa6041f1bf0 kafka-server[3948]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
Jul 23 10:43:59 1aa6041f1bf0 kafka-server[3952]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
Jul 23 10:43:59 1aa6041f1bf0 kafka-server[3770]: Starting  (kafka-server):
Jul 23 10:43:59 1aa6041f1bf0 runuser[3959]: pam_unix(runuser:session): session opened for user kafka(uid=993) by (uid=0)
Jul 23 10:43:59 1aa6041f1bf0 runuser[3959]: pam_unix(runuser:session): session closed for user kafka
Jul 23 10:44:02 1aa6041f1bf0 kafka-server[10616]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
Jul 23 10:44:02 1aa6041f1bf0 kafka-server[10617]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
Jul 23 10:44:02 1aa6041f1bf0 kafka-server[10618]: /etc/redhat-lsb/lsb_log_message: line 3: /etc/init.d/functions: No such file or directory
Jul 23 10:44:02 1aa6041f1bf0 kafka-server[10618]: Failure to start Kafka Server (kafka-server). Return value: 127
Jul 23 10:44:02 1aa6041f1bf0 kafka-server[10619]: /etc/redhat-lsb/lsb_log_message: line 16: failure: command not found
Jul 23 10:44:02 1aa6041f1bf0 systemd[1]: kafka-server.service: Control process exited, code=exited, status=127/n/a
Jul 23 10:44:02 1aa6041f1bf0 systemd[1]: kafka-server.service: Failed with result 'exit-code'.
Jul 23 10:44:02 1aa6041f1bf0 systemd[1]: kafka-server.service: Unit process 3976 (java) remains running after unit stopped.
Jul 23 10:44:02 1aa6041f1bf0 systemd[1]: Failed to start LSB: Kafka Server.
```