### PR TITLE
BIGTOP-4545. hbase: versionless jar symlinks broken for version strings with extra "-<digit>" suffix

### DIFF
--- a/bigtop-packages/src/common/hbase/install_hbase.sh
+++ b/bigtop-packages/src/common/hbase/install_hbase.sh
@@ -150,7 +150,10 @@ pushd `pwd`
 cd $PREFIX/$LIB_DIR
 for i in `ls hbase*jar | grep -v tests.jar`
 do
-    ln -s $i `echo $i | sed -n 's/\(.*\)\(-[0-9].*\)\(.jar\)/\1\3/p'`
+  if [[ $i =~ hbase-(.*)-${HBASE_VERSION}.jar ]]; then
+    name=${BASH_REMATCH[1]}
+    ln -s $i hbase-$name.jar
+  fi
 done
 popd
 

--- a/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
+++ b/bigtop-packages/src/rpm/hbase/SPECS/hbase.spec
@@ -309,7 +309,7 @@ env HBASE_VERSION=%{version} bash %{SOURCE1}
 
 %install
 %__rm -rf $RPM_BUILD_ROOT
-bash %{SOURCE2} \
+env HBASE_VERSION=%{hbase_base_version} bash %{SOURCE2} \
 	--build-dir=build \
     --man-dir=%{man_dir} \
     --bin-dir=%{bin_dir} \


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

The hbase RPM creates versionless symlinks for jars using a sed pattern:

```
for i in `ls hbase*jar | grep -v tests.jar`
do
    ln -s $i `echo $i | sed -n 's/\(.*\)\(-[0-9].*\)\(.jar\)/\1\3/p'`
done
```

The greedy \(.*\) makes the pattern strip only from the *last* "-<digit>" occurrence. This breaks for version strings that contain an additional "-<digit>" segment, e.g. a downstream/vendor version like 2.6.5-custom-1:

```
$ echo hbase-common-2.6.5-custom-1.jar | sed -n 's/\(.*\)\(-[0-9].*\)\(.jar\)/\1\3/p'
hbase-common-2.6.5-custom.jar
```

The expected link name is hbase-common.jar, but hbase-common-2.6.5-custom.jar is created instead.

Fix: match against the known HBASE_VERSION explicitly instead of guessing where the version starts:

```
for i in `ls hbase*jar | grep -v tests.jar`
do
   if [[ $i =~ hbase-(.*)-${HBASE_VERSION}.jar ]]; then
     name=${BASH_REMATCH[1]}
     ln -s $i hbase-$name.jar
   fi
done
```

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/