### PR TITLE
BIGTOP-4543. hadoop: mvn site intermittently fails under parallel build

### DIFF
--- a/bigtop-packages/src/common/hadoop/do-component-build
+++ b/bigtop-packages/src/common/hadoop/do-component-build
@@ -81,7 +81,7 @@ fi
 
 # Build artifacts
 mvn $BUNDLE_SNAPPY $BUNDLE_ISAL -Pdist -Pnative -Psrc -Pyarn-ui -Dtar ${MAVEN_OPTS} install ${EXTRA_GOALS} "$@"
-mvn site site:stage ${MAVEN_OPTS} $@
+mvn site site:stage -T 1 ${MAVEN_OPTS} $@
 
 (cd build ; tar --strip-components=1 -xzvf  ../hadoop-dist/target/hadoop-${HADOOP_VERSION}.tar.gz)
 (cd build/src ; tar --strip-components=1 -xzvf  ../../hadoop-dist/target/hadoop-${HADOOP_VERSION}-src.tar.gz)


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR


When Bigtop builds hadoop with Maven parallel mode (-T), the site goal intermittently fails:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.9.1:site (default-site) on project hadoop-aws: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.9.1:site failed: Cannot invoke "String.length()" because "s" is null -> [Help 1]
```

Root cause: the site mojo in maven-site-plugin 3.9.1 is not marked @threadSafe:

```
@Mojo( name = "site", requiresDependencyResolution = ResolutionScope.TEST, requiresReports = true )
```

With -T, Maven only warns about non-thread-safe plugins and still runs them in parallel. Concurrent site executions across modules race on shared components (Doxia SiteRenderer, Velocity, plexus), which surfaces as the NPE above. The failure is non-deterministic and the failing module varies between runs.

Fix: in the hadoop do-component-build, run the mvn site invocation with -T 1, keeping parallelism for the main build.

### How was this patch tested?

Built the hadoop packages repeatedly on Navix 9 with parallel Maven builds. Before this patch, the site goal failed intermittently with the NPE above (failing module varied between runs). With the site invocation pinned to -T 1, repeated builds completed without failure.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/