### PR TITLE
BIGTOP-4524. Add libuv1-dev to the toolchain for Debian 12.

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -288,7 +288,8 @@ class bigtop_toolchain::packages {
         "flex",
         "libffi-dev",
         "nasm",
-        "yasm"
+        "yasm",
+        "libuv1-dev"
       ]
       if ($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemmajrelease, '24.04') >= 0) {
         $pkgs = concat($_pkgs, ["libtirpc-dev"])


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Currently, [`./gradlew toolchain` fails on Debian 12 due to the lack of libuv1-dev](https://ci.bigtop.apache.org/view/Docker/job/Docker-Toolchain-3.6.0/DISTRO=debian-12,PLATFORM=amd64-slave/1/console). This PR fixes it.

### How was this patch tested?

Ran on Debian 12 (x86_64).

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/