### PR TITLE
BIGTOP-4546. hive: hive-hbase-handler and hbase jars owned by both hive and hive-hbase packages

### DIFF
--- a/bigtop-packages/src/rpm/hive/SPECS/hive.spec
+++ b/bigtop-packages/src/rpm/hive/SPECS/hive.spec
@@ -384,6 +384,8 @@ fi
 %exclude %dir %{usr_lib_hive}
 %exclude %dir %{usr_lib_hive}/jdbc
 %exclude %{usr_lib_hive}/jdbc/hive-jdbc-*.jar
+%exclude %{usr_lib_hive}/lib/hbase-*.jar
+%exclude %{usr_lib_hive}/lib/hive-hbase-handler*.jar
 
 %files hbase
 %defattr(-,root,root,755)


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

The hive-hbase-handler*.jar and hbase-*.jar files under the hive lib directory are owned by both the hive and hive-hbase packages.

In hive.spec, the base %files section includes the whole %{usr_lib_hive} tree, while %files hbase lists the same jars again:

```
%files
...
%{usr_lib_hive}
...
%exclude %dir %{usr_lib_hive}
%exclude %dir %{usr_lib_hive}/jdbc
%exclude %{usr_lib_hive}/jdbc/hive-jdbc-*.jar

%files hbase
%defattr(-,root,root,755)
%{usr_lib_hive}/lib/hbase-*.jar
%{usr_lib_hive}/lib/hive-hbase-handler*.jar
```

The jdbc jars are excluded from the base package, but the hbase-related jars are not, so they end up in both packages. Consequences:

- duplicated payload in the base hive package
- removing hive-hbase does not remove the jars (still owned by hive)
- the hive-hbase subpackage split is effectively meaningless

Fix: exclude the hbase-related jars from the base package, same as jdbc:

```
%exclude %{usr_lib_hive}/lib/hbase-*.jar
%exclude %{usr_lib_hive}/lib/hive-hbase-handler*.jar
```

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/