### PR TITLE
BIGTOP-4525. Upgrade Ranger to 2.8.0.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -339,7 +339,7 @@ bigtop {
       name    = 'ranger'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Ranger'
-      version { base = '2.7.0'; pkg = base; release = 1 }
+      version { base = '2.8.0'; pkg = base; release = 1 }
       tarball { destination = "release-$name-${version.base}.tar.gz"
                 source      = destination }
       url     { site = "https://github.com/apache/ranger/archive/refs/tags"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4525

We need to upgrade Ranger to 2.8.0 for compatibility with Hadoop 3.4.

smoke-tests of ranger passed on ubuntu-24.04 x86_64.