### PR TITLE
BIGTOP-4547. tez: missing mvn install in do-component-build

### DIFF
--- a/bigtop-packages/src/common/tez/do-component-build
+++ b/bigtop-packages/src/common/tez/do-component-build
@@ -18,7 +18,7 @@ set -xe
 
 . `dirname $0`/bigtop.bom
 
-BUILD_TEZ_OPTS="clean package \
+BUILD_TEZ_OPTS="clean install \
 -Dtar -Dhadoop.version=${HADOOP_VERSION} \
 -Phadoop28 \
 -DskipTests"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR

The tez do-component-build runs the Maven build without installing the artifacts into the local repository. As a result, when hive is built afterwards in the same environment, it cannot resolve the tez artifacts just built and either fails or falls back to fetching upstream tez from a remote repository instead of the locally built one.

Fix: use the install goal in the tez do-component-build so the built tez artifacts are installed into the local Maven repository and picked up by subsequent component builds (hive).

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'BIGTOP-3638. Your PR title ...')?
- [ ] Make sure that newly added files do not have any licensing issues. When in doubt refer to https://www.apache.org/licenses/