### PR TITLE
BIGTOP-4534. Make arch of docker image consistent for packaging on MacOS.

### DIFF
--- a/bigtop-ci/build.sh
+++ b/bigtop-ci/build.sh
@@ -80,6 +80,10 @@ fi
 
 IMAGE_NAME=bigtop/slaves:$PREFIX-$OS
 ARCH=$(uname -m)
+case "$ARCH" in
+    aarch64|arm64)   ARCH="aarch64" ;;
+    *)               ARCH="$ARCH" ;;
+esac
 if [ "x86_64" != $ARCH ]; then
     IMAGE_NAME=$IMAGE_NAME-$ARCH
 fi

--- a/provisioner/docker/docker-hadoop.sh
+++ b/provisioner/docker/docker-hadoop.sh
@@ -67,6 +67,10 @@ create() {
         image_name=$(get-yaml-config docker image)
     fi
     running_arch=$(uname -m)
+    case "$running_arch" in
+        aarch64|arm64)   running_arch="aarch64" ;;
+        *)               running_arch="$running_arch" ;;
+    esac
     if [ "x86_64" == ${running_arch} ]; then
         image_name=${image_name}
     else


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4534

bigtop-ci/build.sh needs the same fix with [BIGTOP-4523](https://issues.apache.org/jira/browse/BIGTOP-4523)(#1384) . 