### PR TITLE
BIGTOP-4516. Upgrade Tez to 0.10.5.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -193,7 +193,7 @@ bigtop {
       name    = 'tez'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache TEZ'
-      version { base = '0.10.4'; pkg = base; release = 1 }
+      version { base = '0.10.5'; pkg = base; release = 1 }
       tarball { destination = "apache-${name}-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4516

smoke-tests of tez passed on Ubuntu 24.04 x86_64 and Rocky Linux 9 aarch64.