### PR TITLE
BIGTOP-4528. Restore conf-select removed by BIGTOP-4063

### DIFF
--- a/bigtop-packages/src/common/bigtop-select/conf-select
+++ b/bigtop-packages/src/common/bigtop-select/conf-select
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import optparse
+import copy
+import os
+import re
+import sys
+import errno
+from params import stack_root
+
+# The global prefix and current directory
+root = stack_root
+current = root + "/current"
+vconfroot = 'etc'
+lib_root = "usr/lib"
+vconf_name = "conf.dist"
+packages = ("hadoop", "hbase", "hive", "hive-hcatalog",
+            "kafka", "spark", "tez", "livy",
+            "zookeeper", "zeppelin", "flink", "solr", "ranger-admin", "ranger-usersync", "ranger-tagsync")
+''' conf link
+/usr/bigtop/3.2.0/usr/lib/${pname}/conf -> /etc/${pname}/conf -> /etc/alternatives/${pname}-conf -> /usr/bigtop/3.2.0/etc/${pname}/conf.dist.0
+'''
+
+
+def printHelp():
+    print("""
+usage: conf-select [-h] [<command>] --package --stack-version --conf-version
+arguments:
+  <command>          One of create-conf-dir, set-conf-dir
+  <--package>        package name to set
+  <--stack-version>  stack version number
+  <--conf-version>   conf version to set
+optional arguments:
+  -h, --help  show this help message and exit
+Commands:
+  set-conf-dir      : set the conf to a specified version
+  create-conf-dir   : create the specified conf directory
+  dry-run-set       : dry run for set conf
+  dry-run-create    : dry run for create conf
+""")
+
+
+def chkPkg(sver, pname):
+    '''
+    checks package name against the package tuple, check if the package directory exists and returns True
+    e.g. /usr/bigtop/3.2.0/usr/lib/zookeeper
+    '''
+    pkgdir = os.path.join(root, sver, lib_root, pname)
+    if not os.path.isdir(pkgdir) or pname not in packages:
+        print(pname + " not installed or incorrect package name")
+        sys.exit(1)
+    return True
+
+
+def chksVer(sver):
+    '''
+    returns True if the stack version number exists
+    e.g. /usr/bigtop/3.2.0/usr/lib
+    '''
+    if not os.path.isdir(os.path.join(root, sver, lib_root)):
+        print(sver + " Incorrect stack version")
+        sys.exit(1)
+    return True
+
+
+def chkPath(pname, sver, cver, method):
+    '''
+    e.g. /usr/bigtop/3.2.0/etc/zookeeper/conf.dist.0
+    '''
+    confpath = os.path.join(root, sver, vconfroot, pname, vconf_name)
+    if cver:
+        confpath = os.path.join(root, sver, vconfroot, pname, vconf_name + '.' + cver)
+    if method == "create" and os.path.exists(confpath):
+        print(confpath+" exist already")
+        sys.exit(1)
+    if method == "set" and not os.path.exists(confpath):
+        print(confpath+" does not exist")
+        sys.exit(1)
+    return True
+
+
+def check(sver, pname, cver, method):
+    '''
+    Aggregates chksVer, chkPkg and checks if path exits.
+    Returns True if all the conditions are met
+    '''
+    chksVer(sver)
+    chkPkg(sver, pname)
+    chkPath(pname, sver, cver, method)
+
+
+def drcrtConfDir(pname, sver, cver):
+    '''
+    # Not really executing
+    # e.g. /usr/bigtop/3.2.0/etc/zookeeper/conf.dist.0
+    '''
+    chksVer(sver)
+    chkPkg(sver, pname)
+    for confmapkey, confmapval in confmap.items():
+        path = os.path.join(root, sver, vconfroot, confmapkey, vconf_name)
+        if cver:
+            path = os.path.join(root, sver, vconfroot, confmapkey, vconf_name+'.'+cver)
+        print(path)
+
+
+def crtConfDir(pname, sver, cver):
+    '''
+    e.g. /usr/bigtop/3.2.0/etc/zookeeper/conf.dist.0
+    '''
+    path = os.path.join(root, sver, vconfroot, pname, vconf_name)
+    check(sver, pname, cver, "create")
+    for confmapkey, confmapval in confmap.items():
+        path = os.path.join(root, sver, vconfroot, confmapkey, vconf_name)
+        if cver:
+            path = os.path.join(root, sver, vconfroot, confmapkey, vconf_name+'.'+cver)
+        try:
+            os.makedirs(path)
+            print(path)
+        except OSError as exc:
+            if exc.errno == errno.EACCES:
+                print("Permission denied")
+
+
+def drsetConfDir(pname, sver):
+    '''
+    Not really executing
+    '''
+    chksVer(sver)
+    chkPkg(sver, pname)
+    for confmapkey, confmapval in confmap.items():
+        # e.g. /usr/bigtop/3.2.0/usr/lib/hive/conf
+        confdir = os.path.join(root, sver, lib_root, pname, confmapval)
+        if os.path.exists(confdir) and os.path.islink(confdir):
+            print(confdir)
+        else:
+            print(confdir+" does not exist")
+            sys.exit(1)
+
+
+def setConfDir(pname, sver, cver):
+    '''
+    e.g. /usr/bigtop/3.2.0/usr/lib/zookeeper/conf -> /etc/zookeeper/conf -> /usr/bigtop/3.2.0/etc/zookeeper/conf.dist.0
+    '''
+    check(sver, pname, cver, "set")
+    for confmapkey, confmapval in confmap.items():
+        # e.g. /usr/bigtop/3.2.0/etc/zookeeper/conf.dist.0
+        path = os.path.join(root, sver, vconfroot, confmapkey, vconf_name)
+        if cver:
+            path = os.path.join(root, sver, vconfroot, confmapkey, vconf_name+'.'+cver)
+        # e.g. /usr/bigtop/3.2.0/usr/lib/zookeeper/conf
+        confdir = os.path.join(root, sver, lib_root, pname, confmapval)
+
+        if os.path.exists(confdir) and not os.path.islink(confdir):
+            raise Exception("Expected confdir %s to be a symlink." % confdir)
+
+        if os.path.islink(confdir) and not os.path.exists(confdir):
+            os.remove(confdir)
+
+        if os.path.exists(confdir):
+            if path == os.readlink(confdir):
+                return
+            else:
+                os.remove(confdir)
+
+        os.symlink('/etc/{0}/conf'.format(pname), confdir)
+        print(confdir + " -> " + '/etc/{0}/conf'.format(pname))
+        print('alternatives --install /etc/{0}/conf {0}-conf {1} 30'.format(pname, path))
+        os.system('alternatives --install /etc/{0}/conf {0}-conf {1} 30'.format(pname, path))
+        os.system('alternatives --set {0}-conf {1}'.format(pname, path))
+        print('/etc/{0}/conf'.format(pname) + " -> " + path)
+
+
+# Start of main
+parser = optparse.OptionParser(add_help_option=False)
+parser.add_option("-h", "--help", action="store_true", dest="help",
+                  help="print help")
+parser.add_option("-p", "--package", action="store", dest="pname",
+                  help="package name")
+parser.add_option("-s", "--stack-version", action="store", dest="sver",
+                  help="stack verison number")
+parser.add_option("-c", "--conf-version", action="store", dest="cver",
+                  help="conf verison number", default=None)
+
+(options, args) = parser.parse_args()
+'''default conf mapping'''
+confmap = {options.pname: "conf"}
+'''conf mapping if the pkg name is hive-hcatalog'''
+if options.pname == "hive-hcatalog":
+    confmap = {"hive-hcatalog": "etc/hcatalog",
+               "hive-webhcat": "etc/webhcat"}
+
+
+
+if options.help or len(args) == 0:
+    printHelp()
+elif not options.pname or not options.sver:
+    parser.error("Invalid option")
+    printHelp()
+elif args[0] == 'create-conf-dir':
+    crtConfDir(options.pname, options.sver, options.cver)
+elif args[0] == 'set-conf-dir':
+    setConfDir(options.pname, options.sver, options.cver)
+elif args[0] == 'dry-run-set':
+    drsetConfDir(options.pname, options.sver)
+elif args[0] == 'dry-run-create':
+    drcrtConfDir(options.pname, options.sver, options.cver)
+else:
+    printHelp()

--- a/bigtop-packages/src/common/bigtop-select/install_select.sh
+++ b/bigtop-packages/src/common/bigtop-select/install_select.sh
@@ -79,11 +79,13 @@ CONF_DIR=${CONF_DIR:-/etc/bigtop-select/conf.dist}
 
 STACK_ROOT_DIR=$(echo ${PARENT_DIR} | sed -e "s/\/${BIGTOP_BASE_VERSION}$//")
 STACK_SELECTOR=distro-select
+CONF_SELECTOR=conf-select
 
 # Install packages
 install -d -p -m 755 $PREFIX${LIB_DIR}/
 install -d -p -m 755 $PREFIX${PARENT_DIR}/
 install -p -m 755 ${DISTRO_DIR}/${STACK_SELECTOR} $PREFIX${LIB_DIR}/
+install -p -m 755 ${DISTRO_DIR}/${CONF_SELECTOR} $PREFIX${LIB_DIR}/
 cat > $PREFIX${LIB_DIR}/params.py <<EOF
 #!/usr/bin/env python3
 #

--- a/bigtop-packages/src/rpm/bigtop-select/SPECS/bigtop-select.spec
+++ b/bigtop-packages/src/rpm/bigtop-select/SPECS/bigtop-select.spec
@@ -33,6 +33,7 @@ BuildArch:  noarch
 Source0:    install_select.sh
 Source1:    LICENSE
 Source2:    distro-select
+Source3:    conf-select
 Requires:   bash
 
 # "which" command is needed for a lot of projects.
@@ -54,6 +55,7 @@ This includes a collection of useful tools and files for Bigtop and Ambari
 install -p -m 755 %{SOURCE0} .
 install -p -m 755 %{SOURCE1} .
 install -p -m 755 %{SOURCE2} .
+install -p -m 755 %{SOURCE3} .
 
 
 %build


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Restore `conf-select` that was unintentionally removed in BIGTOP-4063
(#1236, "Adapt bigtop-select to Python 3"). The PR was meant to port the
script to Python 3 but deleted it instead.

The script is still referenced by Ambari's BIGTOP stack:
- `stacks/BIGTOP/*/properties/stack_tools.json` points `conf_selector` at
  `/usr/lib/bigtop-select/conf-select`.
- `ambari-common`'s `resource_management.libraries.functions.conf_select`
  invokes that path during stack-upgrade and config patching, and 30+
  service scripts (HDFS, YARN, HBASE, HIVE, KAFKA, SPARK, FLINK, LIVY,
  TEZ, ZEPPELIN, ZOOKEEPER, ALLUXIO, RANGER_KMS, ...) depend on it.

Changes:
- Restore `conf-select` with `#!/usr/bin/env python3` (content otherwise
  identical to the pre-BIGTOP-4063 version; already Python 3 compatible).
- Re-add `CONF_SELECTOR=conf-select` and its `install` line in
  `install_select.sh`.
- Re-add `Source3: conf-select` and its `%prep` install line in
  `bigtop-select.spec`.


### How was this patch tested?

- `python3 -m py_compile bigtop-packages/src/common/bigtop-select/conf-select`

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [x] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/