### PR TITLE
BIGTOP-4540. bigtop-select: distro-select "set all" fails with TypeEror: cannot pickle 'dict_keys' object on Python 3

### DIFF
--- a/bigtop-packages/src/common/bigtop-select/distro-select
+++ b/bigtop-packages/src/common/bigtop-select/distro-select
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 import optparse
-import copy
 import os
 import re
 import sys
@@ -256,7 +255,7 @@ def setPackages(packages, version, rpm_mode):
 
 # Create command symlinks
 def createCommandSymlinks(packages, rpm_mode):
-  work_packages = copy.copy(packages)
+  work_packages = list(packages)
   for pkg in packages:
     if pkg in locked_contexts:
       for (child, dir) in locked_contexts[pkg]:


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Running "distro-select set all <version>" fails on Python 3:

```
$ sudo ./distro-select set all 3.6.0
Traceback (most recent call last):
  File "/usr/lib/bigtop-select/./distro-select", line 364, in <module>
    createCommandSymlinks(pkgs, options.rpm_mode)
  File "/usr/lib/bigtop-select/./distro-select", line 260, in createCommandSymlinks
    work_packages = copy.copy(packages)
  File "/usr/lib64/python3.9/copy.py", line 92, in copy
    rv = reductor(4)
TypeError: cannot pickle 'dict_keys' object
```

The "packages" argument is a dict_keys view (from dict.keys()). On Python 2 this was a list, so copy.copy() worked, but on Python 3 dict views are not copyable via copy.copy() and the fallback pickle path fails.

Fix: convert the view to a list, e.g.

```
work_packages = list(packages)
```

Environment: Python 3.9 (EL9), Bigtop 3.7.0-SNAPSHOT.


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/