### PR TITLE
BIGTOP-4541. hadoop RPM does not own /usr/bigtop/<version>/usr/lib/hadoop directory

### DIFF
--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -784,6 +784,7 @@ fi
 %config(noreplace) %{etc_default}/hadoop
 %dir %{np_etc_hadoop}
 /etc/bash_completion.d/hadoop
+%dir %{usr_lib_hadoop}
 %{usr_lib_hadoop}/*.jar
 %{usr_lib_hadoop}/lib
 %{usr_lib_hadoop}/sbin


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

The hadoop_3_6_0 package installs its files under /usr/bigtop/3.6.0/usr/lib/hadoop, but the directory itself is not owned by the package (not declared with %dir in the spec %files section).

As a result, removing the package leaves /usr/bigtop/3.6.0/usr/lib/hadoop 

```
$ rpm -qf /usr/bigtop/3.6.0/usr/lib/hadoop
file /usr/bigtop/3.6.0/usr/lib/hadoop is not owned by any package
```

Fix: declare the directory in %files, e.g.

```
%dir %{usr_lib_hadoop}
```

Environment: Bigtop 3.6.0-SNAPSHOT, EL9.

### How was this patch tested?

Built the hadoop RPMs on Navix 9 with this patch, then verified:

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/