### PR TITLE
BIGTOP-4544. bigtop_toolchain: latest ant/maven versions not resolved due to HTML-escaped "&amp;"

### DIFF
--- a/bigtop_toolchain/lib/puppet/parser/functions/latest_ant_binary.rb
+++ b/bigtop_toolchain/lib/puppet/parser/functions/latest_ant_binary.rb
@@ -17,6 +17,6 @@ module Puppet::Parser::Functions
     newfunction(:latest_ant_binary, :type => :rvalue) do |args|
         versionmask=args[0]
         # We are using main mirror here because can't be sure about Apache Server config on every mirror. It could be Nginx, btw. 
-        %x(curl -L --stderr /dev/null 'https://archive.apache.org/dist/ant/binaries/?F=0&amp;V=1' | grep -o '<li>.*href="apache-ant-#{versionmask}-bin.tar.gz"'  |  grep -o "apache-ant-#{versionmask}" | tail -1 | tr -d '\r').chomp
+        %x(curl -L --stderr /dev/null 'https://archive.apache.org/dist/ant/binaries/?F=0&V=1' | grep -o '<li>.*href="apache-ant-#{versionmask}-bin.tar.gz"'  |  grep -o "apache-ant-#{versionmask}" | tail -1 | tr -d '\r').chomp
     end
 end

--- a/bigtop_toolchain/lib/puppet/parser/functions/latest_maven_binary.rb
+++ b/bigtop_toolchain/lib/puppet/parser/functions/latest_maven_binary.rb
@@ -17,6 +17,6 @@ module Puppet::Parser::Functions
     newfunction(:latest_maven_binary, :type => :rvalue) do |args|
         versionmask=args[0]
         # We are using main mirror here because can't be sure about Apache Server config on every mirror. It could be Nginx, btw.
-        %x(curl -L --stderr /dev/null 'https://archive.apache.org/dist/maven/maven-3/?F=0&amp;V=1' | grep -o '<li>.*href="#{versionmask}/"' | tail -1 | grep -o '#{versionmask}'| tr -d '\r').chomp
+        %x(curl -L --stderr /dev/null 'https://archive.apache.org/dist/maven/maven-3/?F=0&V=1' | grep -o '<li>.*href="#{versionmask}/"' | tail -1 | grep -o '#{versionmask}'| tr -d '\r').chomp
     end
 end


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

bigtop_toolchain is intended to install the latest matching ant (1.9.x) and maven (3.9.x) versions:

```
# maven.pp
$mvnversion = latest_maven_binary("3.9.[0-9]*")

# ant.pp
$ant = latest_ant_binary("1.9.[0-9]*")
```

But both resolver functions fetch the archive.apache.org directory listing with an HTML-escaped ampersand in the URL:

```
%x(curl -L --stderr /dev/null 'https://archive.apache.org/dist/maven/maven-3/?F=0&amp;V=1' | ...)
```

Because of "&amp;", the V=1 (version sort) parameter is not applied. The listing is sorted lexicographically, so "tail -1" picks the wrong entry. For maven this resolves 3.9.9 instead of the latest 3.9.16:

```
$ curl -L --stderr /dev/null 'https://archive.apache.org/dist/maven/maven-3/?F=0&amp;V=1' | grep -o '<li>.*href="3.9.[0-9]*/"' | tail -1 | grep -o '3.9.[0-9]*'
3.9.9

$ curl -L --stderr /dev/null 'https://archive.apache.org/dist/maven/maven-3/?F=0&V=1' | grep -o '<li>.*href="3.9.[0-9]*/"' | tail -1 | grep -o '3.9.[0-9]*'
3.9.16
```

latest_ant_binary has the same bug and fails to pick up the latest 1.9.x.

Fix: replace "&amp;" with "&" in the listing URLs in latest_maven_binary.rb and latest_ant_binary.rb.


### How was this patch tested?

Built the bigtop/puppet Docker image for an Navix 9 (EL9-based) distribution with this patch. latest_maven_binary now resolves 3.9.16 (previously 3.9.9) and latest_ant_binary resolves the latest 1.9.x, and both were downloaded and installed successfully during the image build.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/