### PR TITLE
BIGTOP-4542. hadoop.spec: duplicate %description for libhdfs-devel causes "second Description" warning

### DIFF
--- a/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
+++ b/bigtop-packages/src/rpm/hadoop/SPECS/hadoop.spec
@@ -509,9 +509,6 @@ Includes examples and header files for accessing HDFS from C
 Summary: Hadoop Filesystem Library for C++
 Group: Development/Libraries
 
-%description libhdfs-devel
-Includes examples and header files for accessing HDFS from C
-
 %package libhdfspp-devel
 Summary: Development support for libhdfspp
 Group: Development/Libraries


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

Building the hadoop RPMs emits a warning because hadoop.spec declares %description for the libhdfs-devel subpackage twice:

```
warning: line 607: second Description
```

rpmbuild silently ignores the second declaration, so the built package is unaffected, but the duplicated block is dead text.

Fix: remove the redundant %description libhdfs-devel at line 607.

Environment: Bigtop 3.6.0-SNAPSHOT, EL9.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/