### PR TITLE
BIGTOP-4476. Fix invalid permission of conf files of ZooKeeper and Zeppelin.

### DIFF
--- a/bigtop-packages/src/common/zeppelin/install_zeppelin.sh
+++ b/bigtop-packages/src/common/zeppelin/install_zeppelin.sh
@@ -132,5 +132,5 @@ rm -f $PREFIX/$LIB_DIR/bin/*.cmd
 chmod 755 $PREFIX/$LIB_DIR/bin/*
 
 rm -f $PREFIX/$CONF_DIST_DIR/*.cmd.*
-cp -a ${SOURCE_DIR}/zeppelin-env.sh $PREFIX/$CONF_DIST_DIR
+install -m 0755 ${SOURCE_DIR}/zeppelin-env.sh $PREFIX/$CONF_DIST_DIR
 ln -s $CONF_DIR $PREFIX/$LIB_DIR/conf

--- a/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
+++ b/bigtop-packages/src/common/zookeeper/install_zookeeper.sh
@@ -151,7 +151,7 @@ cp $BUILD_DIR/lib/*.jar $PREFIX/$LIB_DIR/lib
 # Copy in the configuration files
 install -d -m 0755 $PREFIX/etc/zookeeper
 install -d -m 0755 $PREFIX/$CONF_DIST_DIR
-cp zoo.cfg $BUILD_DIR/conf/* $PREFIX/$CONF_DIST_DIR/
+install -m 0644 zoo.cfg $BUILD_DIR/conf/* $PREFIX/$CONF_DIST_DIR/
 ln -s $CONF_DIR $PREFIX/$LIB_DIR/conf
 
 # Copy in the /usr/bin/zookeeper-server wrapper


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4476

I got permission issue similar to BIGTOP-4472 on deploying zookeeper and packaging zeppelin. While the issue is only reproducible on specific envireonment (building aarch64 RPM using Docker Desktop on Mac mini M4 for me), it should be nice to fix for stable build.

```
Notice: /Stage[main]/Hadoop_zookeeper::Server/Exec[zookeeper-server-initialize]/returns: grep: /etc/zookeeper/conf/zoo.cfg: Permission denied
Notice: /Stage[main]/Hadoop_zookeeper::Server/Exec[zookeeper-server-initialize]/returns: grep: /etc/zookeeper/conf/zoo.cfg: Permission denied
Notice: /Stage[main]/Hadoop_zookeeper::Server/Exec[zookeeper-server-initialize]/returns: Unable to determine dataDir from /etc/zookeeper/conf/zoo.cfg
Error: '/usr/bin/zookeeper-server-initialize' returned 1 instead of one of [0]
Error: /Stage[main]/Hadoop_zookeeper::Server/Exec[zookeeper-server-initialize]/returns: change from 'notrun' to ['0'] failed: '/usr/bin/zookeeper-server-initialize' returned 1 instead of one of [0]
Notice: /Stage[main]/Hadoop_zookeeper::Server/Service[zookeeper-server]: Dependency Exec[zookeeper-server-initialize] has failures: true
```

```
{noformat}
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.mkynXL
+ umask 022
+ cd /bigtop-home/build/zeppelin/rpm//BUILD
+ '[' /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64 '!=' / ']'
+ rm -rf /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64
++ dirname /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64
+ mkdir -p /bigtop-home/build/zeppelin/rpm/BUILDROOT
+ mkdir /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64
+ cd zeppelin-0.11.2
+ /usr/bin/rm -rf /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64
+ /usr/bin/install -d -m 0755 /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64//etc/rc.d/init.d/
++ pwd
+ bash /bigtop-home/build/zeppelin/rpm//SOURCES/install_zeppelin.sh --build-dir=/bigtop-home/build/zeppelin/rpm/BUILD/zeppelin-0.11.2 --source-dir=/bigtop-home/build/zeppelin/rpm//SOURCES --prefix=/bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64 --doc-dir=//usr/share/doc/zepp\
elin-0.11.2 --lib-dir=/usr/lib/zeppelin --var-dir=/var/lib/zeppelin --man-dir=//usr/share/man --conf-dist-dir=/etc/zeppelin/conf.dist
+ initd_script=/bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64//etc/rc.d/init.d/zeppelin
+ bash /bigtop-home/build/zeppelin/rpm/SOURCES/init.d.tmpl /bigtop-home/build/zeppelin/rpm//SOURCES/zeppelin.svc rpm /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64//etc/rc.d/init.d/zeppelin
+ /usr/lib/rpm/check-buildroot
grep: /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64/etc/zeppelin/conf.dist/zeppelin-env.sh: Permission denied
Processing files: zeppelin-0.11.2-1.el9.aarch64
error: Can't read content of file: /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64/etc/zeppelin/conf.dist/zeppelin-env.sh
error: Can't read content of file: /bigtop-home/build/zeppelin/rpm/BUILDROOT/zeppelin-0.11.2-1.el9.aarch64/etc/zeppelin/conf.dist/zeppelin-env.sh
```
