### PR TITLE
BIGTOP-4535. Fix installation failure of R packages in toolchain.

### DIFF
--- a/bigtop_toolchain/manifests/packages.pp
+++ b/bigtop_toolchain/manifests/packages.pp
@@ -68,6 +68,14 @@ class bigtop_toolchain::packages {
         "perl-Digest-SHA",
         "nasm",
         "yasm",
+        "harfbuzz-devel",
+        "fribidi-devel",
+        "libuv-devel",
+        "libwebp-devel",
+        "freetype-devel",
+        "libpng-devel",
+        "libtiff-devel",
+        "libjpeg-devel",
       ]
 
       if ($operatingsystem == 'Fedora') {
@@ -217,9 +225,6 @@ class bigtop_toolchain::packages {
        "libgit2-devel",
        "libgit2-glib-devel",
        "libxml2",
-       "libpng-devel",
-       "libtiff-devel",
-       "libjpeg-turbo-devel",
        "leveldbjni",
        "psmisc",
        "nc",
@@ -229,7 +234,15 @@ class bigtop_toolchain::packages {
        "texlive",
        "rpmdevtools",
        "nasm",
-       "yasm"
+       "yasm",
+       "harfbuzz-devel",
+       "fribidi-devel",
+       "libuv-devel",
+       "libwebp-devel",
+       "freetype-devel",
+       "libpng-devel",
+       "libtiff-devel",
+       "libjpeg-devel",
     ] }
     /(Ubuntu|Debian)/: {
       $_pkgs = [


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4535

We need additional libraries and header files for installing R packages. We need to fix this for fixing build failure of Spark on openEuler 22.03 and Fedora 40.

Since the added packages are also available on Rocky Linux 9, I added them to manifests for Red Hat variants instead of Fedora specific conditional.