### PR TITLE
BIGTOP-4494. Fix compilation error of TestPing.groovy of test-artifacts

### DIFF
--- a/bigtop-tests/smoke-tests/build.gradle
+++ b/bigtop-tests/smoke-tests/build.gradle
@@ -30,7 +30,7 @@ subprojects {
   ext.groovyVersion = '2.5.4'
   ext.hadoopVersion = '2.7.4'
   ext.hbaseVersion = '1.1.9'
-  ext.solrVersion = '4.6.0'
+  ext.solrVersion = '8.11.4'
   ext.slf4jVersion = '1.6.6'
   // itest needs be greater than or equal to = 1.0.0
   ext.itestVersion = '1.0.0' // Might need to be able to read an input for alternate version?

--- a/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestIndexingSolrJ.groovy
+++ b/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestIndexingSolrJ.groovy
@@ -20,7 +20,7 @@ package org.apache.bigtop.itest.solr.smoke
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.SolrRequest
 import org.apache.solr.client.solrj.SolrServerException
-import org.apache.solr.client.solrj.impl.HttpSolrServer
+import org.apache.solr.client.solrj.impl.HttpSolrClient
 import org.apache.solr.client.solrj.response.QueryResponse
 import org.apache.solr.common.SolrDocument
 import org.apache.solr.common.SolrDocumentList
@@ -41,18 +41,18 @@ import org.junit.Assert
  */
 class TestIndexingSolrJ extends SolrTestBase {
 
-  HttpSolrServer _server
+  HttpSolrClient _client
 
   @Before
   public void before2() {
-    _server = new HttpSolrServer(_baseURL)
+    _client = new HttpSolrClient.Builder(_baseURL).build()
   }
 
   @After
   public void after2() {
-    if (_server != null) {
-      _server.shutdown()
-      _server = null
+    if (_client != null) {
+      _client.close()
+      _client = null
     }
   }
 
@@ -68,8 +68,8 @@ class TestIndexingSolrJ extends SolrTestBase {
     doc.addField("id", "two")
     doc.addField("name", "Another document two")
     docs.add(doc)
-    _server.add(docs)
-    _server.commit()
+    _client.add(docs)
+    _client.commit()
 
     doQuery("*:*", "one", "two")
     // Now see if we can search them.
@@ -81,7 +81,7 @@ class TestIndexingSolrJ extends SolrTestBase {
     SolrQuery query = new SolrQuery()
     query.setQuery(queryString)
     query.setRows(1000)
-    QueryResponse qr = _server.query(query, SolrRequest.METHOD.POST)
+    QueryResponse qr = _client.query(query, SolrRequest.METHOD.POST)
     Object o = qr.getHeader().get("status")
     Assert.assertEquals(0, qr.getHeader().get("status"))
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <hadoop.version>2.7.3</hadoop.version>
     <hbase.version>1.1.9</hbase.version>
     <zookeeper.version>3.4.6</zookeeper.version>
-    <solr.version>4.10.4</solr.version>
+    <solr.version>8.11.4</solr.version>
     <spark.version>2.1.0</spark.version>
     <kafka.version>0.10.1.1</kafka.version>
     <phoenix.version>4.9.0-HBase-1.1</phoenix.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4494

found on [building release artifacts](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27849974#Howtorelease-6.BuildandDeployArtifacts) of Bigtop 3.5.0.

```
$ mvn clean install -DskipTests
$ mvn clean install -DskipTests -f bigtop-test-framework/pom.xml
$ mvn clean install -DskipTests -f bigtop-tests/test-artifacts/pom.xml
$ ...
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /home/iwasakims/srcs/bigtop-3.5/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestPing.groovy:[1,1] 1. ERROR in /home/iwasakims/srcs/bigtop-3.5/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestPing.groovy (at line \
1)
        /*
        ^
The type org.apache.http.client.HttpClient cannot be resolved. It is indirectly referenced from required .class files

[ERROR] /home/iwasakims/srcs/bigtop-3.5/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestPing.groovy:[1,1] 2. ERROR in /home/iwasakims/srcs/bigtop-3.5/bigtop-tests/test-artifacts/solr/src/main/groovy/org/apache/bigtop/itest/solr/smoke/TestPing.groovy (at line \
1)
        /*
        ^
The type org.apache.http.client.methods.HttpRequestBase cannot be resolved. It is indirectly referenced from required .class files

[ERROR] Found 2 errors and 0 warnings.
```

The test artifact assumes quite [old version of solr-solrj](https://github.com/apache/bigtop/blob/branch-3.5/pom.xml#L45).

```
$ mvn dependency:tree
...
[INFO] org.apache.bigtop.itest:solr-smoke:jar:3.5.0
[INFO] +- org.apache.solr:solr-solrj:jar:4.10.4:compile
[INFO] +- org.slf4j:slf4j-simple:jar:1.6.6:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.6.6:compile
[INFO] +- org.apache.bigtop.itest:itest-common:jar:3.5.0:compile
[INFO] |  +- org.codehaus.groovy:groovy-ant:jar:2.5.4:compile
[INFO] |  |  +- org.codehaus.groovy:groovy-groovydoc:jar:2.5.4:compile
[INFO] |  |  +- org.apache.ant:ant-launcher:jar:1.8.2:compile
[INFO] |  |  \- org.apache.ant:ant-antlr:jar:1.9.13:runtime
[INFO] |  +- junit:junit:jar:4.11:compile
[INFO] |  |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.1:compile
[INFO] |  |  +- log4j:log4j:jar:1.2.14:compile
[INFO] |  |  +- logkit:logkit:jar:1.0.1:compile
[INFO] |  |  +- avalon-framework:avalon-framework:jar:4.1.3:compile
[INFO] |  |  \- javax.servlet:servlet-api:jar:2.3:compile
[INFO] |  +- org.apache.ant:ant:jar:1.8.2:compile
[INFO] |  \- org.apache.ant:ant-junit:jar:1.8.2:compile
[INFO] +- org.codehaus.groovy:groovy-json:jar:2.5.4:compile
[INFO] |  \- org.codehaus.groovy:groovy:jar:2.5.4:compile
[INFO] \- org.codehaus.groovy:groovy-xml:jar:2.5.4:compile
```

While I don't understand the exact mechanism of the issue, upgrading the solr-solrj fixed the issue.
