### PR TITLE
BIGTOP-4475. Add dependency on initscripts to Livy RPM.

### DIFF
--- a/bigtop-packages/src/rpm/livy/SPECS/livy.spec
+++ b/bigtop-packages/src/rpm/livy/SPECS/livy.spec
@@ -39,6 +39,7 @@ Source4: bigtop.bom
 Source6: init.d.tmpl
 Requires: bigtop-utils >= 0.7
 Requires(preun): /sbin/service
+Requires: initscripts
 #BIGTOP_PATCH_FILES
 
 %if  %{?suse_version:1}0


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4475

livy-server depends on /etc/init.d/functions provided by initscripts package. Dependency on the initscripts should be added to the RPMs.

```
Error: /Stage[main]/Livy::Server/Service[livy-server]/ensure: change from 'stopped' to 'running' failed: Systemd start for livy-server failed!
journalctl log for livy-server:
Jul 23 12:40:16 de29e4022884 systemd[1]: /run/systemd/generator.late/livy-server.service:20: PIDFile= references a path below legacy directory /var/run/, updating /var/run/livy/livy-livy-server.pid ??? /run/livy/livy-livy-server.pid; please update the unit file accordingly.
Jul 23 12:40:16 de29e4022884 systemd[1]: Starting LSB: Livy Server...
Jul 23 12:40:16 de29e4022884 runuser[8338]: pam_unix(runuser:session): session opened for user livy(uid=990) by (uid=0)
Jul 23 12:40:16 de29e4022884 livy-server[8339]: starting /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.462.b08-3.el9.aarch64/bin/java  -cp /usr/lib/livy/jars/*:/usr/lib/livy/conf:/etc/hadoop/conf: org.apache.livy.server.LivyServer, logging to /var/log/livy/livy-livy-server.out
Jul 23 12:40:18 de29e4022884 runuser[8338]: pam_unix(runuser:session): session closed for user livy
Jul 23 12:40:23 de29e4022884 livy-server[8449]: /etc/redhat-lsb/lsb_pidofproc: line 3: /etc/init.d/functions: No such file or directory
Jul 23 12:40:23 de29e4022884 livy-server[8450]: /etc/redhat-lsb/lsb_pidofproc: line 5: pidofproc: command not found
Jul 23 12:40:23 de29e4022884 livy-server[8451]: /etc/redhat-lsb/lsb_log_message: line 3: /etc/init.d/functions: No such file or directory
Jul 23 12:40:23 de29e4022884 livy-server[8451]: Failed to start Livy Server. Return value: 127
Jul 23 12:40:23 de29e4022884 livy-server[8452]: /etc/redhat-lsb/lsb_log_message: line 16: failure: command not found
Jul 23 12:40:23 de29e4022884 systemd[1]: livy-server.service: Control process exited, code=exited, status=127/n/a
Jul 23 12:40:23 de29e4022884 systemd[1]: livy-server.service: Failed with result 'exit-code'.
Jul 23 12:40:23 de29e4022884 systemd[1]: livy-server.service: Unit process 8342 (java) remains running after unit stopped.
Jul 23 12:40:23 de29e4022884 systemd[1]: Failed to start LSB: Livy Server.
Jul 23 12:40:23 de29e4022884 systemd[1]: livy-server.service: Consumed 2.381s CPU time.
```