### PR TITLE
BIGTOP-4533. Upgrade Airflow to 2.11.0.

### DIFF
--- a/bigtop.bom
+++ b/bigtop.bom
@@ -349,7 +349,7 @@ bigtop {
     'airflow' {
       name    = "airflow"
       relNotes = "Apache Airflow"
-      version { base = '2.10.5'; pkg = base; release = 1 }
+      version { base = '2.11.0'; pkg = base; release = 1 }
       tarball { source      = "apache_airflow-${version.base}.tar.gz"
                 destination = source }
       url     { download_path = "/${name}/${version.base}/"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4533

Since some providers require Airflow 2.11.0+ now, upgrading Airflow to 2.11.0 should resolve issues like [BIGTOP-4532](https://issues.apache.org/jira/browse/BIGTOP-4532).

We can not adopt Airflow 2.11.2 and 2.11.1 since [Python 3.9 support was dropped](https://airflow.apache.org/docs/apache-airflow/2.11.2/release_notes.html#python-3-9-support-removed). After upgrading the supported version of Rocky Linux and openEuler, we can upgrade Airflow further. The target version should be Airflow 3 rather than 2 in that case.