### PR TITLE
BIGTOP-4522. Fix installation failure of Puppet on openEuler 22.03

### DIFF
--- a/bigtop_toolchain/bin/puppetize.sh
+++ b/bigtop_toolchain/bin/puppetize.sh
@@ -71,7 +71,7 @@ case ${ID}-${VERSION_ID} in
         dnf config-manager --set-enabled codeready-builder-for-rhel-8-rhui-rpms
         ;;
     openEuler-*)
-        dnf -y install hostname curl sudo unzip wget ruby ruby-devel vim systemd-devel findutils 'dnf-command(config-manager)' nc initscripts openeuler-lsb openssl-devel make gcc-c++ openEuler-rpm-config python3-pip python3-devel dbus
+        dnf -y install hostname curl sudo unzip wget ruby ruby-devel vim systemd-devel findutils 'dnf-command(config-manager)' nc initscripts openeuler-lsb openssl-devel make gcc-c++ openEuler-rpm-config python3-pip python3-devel dbus libffi-devel
         # openEuler ruby version is 3.X,so use puppet-7.22.0.
         gem install puppet:7.22.0 xmlrpc sync sys-filesystem
         puppet module install puppetlabs-stdlib --version 4.12.0


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4522

`puppetize.sh` failed due to missing a required header file provided libffi-devel package on building docker image of openeuler-22.03.

```
#8 1631.6 ERROR:  Error installing puppet:
#8 1631.6   ERROR: Failed to build gem native extension.
#8 1631.6
#8 1631.6     current directory: /usr/local/share/gems/gems/fiddle-1.1.8/ext/fiddle
#8 1631.6 /usr/bin/ruby -I /usr/share/rubygems -r ./siteconf20260416-314-216qn1.rb extconf.rb
#8 1631.6 checking for --enable-debug-build option... no
#8 1631.6 checking for ffi.h... no
#8 1631.6 checking for ffi/ffi.h... no
#8 1631.6 *** extconf.rb failed ***
#8 1631.6 Could not create Makefile due to some reason, probably lack of necessary
#8 1631.6 libraries and/or headers.  Check the mkmf.log file for more details.  You may
#8 1631.6 need configuration options.
#8 1631.6
#8 1631.6 Provided configuration options:
#8 1631.6   --with-opt-dir
#8 1631.6   --without-opt-dir
#8 1631.6   --with-opt-include
#8 1631.6   --without-opt-include=${opt-dir}/include
#8 1631.6   --with-opt-lib
#8 1631.6   --without-opt-lib=${opt-dir}/lib64
#8 1631.6   --with-make-prog
#8 1631.6   --without-make-prog
#8 1631.6   --srcdir=.
#8 1631.6   --curdir
#8 1631.6   --ruby=/usr/bin/$(RUBY_BASE_NAME)
#8 1631.6   --enable-debug-build
#8 1631.6   --disable-debug-build
#8 1631.6   --with-libffi-source-dir
#8 1631.6   --without-libffi-source-dir
#8 1631.6   --with-libffi-dir
#8 1631.6   --without-libffi-dir
#8 1631.6   --with-libffi-include
#8 1631.6   --without-libffi-include=${libffi-dir}/include
#8 1631.6   --with-libffi-lib
#8 1631.6   --without-libffi-lib=${libffi-dir}/lib64
#8 1631.6   --with-libffi-config
#8 1631.6   --without-libffi-config
#8 1631.6   --with-pkg-config
#8 1631.6   --without-pkg-config
#8 1631.6   --with-ffi-dir
#8 1631.6   --without-ffi-dir
#8 1631.6   --with-ffi-include
#8 1631.6   --without-ffi-include=${ffi-dir}/include
#8 1631.6   --with-ffi-lib
#8 1631.6   --without-ffi-lib=${ffi-dir}/lib64
#8 1631.6 extconf.rb:86:in `<main>': missing libffi. Please install libffi or use --with-libffi-source-dir with libffi source location. (RuntimeError)
#8 1631.6
#8 1631.6 To see why this extension failed to compile, please check the mkmf.log which can be found here:
#8 1631.6
#8 1631.6   /usr/local/lib64/gems/ruby/fiddle-1.1.8/mkmf.log
#8 1631.6
#8 1631.6 extconf failed, exit code 1

```