### PR TITLE
BIGTOP-4519. Upgrade Groovy to 3.0.25

### DIFF
--- a/bigtop-tests/smoke-tests/build.gradle
+++ b/bigtop-tests/smoke-tests/build.gradle
@@ -27,7 +27,7 @@ subprojects {
     }
   }
 
-  ext.groovyVersion = '2.5.4'
+  ext.groovyVersion = '3.0.25'
   ext.hadoopVersion = '2.7.4'
   ext.hbaseVersion = '1.1.9'
   ext.solrVersion = '8.11.4'

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -258,7 +258,7 @@ bigtop {
     'bigtop-groovy' {
       name    = 'bigtop-groovy'
       relNotes = "Groovy: a dynamic language for the Java platform"
-      version { base = '2.5.4'; pkg = '2.5.4'; release = 1 }
+      version { base = '3.0.25'; pkg = '3.0.25'; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz";
                 source      = "apache-groovy-binary-${version.base}.zip" }
       url     { download_path = "/groovy/${version.base}/distribution/"

--- a/bigtop_toolchain/manifests/groovy.pp
+++ b/bigtop_toolchain/manifests/groovy.pp
@@ -17,11 +17,11 @@ class bigtop_toolchain::groovy {
 
   require bigtop_toolchain::packages
 
-  $groovy_version = '2.5.4'
+  $groovy_version = '3.0.25'
   $groovy = "apache-groovy-binary-${groovy_version}"
 
   exec { 'Download Groovy':
-    command => "/usr/bin/wget https://dl.bintray.com/groovy/maven/${groovy}.zip",
+    command => "/usr/bin/wget https://archive.apache.org/dist/groovy/${groovy_version}/distribution/${groovy}.zip",
     cwd     => "/usr/src",
     unless  => "/usr/bin/test -f /usr/src/${groovy}.zip",
   } ~>

--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ project(':itest-common') {
   description = """iTest: system and integration testing in the cloud"""
 
   dependencies {
-    compile group: 'org.codehaus.groovy', name: 'groovy-all', version:'2.5.4'
+    compile group: 'org.codehaus.groovy', name: 'groovy-all', version:'3.0.25'
     compile group: 'junit', name: 'junit', version:'4.11'
     compile group: 'commons-logging', name: 'commons-logging', version:'1.1'
     compile group: 'org.apache.ant', name: 'ant', version:'1.8.2'

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <itest-common.version>${project.version}</itest-common.version>
 
-    <groovy.version>2.5.4</groovy.version>
+    <groovy.version>3.0.25</groovy.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>2.12</maven-failsafe-plugin.version>
     <groovy-eclipse-compiler.version>2.9.2-01</groovy-eclipse-compiler.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4519

We need to upgrade Groovy to address JDK upgrade in the stack. Since Hadoop still requires JDK 8 for release build, Groovy 3.0.25 can be good candidate since it supports all of Java 8, 11 and 17. Since Hadoop 3.4 required JDK 8 for release build, we can not drop the OpenJDK 8 now.

following commands used for release succeeded with the patch.

```
$ mvn clean install
$ mvn clean install -f bigtop-test-framework/pom.xml
$ mvn clean install -f bigtop-tests/test-artifacts/pom.xml
$ HADOOP_CONF_DIR=/etc/hadoop/conf HADOOP_HOME=/usr/lib/hadoop mvn clean install -DskipITs -f bigtop-tests/test-execution/pom.xml
```

smoke-tets of hdfs, yarn and mapreduce passed with the upgraded bigtop-groovy package on Ubuntu 24.04 x86_64.
