### PR TITLE
BIGTOP-4523. Make container tagging consistent between Linux and Mac OS on ARM

### DIFF
--- a/docker/bigtop-puppet/build.sh
+++ b/docker/bigtop-puppet/build.sh
@@ -31,11 +31,10 @@ PREFIX=$(echo "$1" | cut -d '-' -f 1)
 OS=$(echo "$1" | cut -d '-' -f 2)
 VERSION=$(echo "$1" | cut -d '-' -f 3-)
 ARCH=$(uname -m)
-if [ "${ARCH}" != "x86_64" ];then
-ARCH="-${ARCH}"
-else
-ARCH=""
-fi
+case "$ARCH" in
+    aarch64|arm64)   ARCH="aarch64" ;;
+    *)               ARCH="$ARCH" ;;
+esac
 
 ENV_PATH=""
 if [ ${OS} = "centos" -a ${VERSION} -ge 8 ]; then
@@ -67,5 +66,8 @@ case "${OS}-${VERSION}" in
     ;;
 esac
 
-docker build --no-cache -t bigtop/puppet:${PREFIX}-${OS}-${VERSION}${ARCH} .
+if [ "${ARCH}" != "x86_64" ];then
+  VERSION="${VERSION}-${ARCH}"
+fi
+docker build --no-cache -t bigtop/puppet:${PREFIX}-${OS}-${VERSION} .
 rm -f Dockerfile puppetize.sh

--- a/docker/bigtop-slaves/build.sh
+++ b/docker/bigtop-slaves/build.sh
@@ -31,6 +31,10 @@ PREFIX=$(echo "$1" | cut -d '-' -f 1)
 OS=$(echo "$1" | cut -d '-' -f 2)
 VERSION=$(echo "$1" | cut -d '-' -f 3-)
 ARCH=$(uname -m)
+case "$ARCH" in
+    aarch64|arm64)   ARCH="aarch64" ;;
+    *)               ARCH="$ARCH" ;;
+esac
 
 ## Workaround for docker defect on linaros cloud
 if [ "${ARCH}" = "aarch64" ];then


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4523

On ARM, uname -m returns arm64 on Mac while we are assuming aarch64 which is the value on Linux distributions. We should get consistent container image name even if it is built on Mac OS.