### PR TITLE
BIGTOP-4538. Fix deployment error of Ranger on Red Hat distros in container.

### DIFF
--- a/bigtop-deploy/puppet/modules/ranger/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/ranger/manifests/init.pp
@@ -61,7 +61,8 @@ class ranger {
 
     exec { 'change_postgres_password':
       path    => ['/usr/bin', '/bin','/sbin'],
-      command => "sudo -u postgres psql -c \"ALTER USER postgres WITH PASSWORD 'admin';\"",
+      command => "psql -c \"ALTER USER postgres WITH PASSWORD 'admin';\"",
+      user    => 'postgres',
       require => Service['postgresql'],
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BIGTOP-4538


sudo failed with the message like `sudo: PAM account management error: Authentication service cannot retrieve authentication info`.

```
[mNotice: /Stage[main]/Ranger::Admin/Package[ranger-admin]/ensure: created[0m
[mNotice: /Stage[main]/Ranger::Admin/Exec[initdb]/returns: executed successfully[0m
[mNotice: /Stage[main]/Ranger::Admin/Service[postgresql]/ensure: ensure changed 'stopped' to 'running'[0m
[mNotice: /Stage[main]/Ranger::Admin/Exec[change_postgres_password]/returns: sudo: PAM account management error: Authentication service cannot retrieve authentication info[0m
[mNotice: /Stage[main]/Ranger::Admin/Exec[change_postgres_password]/returns: sudo: a password is required[0m
[1;31mError: 'sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'admin';"' returned 1 instead of one of [0][0m
[1;31mError: /Stage[main]/Ranger::Admin/Exec[change_postgres_password]/returns: change from 'notrun' to ['0'] failed: 'sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'admin';"' returned 1 instead of one of [0][0m
[mNotice: /Stage[main]/Ranger::Admin/File[/usr/lib/ranger-admin/install.properties]: Dependency Exec[change_postgres_password] has failures: true[0m
[1;33mWarning: /Stage[main]/Ranger::Admin/File[/usr/lib/ranger-admin/install.properties]: Skipping because of failed dependencies[0m
[1;33mWarning: /Stage[main]/Ranger::Admin/Exec[setup.sh]: Skipping because of failed dependencies[0m
[1;33mWarning: /Stage[main]/Ranger::Admin/Exec[set_globals.sh]: Skipping because of failed dependencies[0m
[1;33mWarning: /Stage[main]/Ranger::Admin/Exec[systemctl daemon-reload]: Skipping because of failed dependencies[0m
[1;33mWarning: /Stage[main]/Ranger::Admin/Service[ranger-admin]: Skipping because of failed dependencies[0m
```

I observed the issue on CI environment. I can not reproduce the error on my local host machines (ubuntu 26.04 x86_64 and MacOS (Mac mini M4)). I guess [AppArmor issue of Ubuntu 24.04](https://www.tunbury.org/2025/05/13/ubuntu-apparmor/) is related.

Since [initdb using user param of exec resource](https://github.com/apache/bigtop/blob/branch-3.6/bigtop-deploy/puppet/modules/ranger/manifests/init.pp#L50-L54) succeeds, getting rid of using sudo could be the quick fix.