### PR TITLE
BIGTOP-4537. Fix build failure of Ranger due to unresolvable dependency.

### DIFF
--- a/bigtop-packages/src/common/ranger/patch1-RANGER-5552.diff
+++ b/bigtop-packages/src/common/ranger/patch1-RANGER-5552.diff
@@ -1,0 +1,24 @@
+commit 55388d65d74613bdb2eda58c1f6c2b91d155628f
+Author: Abhishek Kumar <abhi@apache.org>
+Date:   Mon Apr 13 10:32:37 2026 -0700
+
+    RANGER-5552: Remove ozone-2.1.0-rc repository from pom.xml (#914)
+    
+    (cherry picked from commit 8e81392bdfc85244344d3ae92bb52a42dc015476)
+
+diff --git a/pom.xml b/pom.xml
+index 8eafa7833..3e13d5b36 100755
+--- a/pom.xml
++++ b/pom.xml
+@@ -765,11 +765,6 @@
+             <name>jetbrains-intellij-dependencies</name>
+             <url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies</url>
+         </repository>
+-        <repository>
+-            <id>ozone-2.1.0-rc</id>
+-            <name>ozone-2.1.0-rc</name>
+-            <url>https://repository.apache.org/content/repositories/orgapacheozone-1061</url>
+-        </repository>
+     </repositories>
+     <distributionManagement>
+         <repository>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4537

The error is not deterministic but ozone-2.1.0-rc frequently appears around the issue. I'm expecting the backport of [RANGER-5552](https://issues.apache.org/jira/browse/RANGER-5552) to mitigate this.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process (process-resource-bundles) on project ranger-hive-plugin: Error resolving project artifact: The following artifacts could not be resolved: net.shibboleth.tool:xmlsectool:pom:2.0.0 (present, but unavailable): Could not transfer artifact net.shibboleth.\
tool:xmlsectool:pom:2.0.0 from/to ozone-2.1.0-rc (https://repository.apache.org/content/repositories/orgapacheozone-1061): Connect to repository.apache.org:443 [repository.apache.org/37.27.138.133] failed: connect timed out for project net.shibboleth.tool:xmlsectool:jar:2.0.0 -> [Help 1]
```