### PR TITLE
BIGTOP-4527. Upgrade Phoenix to 5.3.0.

### DIFF
--- a/bigtop-packages/src/common/phoenix/patch1-PHOENIX-7741.diff
+++ b/bigtop-packages/src/common/phoenix/patch1-PHOENIX-7741.diff
@@ -1,0 +1,31 @@
+commit 3de9b9eb2e4be9e2763bb2932e45d025c90f0c20
+Author: Umesh <9414umeshkumar@gmail.com>
+Date:   Wed Dec 10 08:55:51 2025 +0530
+
+    PHOENIX-7741 Remove usage of isRegionInTransition method from phoenix tests (#2330)
+    
+    ---------
+    
+    Co-authored-by: ukumawat <ukumawat@salesforce.com>
+    (cherry picked from commit fd6a76e66f04718d9ec4aaa142ca43ebf6c8cad8)
+
+diff --git a/phoenix-core/src/it/java/org/apache/phoenix/rpc/PhoenixServerRpcIT.java b/phoenix-core/src/it/java/org/apache/phoenix/rpc/PhoenixServerRpcIT.java
+index 2c1752ba02..3dc8238855 100644
+--- a/phoenix-core/src/it/java/org/apache/phoenix/rpc/PhoenixServerRpcIT.java
++++ b/phoenix-core/src/it/java/org/apache/phoenix/rpc/PhoenixServerRpcIT.java
+@@ -243,11 +243,14 @@ public class PhoenixServerRpcIT extends BaseTest {
+       }
+       byte[] encodedRegionNameInBytes = hri2.getEncodedNameAsBytes();
+       admin.move(encodedRegionNameInBytes, dstServer.getServerName());
++      // verify that both HMaster and Region server are aware of this movement
+       while (
+         dstServer.getOnlineRegion(hri2.getRegionName()) == null
+           || dstServer.getRegionsInTransitionInRS().containsKey(encodedRegionNameInBytes)
+           || srcServer.getRegionsInTransitionInRS().containsKey(encodedRegionNameInBytes)
+-          || master.getAssignmentManager().getRegionStates().isRegionInTransition(hri2)
++          || !ServerName.isSameAddress(
++            master.getAssignmentManager().getRegionStates().getRegionServerOfRegion(hri2),
++            dstServer.getServerName())
+       ) {
+         // wait for the move to be finished
+         Thread.sleep(1);

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -247,7 +247,7 @@ bigtop {
     'phoenix' {
       name    = 'phoenix'
       relNotes = 'Apache Phoenix: A SQL skin over HBase'
-      version { base = "5.2.1"; pkg = base; release = 1 }
+      version { base = "5.3.0"; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4527

We should upgrade phoenix to 5.3.0 for better compatibility with HBase 2.6 ([BIGTOP-4515](https://issues.apache.org/jira/browse/BIGTOP-4515)).

We need [PHOENIX-7741](https://issues.apache.org/jira/browse/PHOENIX-7741) to fix compilation error against HBase 2.6.5.