### PR TITLE
BIGTOP-4484. Upgrade Ranger to 2.7.0.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -339,7 +339,7 @@ bigtop {
       name    = 'ranger'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Ranger'
-      version { base = '2.6.0'; pkg = base; release = 1 }
+      version { base = '2.7.0'; pkg = base; release = 1 }
       tarball { destination = "release-$name-${version.base}.tar.gz"
                 source      = destination }
       url     { site = "https://github.com/apache/ranger/archive/refs/tags"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4484

Ranger 2.7.0 was released and it looks compatible with current versions of Bigtop stack.
https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.7.0+-+Release+Notes