### PR TITLE
BIGTOP-4530. Upgrade Livy to 0.9.0.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -327,7 +327,7 @@ bigtop {
       name    = 'livy'
       rpm_pkg_suffix = "_" + bigtop.base_version.replace(".", "_")
       relNotes = 'Apache Livy'
-      version { base = '0.8.0'; pkg = base; release = 1 }
+      version { base = '0.9.0'; pkg = base; release = 1 }
       tarball { destination = "${name}-${version.base}.zip"
                 source      = "apache-livy-${version.base}-incubating-src.zip" }
       url     { download_path = "incubator/livy/${version.base}-incubating/"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4530

smoke-tests of livy passed on ubuntu-24.04-x86_86.

I tested this against Spark 3.5.8 with the patch of BIGTOP-4529.