### PR TITLE
BIGTOP-4526. Upgrade the base Docker image of Rocky 9.

### DIFF
--- a/docker/bigtop-puppet/build.sh
+++ b/docker/bigtop-puppet/build.sh
@@ -28,8 +28,15 @@ if [ $# != 1 ]; then
 fi
 
 PREFIX=$(echo "$1" | cut -d '-' -f 1)
+
 OS=$(echo "$1" | cut -d '-' -f 2)
+case "$OS" in
+    rockylinux)   REPO="rockylinux/rockylinux" ;;
+    *)            REPO="$OS" ;;
+esac
+
 VERSION=$(echo "$1" | cut -d '-' -f 3-)
+
 ARCH=$(uname -m)
 case "$ARCH" in
     aarch64|arm64)   ARCH="aarch64" ;;
@@ -43,7 +50,7 @@ fi
 
 cp ../../bigtop_toolchain/bin/puppetize.sh .
 cat >Dockerfile <<EOF
-FROM ${OS}:${VERSION}
+FROM ${REPO}:${VERSION}
 MAINTAINER dev@bigtop.apache.org
 COPY puppetize.sh /tmp/puppetize.sh
 ${ENV_PATH}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4526

tested by `./build.sh 3.6.0-rockylinux-9` and `./build.sh 3.6.0-ubuntu-24.04`.
build.sh of bigtop-slaves worked for rockylinux-9 based on the bigtop-pupet:3.6.0-rockylinux-9.